### PR TITLE
Use ImageOps.fit instead of Image.thumbnail 

### DIFF
--- a/app/dashboard/embed.py
+++ b/app/dashboard/embed.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse, JsonResponse
 import requests
 from dashboard.models import Bounty
 from github.utils import get_user, org_name
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, ImageOps
 from ratelimit.decorators import ratelimit
 
 
@@ -316,8 +316,7 @@ def avatar(request):
         ## config
         icon_size = (215, 215)
         ## execute
-        img_w, img_h = avatar.size
-        avatar.thumbnail(icon_size, Image.ANTIALIAS)
+        avatar = ImageOps.fit(avatar, icon_size, Image.ANTIALIAS)
         bg_w, bg_h = img.size
         offset = 0, 0
         img.paste(avatar, offset, avatar)


### PR DESCRIPTION
Fixes: https://github.com/gitcoinco/web/issues/355

##### Description
Now scales avatar photos by using [ImageOps.fit](http://pillow.readthedocs.io/en/4.0.x/reference/ImageOps.html#PIL.ImageOps.fit) instead of [Image.thumbnail](http://pillow.readthedocs.io/en/4.0.x/reference/Image.html#PIL.Image.Image.thumbnail) because Image.thumbnail will modify the image only if is larger than the given size. 

*Before*:
![avatar](https://user-images.githubusercontent.com/766596/35658684-2a23ebe0-06c8-11e8-8213-10ea0e627508.jpeg)

*After*:
![avatar 1](https://user-images.githubusercontent.com/766596/35658689-2de378a4-06c8-11e8-89b8-a0ee73a32969.jpeg)

As this is my first PR contributing to this repo, please let me know if I missed anything or if I need to include more data here. I read the CONTRIBUTING.md guide but I'm nervous I missed something 😬 

##### Checklist
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
dashboard/embed

##### Refers/Fixes
Fixes #355 

