### PR TITLE
css : fixed display for devices below 380px

### DIFF
--- a/app/assets/v2/css/dashboard.css
+++ b/app/assets/v2/css/dashboard.css
@@ -108,3 +108,9 @@ body {
     font-size: 10px;
   }
 }
+
+@media (max-width: 380px) {
+  .bounty-summary img {
+    bottom: 24px;
+  }
+}


### PR DESCRIPTION

##### Description
<!-- A description on what this PR aims to solve -->
 noticed that a few devices have width 380px which causes the github comment section to break
<img width="388" alt="screen shot 2018-03-07 at 11 50 23 pm" src="https://user-images.githubusercontent.com/5358146/37110347-a584f698-2262-11e8-9a7f-e13f49e54cea.png">

Fixed that up ! It's not needed but meh why not

<img width="419" alt="screen shot 2018-03-07 at 11 50 51 pm" src="https://user-images.githubusercontent.com/5358146/37110366-b2233298-2262-11e8-8b02-1dce153edb48.png">
