### PR TITLE
Remove all-caps default in /tip (yge)

### DIFF
--- a/app/assets/yge/css/main.css
+++ b/app/assets/yge/css/main.css
@@ -143,7 +143,6 @@ body {
 		font-weight: 300;
 		line-height: 2;
 		letter-spacing: 0.2em;
-		text-transform: uppercase;
 	}
 
 		@media screen and (max-width: 1680px) {

--- a/app/assets/yge/sass/base/_typography.scss
+++ b/app/assets/yge/sass/base/_typography.scss
@@ -17,7 +17,6 @@
 		font-weight: _font(weight);
 		line-height: 2;
 		letter-spacing: _size(letter-spacing);
-		text-transform: uppercase;
 
 		@include breakpoint(xlarge) {
 			font-size: 11pt;

--- a/app/dashboard/templates/yge/base.html
+++ b/app/dashboard/templates/yge/base.html
@@ -5,6 +5,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!--[if lte IE 8]><script src="/static/yge/js/html5shiv.js"></script><![endif]-->
+		<link rel="stylesheet" href="/static/v2/css/gitcoin.css" />
 		<link rel="stylesheet" href="/static/yge/css/main.css" />
         <link rel="stylesheet" href="/static/v2/css/rain.css" />
         <link rel="stylesheet" href="/static/v2/css/jquery.select2.min.css" />

--- a/app/dashboard/templates/yge/send1.html
+++ b/app/dashboard/templates/yge/send1.html
@@ -21,7 +21,7 @@
         </span>
 		<h1>Send Tip ⚡</h1>
 		<h3>It's Fast.  It's Easy.  It's Free.️</h3>
-        <h4>(Supports any github username or email address)</h4>
+        <p>(Supports any github username or email address)</p
         <br>
             <select id="batches" style="background:transparent; display: none; margin-bottom: 20px; margin-top: -20px" >
                 <option value="1">1 receipient</option>


### PR DESCRIPTION
##### Description
Similar to #116 and discussed in #151 this PR removes the global (on body) `text-transform: uppercase` style from the /tip (yge) application. 

As discussed in #151 properties like the bounty status should also be normalized (capitalized in the UI) 
These properties are stored in the DB and we need to decide where to put that presentation logic. 


##### Checklist

- [ ] normalize bounty properties (status, etc.)

##### Affected core subsystem(s)
ui

##### Refers/Fixes
* #151 - "typography cleanup after PR #116" 
