### PR TITLE
explorer: updated tooltip

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -1029,7 +1029,7 @@ body.bounty_details #title {
     color: #919191;
 }
 
-.profile_details .tips li .amount, 
+.profile_details .tips li .amount,
 .profile_details .bounties li .amount {
     height: 80px;
     width: 200px;
@@ -1146,6 +1146,38 @@ input.is-invalid {
 
 .faucet_response .frmessage {
   font-size: large;
+}
+
+.tooltip-info {
+  font-family: "Muli";
+  padding: 20px;
+  margin: 0;
+  width: 25em;
+}
+
+.tooltip-info p {
+  margin-bottom: 10px;
+}
+
+.tooltip-info span {
+  font-family: "Muli-SemiBold";
+}
+
+.tooltip-info ol {
+  counter-reset: item;
+  padding-left: 15px;
+}
+
+.tooltip-info ol li {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.tooltip-info ol li:before {
+    content: counter(item) " ";
+    counter-increment: item;
+    font-weight: bold;
+    padding-right: 10px;
 }
 
 @media (max-width: 1350px) {
@@ -1366,6 +1398,10 @@ input.is-invalid {
     }
     #mission_hero .mission-img-wrapper img {
         max-height: 150px;
+    }
+
+    .tooltip-info {
+      display: none;
     }
 }
 @media (max-width: 481px) {

--- a/app/dashboard/templates/shared/status_tooltip.html
+++ b/app/dashboard/templates/shared/status_tooltip.html
@@ -1,24 +1,26 @@
-Possible Statuses: 
-<ol>
+<div class="tooltip-info">
+  <p class="font-subheader">Possible Status:</p>
+  <ol class="font-body">
     <li>
-        <strong>Open</strong>: Bounty is funded, and available for a new developer to come tackle. 
+      <span>Open:</span> A funded bounty is available for anyone to work on.
     </li>
     <li>
-        <strong>Work Started</strong> Bounty is funded, Coding has been started by at least one developer.
+      <span>Work Started:</span> Work has been started by at least one person.
     </li>
     <li>
-        <strong>Work Submitted</strong>: Bounty is funded, Code has been completed, and bounty hunters have *submitted* a claim
+      <span>Work Submitted:</span> Completed work has been submitted by for review.
     </li>
     <li>
-        <strong>Work Done</strong>: The funder has accepted the work submission.  The staked funds have been paid out.
+      <span>Work Done:</span> The submitted project has been accepted and the funds have been paid.
     </li>
-</ol>
-Cancellation Statuses:
-<ol>
+  </ol>
+  <p class="font-subheader">Cancellation Status:</p>
+  <ol class="font-body">
     <li>
-        <strong>Expired</strong>: Bounty was not completed by expiration date and has expired.
+      <span>Expired:</span> Work was not completed by the expiration date.
     </li>
     <li>
-        <strong>Canceled</strong>: Bounty was not completed, and was canceled by the bounty submitter.
+      <span>Canceled:</span> A funded bounty was  cancelled by the owner of the project.
     </li>
-</ol>
+  </ol>
+</div>


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- Updated the tooltip on the explorer page. 
- Made it generic enough to be reused.
- Added the styling to `base.css`


<img width="1440" alt="screen shot 2018-03-10 at 3 18 08 am" src="https://user-images.githubusercontent.com/5358146/37231736-4e03981e-2412-11e8-934a-d013ac977d42.png">


##### Checklist

- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- ui
