### PR TITLE
HTTP Strict Transport Security

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -179,6 +179,14 @@ CACHES = {
     }
 }
 
+# HTTP Strict Transport Security
+# https://docs.djangoproject.com/en/1.11/ref/middleware/#http-strict-transport-security
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+# Once you confirm that all assets are served securely on your site (i.e. HSTS didn’t break anything),
+# it’s a good idea to increase this value so that infrequent visitors will be protected (31536000 seconds, i.e. 1 year, is common).
+SECURE_HSTS_SECONDS = 3600
+
 # Include local settings overrides
 try:
     from .local_settings import *  # NOQA


### PR DESCRIPTION
HTTP Strict Transport Security (HSTS) is an opt-in security enhancement that is specified by a web application through the use of a special response header. Once a supported browser receives this header that browser will prevent any communications from being sent over HTTP to the specified domain and will instead send all communications over HTTPS. It also prevents HTTPS click through prompts on browsers.

[OWASP HSTS](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet)

[OWASP HSTS test](https://www.owasp.org/index.php/Test_HTTP_Strict_Transport_Security_(OTG-CONFIG-007))

[Django HSTS](https://docs.djangoproject.com/en/1.11/ref/middleware/#http-strict-transport-security)

[Django HSTS settings](https://docs.djangoproject.com/en/1.11/ref/settings/#secure-hsts-include-subdomains)

#38 