### PR TITLE
css: resize images to fit within the timeline container

### DIFF
--- a/app/assets/v2/css/timeline.css
+++ b/app/assets/v2/css/timeline.css
@@ -162,6 +162,11 @@
     margin-top: 20px;
 }
 
+.tline img {
+    margin: 10px 0;
+    width: 100%;
+}
+
 @media (max-width: 760px) {
     ul.tline:before {
         left: 41px;


### PR DESCRIPTION
Images in the landing page timeline section were overflowing their containers. Not anymore.