### PR TITLE
Default network should be mainnet

### DIFF
--- a/app/assets/v2/js/abi.js
+++ b/app/assets/v2/js/abi.js
@@ -3,9 +3,9 @@ var bounty_abi = [{"constant":false,"inputs":[{"name":"_bountyId","type":"uint25
 
 
 var bounty_address = function (){
-    // workaround for document.web3network not working with rinkeby
     if (document.web3network == null) {
-        document.web3network = 'rinkeby';
+        // default to mainnet if web3network isn't found in time
+        document.web3network = 'mainnet';
     }
     switch(document.web3network){
         case "mainnet":


### PR DESCRIPTION
##### Description
Fix issue where if the `web3network` is not found in time it defaults to **rinkeby**.  It should default to **mainnet** instead.

##### Checklist
- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
abi.js

##### Testing
Just changes the default network in web3document is not found. 

##### Refers/Fixes

issue #370 
