### PR TITLE
css: fixed overflow scroll on tip recieve page

### DIFF
--- a/app/assets/yge/css/main.css
+++ b/app/assets/yge/css/main.css
@@ -10,6 +10,10 @@ body {
   width: 100%;
 }
 
+#yge {
+  overflow-y: hidden;
+}
+
 /*
 	Identity by HTML5 UP
 	html5up.net | @ajlkn
@@ -733,7 +737,7 @@ body {
     #main #send_eth #advanced div{
         padding-top: 10px;
     }
-    #main #send_eth input, 
+    #main #send_eth input,
     #main #send_eth select{
         font-size: 12px;
     }
@@ -904,7 +908,7 @@ body {
 			top:0px;
 			width: 100%;
 			z-index: 99999;
-		    background-color: #f44336; 
+		    background-color: #f44336;
 			color: white;
 			position: fixed;
 			text-align: center;


### PR DESCRIPTION
**Problem:**

 On this tip, the background image overflows (as the position keeps changing ) cause the screen to be scroll-able as the screen bg changes position, bad user experience.

![overflow-scroll](https://user-images.githubusercontent.com/5358146/33947385-445a51ba-e04a-11e7-86da-8f0f7ed52192.gif)


**Fix:** A single line of css

@owocki Might need an extra pair of eyes to look into this , to make sure nothing else is broken.

