### PR TITLE
Add initial pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: git://github.com/pre-commit/mirrors-isort
+  sha: 'v4.2.15'
+  hooks:
+  - id: isort
+    args:
+      - --check-only
+      - --recursive
+      - --settings-path
+      - ./setup.cfg
+      - .

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -33,7 +33,6 @@ from dashboard.tokens import addr_to_token
 from economy.models import SuperModel
 from economy.utils import convert_amount
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,6 +45,11 @@ your answers cleared up.
 Pull Requests are the way in which concrete changes are made to the code and
 documentation.
 
+## Prerequisites
+
+You must install [pre-commit](https://pre-commit.com/#install) in order to enable our
+precommit hooks and `pre-commit install` from your `gitcoinco/web` root directory.
+
 ### Step 1: Fork
 
 Fork the project [on GitHub](https://github.com/gitcoinco/web) and clone your


### PR DESCRIPTION
##### Description

The goal of this PR is to introduce [pre-commit](https://pre-commit.com/#install) for handling pre-commit checks (isort, eslint, etc).
Currently, this initial implementation enabled the `isort` pre-commit hook, which will verify that all python file imports are properly sorted.

Steps to install/test from within the `web` repository directory:

- `brew install pre-commit`
- `pre-commit install`
- Modify any .py file to include unsorted imports
- Attempt to stage the changes

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
