### PR TITLE
refactors interest storage to be from localstorage => server

### DIFF
--- a/app/app/context.py
+++ b/app/app/context.py
@@ -1,5 +1,7 @@
-from django.conf import settings
 import json
+
+from django.conf import settings
+
 
 def insert_settings(request):
     from marketing.utils import get_stat

--- a/app/app/context.py
+++ b/app/app/context.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-
+import json
 
 def insert_settings(request):
     from marketing.utils import get_stat
@@ -18,4 +18,6 @@ def insert_settings(request):
         'rollbar_client_token': settings.ROLLBAR_CLIENT_TOKEN,
         'env': settings.ENV,
     }
+    context['json_context'] = json.dumps(context)
+
     return context

--- a/app/assets/legacy/v2/js/pages/bounty_details.js
+++ b/app/assets/legacy/v2/js/pages/bounty_details.js
@@ -295,10 +295,50 @@ var pendingChangesWarning = function(issueURL, last_modified_time_remote, now){
 
 window.addEventListener('load', function() {
 
+    var build_detail_page = function(result){
+
+        //setup
+        var decimals = 18;
+        var related_token_details = tokenAddressToDetails(result['token_address'])
+        if(related_token_details && related_token_details.decimals){
+            decimals = related_token_details.decimals;
+        }
+        document.decimals = decimals;
+        $("#bounty_details").css('display','flex');
+
+        // title
+        result['title'] = result['title'] ? result['title'] : result['github_url'];
+        result['title'] = result['network'] != 'mainnet' ? "(" + result['network'] + ") " + result['title'] : result['title'];
+        $('.title').html("Funded Issue Details: " + result['title']);
+
+        //insert table onto page
+        for(var j=0; j< rows.length; j++){
+            var key = rows[j];
+            var head = null;
+            var val = result[key];
+            if(heads[key]){
+                head = heads[key];
+            }
+            if(callbacks[key]){
+                _result = callbacks[key](key, val, result);
+                val = _result[1];
+            }
+            var entry = {
+                'head': head,
+                'key': key,
+                'val': val,
+            }
+            var id = '#' + key;
+            if($(id).length){
+                $(id).html(val);
+            }
+        }
+
+    };
+
     var do_actions = function(result){
 
     // Find interest information
-    var is_interested = document.interested
     pull_interest_list(result['pk'], function(is_interested){
 
         //actions
@@ -414,44 +454,9 @@ window.addEventListener('load', function() {
                 var result = results[i];
                 // if the result from the database matches the one in question.
                 if(normalizeURL(result['github_url']) == normalizeURL(issueURL)){
-                    $("#bounty_details").css('display','flex');
                     nonefound = false;
 
-                    //setup
-                    var decimals = 18;
-                    var related_token_details = tokenAddressToDetails(result['token_address'])
-                    if(related_token_details && related_token_details.decimals){
-                        decimals = related_token_details.decimals;
-                    }
-                    document.decimals = decimals;
-
-                    // title
-                    result['title'] = result['title'] ? result['title'] : result['github_url'];
-                    result['title'] = result['network'] != 'mainnet' ? "(" + result['network'] + ") " + result['title'] : result['title'];
-                    $('.title').html("Funded Issue Details: " + result['title']);
-
-                    //insert table onto page
-                    for(var j=0; j< rows.length; j++){
-                        var key = rows[j];
-                        var head = null;
-                        var val = result[key];
-                        if(heads[key]){
-                            head = heads[key];
-                        }
-                        if(callbacks[key]){
-                            _result = callbacks[key](key, val, result);
-                            val = _result[1];
-                        }
-                        var entry = {
-                            'head': head,
-                            'key': key,
-                            'val': val,
-                        }
-                        var id = '#' + key;
-                        if($(id).length){
-                            $(id).html(val);
-                        }
-                    }
+                    build_detail_page(result);
 
                     do_actions(result);
 

--- a/app/assets/legacy/v2/js/pages/bounty_details.js
+++ b/app/assets/legacy/v2/js/pages/bounty_details.js
@@ -294,6 +294,114 @@ var pendingChangesWarning = function(issueURL, last_modified_time_remote, now){
 };
 
 window.addEventListener('load', function() {
+
+    var do_actions = function(result){
+
+    // Find interest information
+    var is_interested = document.interested
+    pull_interest_list(result['pk'], function(is_interested){
+
+        //actions
+        var actions = [];
+        if(result['github_url'].substring(0,4) == 'http'){
+
+            var github_url = result['github_url'];
+
+            // hack to get around the renamed repo for piper's work.  can't change the data layer since blockchain is immutable
+            github_url = github_url.replace('pipermerriam/web3.py','ethereum/web3.py');
+
+            if(result['github_comments']){
+                var entry_comment = {
+                  href: github_url,
+                  text: result['github_comments'],
+                  target: 'new',
+                  parent: 'right_actions',
+                  color: 'github-comment'
+                };
+                actions.push(entry_comment);
+            }
+
+            var entry = {
+                href: github_url,
+                text: 'View on Github',
+                target: 'new',
+                parent: 'right_actions',
+                color: 'darkBlue',
+                title: 'Github is where the issue scope lives.  Its also a great place to collaborate with, and get to know, other developers (and sometimes even the repo maintainer themselves!).'
+            }
+
+            actions.push(entry);
+        }
+
+        if(result['status']=='open' || result['status']=='started' ){
+
+            // is enabled
+            var enabled = !isBountyOwner(result);
+            var interestEntry = {
+                href: is_interested ? '/uninterested' : '/interested',
+                text: is_interested ? 'Stop Work' : 'Start Work',
+                parent: 'right_actions',
+                color: enabled ? 'darkBlue' : 'darkGrey',
+                extraClass: enabled ? '' : 'disabled',
+                title: enabled ? 'Start Work in an issue to let the issue funder know that youre interested in working with them.  Use this functionality when you START work.  Please leave a comment for the bounty submitter to let them know you are interested in working with them after you start work' : 'Can only be performed if you are not the funder.',
+            }
+            actions.push(interestEntry);
+
+        }
+
+        // is enabled
+        var enabled = !isBountyOwner(result);
+        var entry = {
+            href: '/legacy/funding/fulfill?source='+result['github_url'],
+            text: 'Submit Work',
+            parent: 'right_actions',
+            color: enabled ? 'darkBlue' : 'darkGrey',
+            extraClass: enabled ? '' : 'disabled',
+            title: enabled ? 'Use Submit Work when you FINISH work on a bounty.   Use Claim Work when you START work.' : 'Can only be performed if you are not the funder.',
+        }
+        actions.push(entry);
+
+        var is_expired = result['status']=='expired' || (new Date(result['now']) > new Date(result['expires_date']));
+        if(is_expired){
+            var enabled = isBountyOwner(result);
+            var entry = {
+                href: '/legacy/funding/clawback?source='+result['github_url'],
+                text: 'Clawback Expired Funds',
+                parent: 'right_actions',
+                color: enabled ? 'darkBlue' : 'darkGrey',
+                extraClass: enabled ? '' : 'disabled',
+                title: enabled ? '' : 'Can only be performed if you are the funder.',
+            }
+            actions.push(entry);
+        }
+        if(result['status']=='submitted' ){
+            var enabled = isBountyOwner(result);
+            var entry = {
+                href: '/legacy/funding/process?source='+result['github_url'],
+                text: 'Accept/Reject Submission',
+                parent: 'right_actions',
+                color: enabled ? 'darkBlue' : 'darkGrey',
+                extraClass: enabled ? '' : 'disabled',
+                title: enabled ? '' : 'Can only be performed if you are the funder.',
+
+            }
+            actions.push(entry);
+        }
+
+        render_actions(actions);     
+
+        });  
+    }
+
+    var render_actions = function(actions){
+        for(var l=0; l< actions.length; l++){
+            var target = actions[l]['parent'];
+            var tmpl = $.templates("#action");
+            var html = tmpl.render(actions[l]);
+            $("#"+target).append(html);
+        };      
+    }
+
     setTimeout(function(){
         var issueURL = getParam('url');
         $("#submitsolicitation a").attr('href','/funding/new/?source=' + issueURL)
@@ -322,10 +430,6 @@ window.addEventListener('load', function() {
                     result['title'] = result['network'] != 'mainnet' ? "(" + result['network'] + ") " + result['title'] : result['title'];
                     $('.title').html("Funded Issue Details: " + result['title']);
 
-                    // Find interest information
-                    var is_interested = is_on_interest_list(result['pk']);
-                    update_interest_list(result['pk']);
-
                     //insert table onto page
                     for(var j=0; j< rows.length; j++){
                         var key = rows[j];
@@ -349,95 +453,7 @@ window.addEventListener('load', function() {
                         }
                     }
 
-                    //actions
-                    var actions = [];
-                    if(result['github_url'].substring(0,4) == 'http'){
-
-                        var github_url = result['github_url'];
-                        // hack to get around the renamed repo for piper's work.  can't change the data layer since blockchain is immutable
-                        github_url = github_url.replace('pipermerriam/web3.py','ethereum/web3.py');
-
-                        if(result['github_comments']){
-                            var entry_comment = {
-                              href: github_url,
-                              text: result['github_comments'],
-                              target: 'new',
-                              parent: 'right_actions',
-                              color: 'github-comment'
-                            };
-                            actions.push(entry_comment);
-                        }
-
-
-
-                        var entry = {
-                            href: github_url,
-                            text: 'View on Github',
-                            target: 'new',
-                            parent: 'right_actions',
-                            color: 'darkBlue',
-                            title: 'Github is where the issue scope lives.  Its also a great place to collaborate with, and get to know, other developers (and sometimes even the repo maintainer themselves!).'
-                        }
-
-                        actions.push(entry);
-                    }
-                    var enabled = !isBountyOwner(result);
-                    if(result['status']=='open' || result['status']=='started' ){
-
-                        var interestEntry = {
-                            href: is_interested ? '/uninterested' : '/interested',
-                            text: is_interested ? 'Stop Work' : 'Start Work',
-                            parent: 'right_actions',
-                            color: enabled ? 'darkBlue' : 'darkGrey',
-                            extraClass: enabled ? '' : 'disabled',
-                            title: enabled ? 'Start Work in an issue to let the issue funder know that youre interested in working with them.  Use this functionality when you START work.  Please leave a comment for the bounty submitter to let them know you are interested in working with them after you start work' : 'Can only be performed if you are not the funder.',
-                        }
-                        actions.push(interestEntry);
-
-                        var entry = {
-                            href: '/legacy/funding/fulfill?source='+result['github_url'],
-                            text: 'Submit Work',
-                            parent: 'right_actions',
-                            color: enabled ? 'darkBlue' : 'darkGrey',
-                            extraClass: enabled ? '' : 'disabled',
-                            title: enabled ? 'Use Submit Work when you FINISH work on a bounty.   Use Claim Work when you START work.' : 'Can only be performed if you are not the funder.',
-                        }
-                        actions.push(entry);
-                    }
-
-                    var is_expired = result['status']=='expired' || (new Date(result['now']) > new Date(result['expires_date']));
-                    if(is_expired){
-                        var enabled = isBountyOwner(result);
-                        var entry = {
-                            href: '/legacy/funding/clawback?source='+result['github_url'],
-                            text: 'Clawback Expired Funds',
-                            parent: 'right_actions',
-                            color: enabled ? 'darkBlue' : 'darkGrey',
-                            extraClass: enabled ? '' : 'disabled',
-                            title: enabled ? '' : 'Can only be performed if you are the funder.',
-                        }
-                        actions.push(entry);
-                    }
-                    if(result['status']=='submitted' ){
-                        var enabled = isBountyOwner(result);
-                        var entry = {
-                            href: '/legacy/funding/process?source='+result['github_url'],
-                            text: 'Accept/Reject Submission',
-                            parent: 'right_actions',
-                            color: enabled ? 'darkBlue' : 'darkGrey',
-                            extraClass: enabled ? '' : 'disabled',
-                            title: enabled ? '' : 'Can only be performed if you are the funder.',
-
-                        }
-                        actions.push(entry);
-                    }
-
-                    for(var l=0; l< actions.length; l++){
-                        var target = actions[l]['parent'];
-                        var tmpl = $.templates("#action");
-                        var html = tmpl.render(actions[l]);
-                        $("#"+target).append(html);
-                    }
+                    do_actions(result);
 
                     //cleanup
                     document.result = result;

--- a/app/assets/legacy/v2/js/shared.js
+++ b/app/assets/legacy/v2/js/shared.js
@@ -128,52 +128,30 @@ var showLoading = function(){
     setTimeout(showLoading,10);
 };
 
-/** The local list of bounty PKs the current profile is interested in. */
-var interested_list = function () {
-    if (typeof localStorage.interests == 'undefined') {
-        return [];
-    }
-    return localStorage.interests.split(',');
-}
-
-/** Check whether or not the current profile is interested in the bounty. */
-var is_on_interest_list = function (bounty_pk) {
-    if (localStorage.interests && localStorage.interests.indexOf(bounty_pk) != -1) {
-        return true;
-    }
-    return false;
-}
 
 /** Add the current profile to the interested profiles list. */
 var add_interest = function (bounty_pk) {
-    if (is_on_interest_list(bounty_pk)) {
+    if (document.interested) {
         return;
     }
-    var request_url = '/actions/bounty/' + bounty_pk + '/interest/new/';
-    $.post(request_url, function (result) {
-        localStorage.interests = localStorage.interests + "," + bounty_pk;
-        result = sanitizeAPIResults(result);
-        if (result.success) {
-            update_interest_list(bounty_pk);
-            return true;
-        }
-        return false;
-    }).fail(function(result){
-        alert("You must login via github to use this feature");
-    });
+    mutate_interest(bounty_pk,'new');
 }
 
 /** Remove the current profile from the interested profiles list. */
 var remove_interest = function (bounty_pk) {
-    if (!is_on_interest_list(bounty_pk)) {
+    if (!document.interested) {
         return;
     }
-    var request_url = '/actions/bounty/' + bounty_pk + '/interest/remove/';
+    mutate_interest(bounty_pk,'remove');
+}
+
+/** Helper function -- mutates interests in either direction. */
+var mutate_interest = function (bounty_pk, direction) {
+    var request_url = '/actions/bounty/' + bounty_pk + '/interest/'+direction+'/';
     $.post(request_url, function (result) {
-        localStorage.interests = localStorage.interests.replace("," + bounty_pk, "");
         result = sanitizeAPIResults(result);
         if (result.success) {
-            update_interest_list(bounty_pk);
+            pull_interest_list(bounty_pk);
             return true;
         }
         return false;
@@ -182,9 +160,10 @@ var remove_interest = function (bounty_pk) {
     });
 }
 
-/** Update the list of interested profiles. */
-var update_interest_list = function (bounty_pk) {
+/** Pulls the list of interested profiles from the server. */
+var pull_interest_list = function (bounty_pk, callback) {
     profiles = [];
+    document.interested = false
     $.getJSON("/actions/bounty/" + bounty_pk + "/interest/", function (data) {
         data = sanitizeAPIResults(JSON.parse(data));
         $.each(data, function (index, value) {
@@ -193,7 +172,13 @@ var update_interest_list = function (bounty_pk) {
                 handle: value.handle,
                 url: value.url
             };
+            // add to template
             profiles.push(profile);
+            // update document.interested
+            if(profile.handle == document.contxt.github_handle){
+                document.interested = true
+            }
+
         });
         var tmpl = $.templates("#interested");
         var html = tmpl.render(profiles);
@@ -201,6 +186,9 @@ var update_interest_list = function (bounty_pk) {
             html = "No one has started work on this issue yet.";
         }
         $("#interest_list").html(html);
+        if(typeof callback != 'undefined'){
+            callback(document.interested);
+        }
     });
     return profiles;
 }

--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -392,6 +392,45 @@ var pendingChangesWarning = function(issueURL, last_modified_time_remote, now){
 
 window.addEventListener('load', function() {
 
+    var build_detail_page = function(result){
+        //setup
+        var decimals = 18;
+        var related_token_details = tokenAddressToDetails(result['token_address'])
+        if(related_token_details && related_token_details.decimals){
+            decimals = related_token_details.decimals;
+        }
+        $("#bounty_details").css('display','flex');
+        document.decimals = decimals;
+
+        // title
+        result['title'] = result['title'] ? result['title'] : result['github_url'];
+        result['title'] = result['network'] != 'mainnet' ? "(" + result['network'] + ") " + result['title'] : result['title'];
+        $('.title').html("Funded Issue Details: " + result['title']);
+
+        //insert table onto page
+        for(var j=0; j< rows.length; j++){
+            var key = rows[j];
+            var head = null;
+            var val = result[key];
+            if(heads[key]){
+                head = heads[key];
+            }
+            if(callbacks[key]){
+                _result = callbacks[key](key, val, result);
+                val = _result[1];
+            }
+            var entry = {
+                'head': head,
+                'key': key,
+                'val': val,
+            }
+            var id = '#' + key;
+            if($(id).length){
+                $(id).html(val);
+            }
+        }        
+    }
+
     var do_actions = function(result){
         // Find interest information
         pull_interest_list(result['pk'], function(is_interested){
@@ -507,45 +546,10 @@ window.addEventListener('load', function() {
                 var result = results[i];
                 // if the result from the database matches the one in question..
                 if(normalizeURL(result['github_url']) == normalizeURL(document.issueURL)){
-                    $("#bounty_details").css('display','flex');
+
                     nonefound = false;
 
-                    //setup
-                    var decimals = 18;
-                    var related_token_details = tokenAddressToDetails(result['token_address'])
-                    if(related_token_details && related_token_details.decimals){
-                        decimals = related_token_details.decimals;
-                    }
-                    document.decimals = decimals;
-
-                    // title
-                    result['title'] = result['title'] ? result['title'] : result['github_url'];
-                    result['title'] = result['network'] != 'mainnet' ? "(" + result['network'] + ") " + result['title'] : result['title'];
-                    $('.title').html("Funded Issue Details: " + result['title']);
-
-                    //insert table onto page
-                    for(var j=0; j< rows.length; j++){
-                        var key = rows[j];
-                        var head = null;
-                        var val = result[key];
-                        if(heads[key]){
-                            head = heads[key];
-                        }
-                        if(callbacks[key]){
-                            _result = callbacks[key](key, val, result);
-                            val = _result[1];
-                        }
-                        var entry = {
-                            'head': head,
-                            'key': key,
-                            'val': val,
-                        }
-                        var id = '#' + key;
-                        if($(id).length){
-                            $(id).html(val);
-                        }
-                    }
-
+                    build_detail_page(result);
                     do_actions(result);
 
                     //cleanup

--- a/app/retail/templates/shared/footer_scripts.html
+++ b/app/retail/templates/shared/footer_scripts.html
@@ -48,3 +48,7 @@
             startTimer();
         </script>
     {% endif %}
+
+    <script>
+        document.contxt = {{json_context | safe}};
+    </script>


### PR DESCRIPTION
##### Checklist
Hi from United Airlines!  We just got a bug report from a user ( https://gitcoincommunity.slack.com/archives/C8E45J5D0/p1517679189000173 ) who had a few problems with the site. Among them, was an issue where once he received an email removing him from the list of `Interstest`ed (now Start/Stop Work) list... he couldnt re-expres interest in the work:

From his bug report: 
> Unfortunately there is only one option for me "stop work" when I click on it i get a prompt "You must login via github to use this feature". Even though I am already logged in.

Basically, there are two problems here
1. the js assumes that anytime you get a non 200 response from the server in `add_interest()` or `remove_interest()`, its that you're not logged in with github.
2. the users local browser stored that they were interested in `localstorage.interested`, and this cannot be cleared when the system's state is mutated.

To solve for the second issue, I've 
1. Refactored all of the actions logic into a method called `do_actions`, and just for good measure, the logic that builds the page, to its own seperate method too.
2. Made all of the interest action functionality pull from the server.  There is no more localstorage
3. Threaded all of the request context for a user through to the javascript layer, so that the system can reason about who is logged in / who is not.

- [X] linter status: 100% pass
- [X] changes don't break existing behavior

##### Affected core subsystem(s)
frontend

##### Testing
I've tested the start/stop functionality on both the legacy bounty details page, and also on the new bounty details page

##### Refers/Fixes
https://gitcoincommunity.slack.com/archives/C8E45J5D0/p1517679189000173
