### PR TITLE
carousel: fixed css 

### DIFF
--- a/app/assets/v2/css/carousel.css
+++ b/app/assets/v2/css/carousel.css
@@ -132,9 +132,11 @@
 .carousel .author i {
   font-size: 7px;
 }
+
 .carousel .author a{
   cursor: pointer;
 }
+
 .carousel .content {
   border-left: 4px solid #3e00ff;
   padding-left: 10px;
@@ -153,18 +155,31 @@
   top: 0px;
   width: 100%;
   height: 100%;
+  display: none;
   opacity: 0;
-  transition: opacity .5s;
 }
 
 .showing {
   position: relative;
   opacity: 1;
+  display: inline;
+  animation: fadeIn 1.25s;
 }
 
-.carousel .pilot_projects{
-  
+.hide {
+  animation: fadeOut 1.25s;
 }
+
+@keyframes fadeIn {
+  0% { opacity: 0; display: none; }
+  100% { opacity: 1; display: inline; }
+}
+
+@keyframes fadeOut {
+  0% { opacity: 1; display: inline; }
+  100% { opacity: 0; display: none; }
+}
+
 .carousel .pilot_projects img{
     max-height: 100px;
     max-width: 100%;

--- a/app/assets/v2/js/pages/carousel.js
+++ b/app/assets/v2/js/pages/carousel.js
@@ -4,14 +4,14 @@ if(slides.length){
   slides[0].className = 'slide showing';
 
   function nextSlide() {
-    slides[currentSlide].className = 'slide';
+    slides[currentSlide].className = 'slide hide';
     currentSlide = (currentSlide+1) % slides.length;
     slides[currentSlide].className = 'slide showing';
     resetTimer();
   }
 
   function prevSlide() {
-    slides[currentSlide].className = 'slide';
+    slides[currentSlide].className = 'slide hide';
     if(currentSlide == 0)
       currentSlide = slides.length - 1;
     else
@@ -24,5 +24,5 @@ if(slides.length){
      clearInterval(interval);
      startTimer();
   }
-  
+
 }

--- a/app/retail/templates/shared/testimonials.html
+++ b/app/retail/templates/shared/testimonials.html
@@ -21,7 +21,7 @@
     </div>
     <div class="col-lg-6 col-md-8 col-sm-10 col-xs-12" id="slides">
       {% for author, avatar, testimonial, url in slides %}
-      <div class="slide">
+      <div class="slide hide">
           <div class="flex-container col-12">
             <div class="avatar">
               <div class="circles">
@@ -40,6 +40,7 @@
                 <a href="{{url}}">
                     {{author}}
                 </a>
+                <i class="fa fa-minus" aria-hidden="true"></i>
               </p>
             </div>
           </div>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Set display as none when slide goes out of focus. Ensures that user
get redirected to the active slides author profile  upon click.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
- ui

__Currently:__ 

(head out to the testimonial section and click on the authors name, it redirects to issacs GitHub profile as even though the slide is hidden, it still exists in the background )

__hint: look at the bottom left corner__

<img width="1440" alt="screen shot 2017-12-23 at 3 10 34 am" src="https://user-images.githubusercontent.com/5358146/34319141-3ba76c00-e78f-11e7-868b-96dd4cc595f5.png">

<img width="1440" alt="screen shot 2017-12-23 at 3 10 21 am" src="https://user-images.githubusercontent.com/5358146/34319140-2ad733f6-e78f-11e7-8ab0-f7a3b42cf529.png">

__After this commit:__

<img width="1440" alt="screen shot 2017-12-23 at 3 11 10 am" src="https://user-images.githubusercontent.com/5358146/34319152-7d864448-e78f-11e7-9b4f-61c2297233b7.png">

<img width="1440" alt="screen shot 2017-12-23 at 3 11 07 am" src="https://user-images.githubusercontent.com/5358146/34319154-877354d2-e78f-11e7-83c4-05ff77065366.png">

