### PR TITLE
Generate high-entropy secrets and codes

### DIFF
--- a/app/marketing/models.py
+++ b/app/marketing/models.py
@@ -40,13 +40,11 @@ class EmailSubscriber(SuperModel):
         return self.email
 
     def set_priv(self):
-        import hashlib
+        import codecs
+        import os
         from django.utils import timezone
 
-        h = hashlib.new('ripemd160')
-        h.update("{}-{}-{}".format(h.hexdigest(), timezone.now(), self.email))
-        self.priv = h.hexdigest()[:29]
-
+        self.priv = codecs.getencoder('hex')(os.urandom(16))[0][:29]
 
 class Stat(SuperModel):
     key = models.CharField(max_length=50, db_index=True)

--- a/app/tdi/views.py
+++ b/app/tdi/views.py
@@ -15,7 +15,7 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
-import hashlib
+import codecs
 import os
 import StringIO
 from wsgiref.util import FileWrapper
@@ -222,9 +222,7 @@ def process_accesscode_request(request, pk):
         raise
 
     if request.POST.get('submit', False):
-        h = hashlib.new('ripemd160')
-        h.update(h.hexdigest() + str(timezone.now()))
-        invitecode = h.hexdigest()[:29]
+        invitecode = codecs.getencoder('hex')(os.urandom(16))[0][:29]
 
         AccessCodes.objects.create(
             invitecode=invitecode,


### PR DESCRIPTION
#####  Description

Gitcoin Core currently generates hashes from low-entropy, predictable
data. While they may appear random to outside observers, looking at the
source code quickly shows these as being predictable.

The construct used in both places appears to be a RIPEMD-160 hash
salted with the RIPEMD-160 hash for empty string and then the Django
timezone. An adversary with knowledge of the rough time in which a
secret was generated may use this knowledge to predict the hash used for
the whitepaper access code or the `priv` property.

This pull request removes the `hashlib` from use and generates
hexadecimal secrets from the OS `urandom` facility. These strings are
then truncated to match the same length as previously to avoid any
compatibility issues.

While the construct with `codecs` may appear strange, it will generate
the proper string in both Python 2.x and 3.x.

Testing: No joke, I just tested the construct, linted this and
called it good. Please pull this and try it locally before merge. I
don't have docker / docker-compose working on this workstation yet.

##### Checklist
- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md#step-4-commit)
