### PR TITLE
Update Docker image to support Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ FROM python:3.6-slim-jessie
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code && \
     apt-get update && \
-    apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev make automake libtool autoconf pkg-config libffi-dev && \
+    apt-get install -y --no-install-recommends dos2unix gcc libc6-dev libc-dev libssl-dev make automake libtool autoconf pkg-config libffi-dev && \
     pip3 install dumb-init && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /code
-COPY requirements/base.txt /code/
-COPY requirements/test.txt /code/
+COPY requirements/ /code/
 RUN pip install -r test.txt
-COPY requirements/dev.txt /code/
+COPY bin/docker-command.bash /bin/docker-command.bash
 RUN pip install -r dev.txt && \
-    apt-get purge -y --auto-remove gcc libc6-dev libc-dev libssl-dev make automake libtool autoconf pkg-config libffi-dev
+    dos2unix /bin/docker-command.bash && \
+    apt-get purge -y --auto-remove dos2unix gcc libc6-dev libc-dev libssl-dev make automake libtool autoconf pkg-config libffi-dev
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["bash", "/bin/docker-command.bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/code/app
     build: .
-    command: ["bash", "bin/docker-command.bash"]
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
##### Description
When a user clones the `gitcoinco/web` repository on Windows without `--config core.autocrlf=input`, provisioning scripts are formatted incorrectly for execution in the deb container.

The goal of this PR is to resolve that issue by converting the `docker-command.bash` during the image build process with `dos2unix`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Testing
Tested building and running the docker-compose stack on both macos high sierra (10.13.2) and Windows 10.

##### Refers/Fixes
Refs: #363