### PR TITLE
Pin cytoolz to 0.9.0 to fulfill ethereum new reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ MechanicalSoup==0.9.0.post4
 tinyurl
 statistics
 django-email-obfuscator
-cytoolz==0.8.2
+cytoolz==0.9.0


### PR DESCRIPTION
##### Description
The goal of this PR is to resolve the failing travis builds that are a result of the python ethereum version change (since we aren't pinning that module until something like #146 is merged).

##### Checklist
- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
Travis CI

##### Refers/Fixes
Fixes #163 
