### PR TITLE
fix roadmap items shift #100

### DIFF
--- a/app/assets/v2/css/timeline.css
+++ b/app/assets/v2/css/timeline.css
@@ -134,6 +134,7 @@
 .tline > li.tline_other > .tline_module:hover {
     border-right: 1px solid #d3d3d3;
     border-left: none;
+    padding-right: 16px;
 }
 .tline_module.contain1 {
     left: -21%;


### PR DESCRIPTION
Some blocks still shift and it shifts when content fits, see:
https://drive.google.com/open?id=1Oaj7HIMb9gt4PPbd6x0w06njsiicXf2v

css: fix roadmap items shift by reducing padding on div :hover

Fixes: #100 