### PR TITLE
Fix unselectable icons on select2 selects

### DIFF
--- a/app/assets/v2/css/forms/select.css
+++ b/app/assets/v2/css/forms/select.css
@@ -14,6 +14,7 @@
   height: 100%;
   justify-content: center;
   position: absolute;
+  pointer-events: none;
   right: 0;
   top: 0;
   width: 40px;


### PR DESCRIPTION
##### Description
Due to custom icons on select2 selects we used an image for the dropdown arrow. This image needs to have `pointer-events` removed.

##### Checklist
- [ ] linter status: 100% pass
- [ ] changes don't break existing behavior
- [ ] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
UI

##### Testing
Pull down and test

##### Refers/Fixes
#514 
