### PR TITLE
Fix display of plurals for some models in admin

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -33,6 +33,10 @@ from economy.utils import convert_amount
 
 
 class Bounty(SuperModel):
+    
+    class Meta:
+        verbose_name_plural = 'Bounties'
+
     BOUNTY_TYPES = [
         ('Bug', 'Bug'),
         ('Security', 'Security'),

--- a/app/marketing/models.py
+++ b/app/marketing/models.py
@@ -79,6 +79,10 @@ class LeaderboardRank(SuperModel):
 
 
 class Match(SuperModel):
+
+    class Meta:
+        verbose_name_plural = 'Matches'
+
     email = models.EmailField(max_length=255)
     bounty = models.ForeignKey(Bounty, on_delete=models.CASCADE)
     direction = models.CharField(max_length=50)

--- a/app/tdi/models.py
+++ b/app/tdi/models.py
@@ -25,6 +25,10 @@ from economy.models import SuperModel
 
 
 class AccessCodes(SuperModel):
+    
+    class Meta:
+        verbose_name_plural = 'Access codes'
+
     invitecode = models.CharField(max_length=30)
     maxuses = models.PositiveIntegerField(default=1)
 
@@ -37,6 +41,10 @@ class AccessCodes(SuperModel):
 
 
 class WhitepaperAccess(SuperModel):
+    
+    class Meta:
+        verbose_name_plural = 'Whitepaper access'
+
     invitecode = models.CharField(max_length=30)
     email = models.CharField(max_length=255)
     ip = models.CharField(max_length=30)


### PR DESCRIPTION
The goal of this PR is to properly display:
- `Matches`
- `Access codes`
- `Bounties`
- `Whitepaper access`
while navigating the django admin.