### PR TITLE
Changes Math to Math.pow for gwei->ether gas calculation

### DIFF
--- a/app/assets/v2/js/pages/fulfill_bounty.js
+++ b/app/assets/v2/js/pages/fulfill_bounty.js
@@ -94,7 +94,7 @@ window.onload = function(){
                                     'dataHash': null,
                                     'issuer': account,
                                     'txid': result,
-                                });  
+                                });
 
                                 // See views.sync_web3
                                 dataLayer.push({'event': 'claimissue'});
@@ -129,7 +129,7 @@ window.onload = function(){
 
                             var bountyId = result['standard_bounties_id'];
 
-                            bounty.fulfillBounty(bountyId, document.ipfsDataHash, {gasPrice:web3.toHex($("#gasPrice").val()) * Math( 10, 9 )}, web3Callback);
+                            bounty.fulfillBounty(bountyId, document.ipfsDataHash, {gasPrice:web3.toHex($("#gasPrice").val()) * Math.pow( 10, 9 )}, web3Callback);
                         })
                     }
                     e.preventDefault();


### PR DESCRIPTION
##### Description
Just changes the call to `Math` to be `Math.pow` for the gwei to ether gas calculation so the submitting process doesn't throw. Looking at commit history, seems like a bad merge occurred somewhere. Pretty straightforward unless I'm missing something here 😁 

##### Checklist
- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
frontend

##### Refers/Fixes
Fixes https://github.com/gitcoinco/web/issues/357