### PR TITLE
Modify slack email invitation handling

### DIFF
--- a/app/marketing/management/commands/ingest_slack_users.py
+++ b/app/marketing/management/commands/ingest_slack_users.py
@@ -1,5 +1,5 @@
 '''
-    Copyright (C) 2017 Gitcoin Core 
+    Copyright (C) 2017 Gitcoin Core
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -27,10 +27,10 @@ def process_email(email):
     if not queryset.exists():
         print(email)
         source = 'slack_ingester'
-        es = EmailSubscriber.objects.create(
+        EmailSubscriber.objects.create(
             email=email,
             source=source,
-            )
+        )
 
 
 class Command(BaseCommand):
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             try:
                 email = member['profile']['email']
                 process_email(email)
-            except:
+            except Exception:
                 pass
 
         # pennding invites

--- a/app/marketing/utils.py
+++ b/app/marketing/utils.py
@@ -1,5 +1,5 @@
 '''
-    Copyright (C) 2017 Gitcoin Core 
+    Copyright (C) 2018 Gitcoin Core
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -28,7 +28,7 @@ def get_stat(key):
 
 def invite_to_slack(email):
     if settings.DEBUG:
-        return False
+        return {}
     sc = SlackClient(settings.SLACK_TOKEN)
     response = sc.api_call('users.admin.invite', email=email)
     return response
@@ -41,7 +41,7 @@ def should_suppress_notification_email(email):
     return False
 
 
-def get_or_save_email_subscriber(email, source):
+def get_or_save_email_subscriber(email, source, send_slack_invite=True):
     queryset = EmailSubscriber.objects.filter(email__iexact=email)
     if not queryset.exists():
         es = EmailSubscriber.objects.create(
@@ -50,7 +50,7 @@ def get_or_save_email_subscriber(email, source):
             )
         es.set_priv()
         es.save()
-        invite_to_slack(email)
+        if send_slack_invite:
+            invite_to_slack(email)
         return es.priv
-    else:
-        return queryset.first().priv
+    return queryset.first().priv

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -1,6 +1,6 @@
 # encoding=utf8
 '''
-    Copyright (C) 2017 Gitcoin Core
+    Copyright (C) 2018 Gitcoin Core
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -22,6 +22,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
+import rollbar
 from marketing.utils import get_or_save_email_subscriber, invite_to_slack
 
 
@@ -247,7 +248,7 @@ The best way to stay in touch is to
 
             """
         },
-     ], 
+     ],
      'Web3': [
         {
             'category': "Web3",
@@ -393,8 +394,7 @@ def error(request, code):
 
     if return_as_json:
         return JsonResponse(context, status=500)
-    else:
-        return TemplateResponse(request, 'error.html', context)
+    return TemplateResponse(request, 'error.html', context)
 
 
 def portal(request):
@@ -473,30 +473,28 @@ def schwag(request):
 
 
 def slack(request):
+    email = request.POST.get('email')
     context = {
         'active': 'slack',
+        'msg': 'You must provide an email address',
     }
 
-    if request.POST.get('email', False):
-        email = request.POST['email']
-        valid_email = True
+    if email:
+        context['msg'] = 'Your invite has been sent. '
         try:
-            validate_email(request.POST.get('email', False))
-        except ValidationError:
-            valid_email = False
-
-        if valid_email:
-            get_or_save_email_subscriber(email, 'slack')
+            validate_email(email)
+            get_or_save_email_subscriber(email, 'slack', send_slack_invite=False)
             response = invite_to_slack(email)
-            if response['ok']:
-                context['msg'] = "Your invite has been sent. "
-            else:
-                context['msg'] = response['error']
-        else:
-            context['msg'] = "Invalid email"
+
+            if not response.get('ok'):
+                context['msg'] = response.get('error', 'Unknown error')
+                rollbar.report_message(
+                    'Slack invitation failed', 'warning',
+                    extra_data={'slack_response': response})
+        except ValidationError:
+            context['msg'] = 'Invalid email'
 
     return TemplateResponse(request, 'slack.html', context)
-
 
 
 def btctalk(request):


### PR DESCRIPTION
##### Description

The goal of this PR is to modify Slack invitation handling.  Previously, we were calling `invite_to_slack` twice for users attempting to join slack via the `/slack` endpoint (calling the method: `invite_to_slack` in both the view and the `get_or_save_email_subscriber` method).

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Refers/Fixes
Refs: #276
