### PR TITLE
Adjust email handling for tip flow

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -210,7 +210,7 @@ SECURE_HSTS_SECONDS = 3600
 GITHUB_API_BASE_URL = 'https://api.github.com'
 GITHUB_AUTH_BASE_URL = 'https://github.com/login/oauth/authorize'
 GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token'
-GITHUB_SCOPE = 'user'
+GITHUB_SCOPE = 'read:user,user:email,read:org'
 
 # List of github usernames to not count as comments on an issue
 IGNORE_COMMENTS_FROM = ['gitcoinbot', ]

--- a/app/dashboard/templates/shared/github_username.html
+++ b/app/dashboard/templates/shared/github_username.html
@@ -1,5 +1,5 @@
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core 
+    Copyright (C) 2017 Gitcoin Core
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -17,10 +17,10 @@
 {% endcomment %}
 
                                 <div class="w-100 mt-2">
-                                    <label for=githubUsername>Github Username:</label> 
-                                    {% if github_profile %}
+                                    <label for=githubUsername>Github Username:</label>
+                                    {% if not github_handle %}
                                         <a href="/_github/auth">(Login)</a>
                                     {% else %}
                                     {% endif %}
-                                    <input name='githubUsername' id='githubUsername'  class="w-100 gc-round-text-input" type="text" disabled="disabled" placeholder="@you (optional)" value="{% if github_profile %}{{ github_profile }}{% else %}{{githubUsername}}{% endif %}" />
+                                    <input name='githubUsername' id='githubUsername'  class="w-100 gc-round-text-input" type="text" disabled="disabled" placeholder="@you (optional)" value="{% if github_handle %}{{ github_handle }}{% else %}{{githubUsername}}{% endif %}" />
                                 </div>

--- a/app/github/tests/test_utils.py
+++ b/app/github/tests/test_utils.py
@@ -127,7 +127,7 @@ class GithubUtilitiesTest(TestCase):
     @responses.activate
     def test_get_github_user_token(self):
         """Test the github utility get_github_user_token method."""
-        data = {'access_token': self.user_oauth_token, 'scope': 'user'}
+        data = {'access_token': self.user_oauth_token, 'scope': 'read:user,user:email'}
         params = {
             'code': self.callback_code,
             'client_id': settings.GITHUB_CLIENT_ID,

--- a/app/github/utils.py
+++ b/app/github/utils.py
@@ -169,7 +169,7 @@ def get_github_user_token(code, **kwargs):
         settings.GITHUB_TOKEN_URL, headers=JSON_HEADER, params=_params)
     response = response.json()
     scope = response.get('scope', None)
-    if scope and scope == settings.GITHUB_SCOPE:
+    if scope:
         access_token = response.get('access_token', None)
         return access_token
     return None


### PR DESCRIPTION
##### Description
The goal of this PR is to resolve an issue with `Tip` notifications not going out to the intended recipient email address.

Additional adjustments include fixing the github auth template to display the login link if they are not authenticated with github and adjusted the github scope to request read-only permissions.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Refers/Fixes
Fixes #321 