### PR TITLE
Fix #86 - display bounties plural in admin

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -33,6 +33,10 @@ from economy.utils import convert_amount
 
 
 class Bounty(SuperModel):
+    
+    class Meta:
+        verbose_name_plural = 'Bounties'
+
     BOUNTY_TYPES = [
         ('Bug', 'Bug'),
         ('Security', 'Security'),


### PR DESCRIPTION
The goal of this PR is to fix the plural display of `Bounties` in the admin.