### PR TITLE
refactor: reused wallet address readily available in document

### DIFF
--- a/app/assets/yge/youvegoteth/send.js
+++ b/app/assets/yge/youvegoteth/send.js
@@ -174,7 +174,7 @@ window.onload = function () {
         var plural = numBatches > 1 ? 's' : '';
         var processTx = function(i){
             //generate ephemeral account
-            var _owner = '0x' + lightwallet.keystore._computeAddressFromPrivKey(document.addresses[i].pk);
+            var _owner = document.addresses[i]['address'];
             var _private_key = document.addresses[i]['pk'];
 
             //set up callback for web3 call to final transfer


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

- reused wallet address readily available in document rather than computing address from the private key (The image you see there is  the output of  `console.log("A0", _owner, document.addresses[i]);`

<img width="919" alt="screen shot 2018-01-26 at 1 25 47 pm" src="https://user-images.githubusercontent.com/5358146/35461387-9a1b0062-029c-11e8-863a-088ea6cf91f4.png">

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
- youvegoteth
