### PR TITLE
Changed bounties URL in JS to prevent 301 redirect

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -192,7 +192,7 @@ var pendingChangesWarning = function(issueURL, last_modified_time_remote, now){
             //check_for_bounty_changed_updates_REST();
         };
         var check_for_bounty_changed_updates_REST = function(){
-            var uri = '/api/v0.1/bounties?github_url='+issueURL;
+            var uri = '/api/v0.1/bounties/?github_url='+issueURL;
              $.get(uri, function(results){
                 results = sanitizeAPIResults(results);
                 var result = results[0];
@@ -273,7 +273,7 @@ window.addEventListener('load', function() {
     setTimeout(function(){
         var issueURL = getParam('url');
         $("#submitsolicitation a").attr('href','/funding/new/?source=' + issueURL)
-        var uri = '/api/v0.1/bounties?';
+        var uri = '/api/v0.1/bounties/?';
         $.get(uri, function(results){
             results = sanitizeAPIResults(results);
             var nonefound = true;

--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -72,7 +72,7 @@ var set_modifiers_sentence = function(){
 };
 
 var get_search_URI = function(){
-    var uri = '/api/v0.1/bounties?';
+    var uri = '/api/v0.1/bounties/?';
     var keywords = $("#keywords").val();
     if(keywords){
         uri += '&raw_data='+keywords;


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
When the Issue Explorer is visited there are XHR requests to an endpoint related to bounties information. Due a missing trailing slash in the XHR's the API server returns with a 301 redirect and duplicate XHR's (now with the trailing slash) are sent out. This fix adds the trailing slashes into the JS files where the requests are sent out, so as to prevent the 301 and reduce loading time and bandwidth, if only by a small amount.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
