### PR TITLE
Update get_prices to use new etherdelta WS API

### DIFF
--- a/app/economy/management/commands/get_prices.py
+++ b/app/economy/management/commands/get_prices.py
@@ -49,9 +49,13 @@ class Command(BaseCommand):
 
         ws.close()  # Close the websocket connection.
 
-        # Format the response data.
-        market_results = json.loads(result[2:])
-        tickers = market_results[1]['returnTicker']
+        try:
+            # Attempt to format the response data.
+            market_results = json.loads(result[2:])
+            tickers = market_results[1]['returnTicker']
+        except ValueError:
+            tickers = {}
+            print('Failed to retrieve etherdelta ticker data!')
 
         # etherdelta
         for pair, result in tickers.items():
@@ -68,7 +72,7 @@ class Command(BaseCommand):
                     from_currency=from_currency,
                     to_currency=to_currency,
                 )
-                print('EtherDelta: {}=>{}:{}'.format(from_currency, to_currency, to_amount))
+                print('Etherdelta: {}=>{}:{}'.format(from_currency, to_currency, to_amount))
             except Exception as e:
                 print(e)
 

--- a/app/economy/management/commands/get_prices.py
+++ b/app/economy/management/commands/get_prices.py
@@ -1,5 +1,5 @@
 '''
-    Copyright (C) 2017 Gitcoin Core 
+    Copyright (C) 2017 Gitcoin Core
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -15,24 +15,45 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
+import json
+
 from django.core.management.base import BaseCommand
 
 import ccxt
-import requests
 from dashboard.models import Bounty
 from economy.models import ConversionRate
+from websocket import create_connection
 
 
 class Command(BaseCommand):
+    """Define the management command to update currency conversion rates."""
 
     help = 'gets prices for all (or... as many as possible) tokens'
 
     def handle(self, *args, **options):
+        """Get the latest currency rates."""
+        count = 0
+        result = ''
 
-        r = requests.get('https://api.etherdelta.com/returnTicker')
-        tickers = r.json()
+        print('Attempting to connect to etherdelta API websocket...')
+        ws = create_connection('wss://socket.etherdelta.com/socket.io/?transport=websocket')
+        print('Sending getMarket message...')
+        ws.send('42["getMarket",{}]')
+        print('Sent getMarket message! Waiting on proper response...')
 
-        #etherdelta
+        # Wait for the getMarket response or timeout at 30.
+        while (result[:2] != "42" or count > 60):
+            result = ws.recv()
+            count += 1
+            print(count)
+
+        ws.close()  # Close the websocket connection.
+
+        # Format the response data.
+        market_results = json.loads(result[2:])
+        tickers = market_results[1]['returnTicker']
+
+        # etherdelta
         for pair, result in tickers.items():
             from_currency = pair.split('_')[0]
             to_currency = pair.split('_')[1]
@@ -46,8 +67,8 @@ class Command(BaseCommand):
                     source='etherdelta',
                     from_currency=from_currency,
                     to_currency=to_currency,
-                    )
-                print('{}=>{}:{}'.format(from_currency, to_currency, to_amount))
+                )
+                print('EtherDelta: {}=>{}:{}'.format(from_currency, to_currency, to_amount))
             except Exception as e:
                 print(e)
 
@@ -65,8 +86,8 @@ class Command(BaseCommand):
                     source='poloniex',
                     from_currency=from_currency,
                     to_currency=to_currency,
-                    )
-                print('{}=>{}:{}'.format(from_currency, to_currency, to_amount))
+                )
+                print('Poloniex: {}=>{}:{}'.format(from_currency, to_currency, to_amount))
             except Exception as e:
                 print(e)
 


### PR DESCRIPTION
The goal of this PR is to resolve #94 by updating the `get_prices` api to use the new etherdelta websocket-based API documented at:  https://github.com/etherdelta/etherdelta.github.io/blob/master/docs/API.md