### PR TITLE
Enable ESLint in pre-commit and on Travis CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -92,7 +92,7 @@
       }
     ],
     "no-empty-function": "error",
-    "no-eq-null": "error",
+    "no-eq-null": "warn",
     "no-extra-bind": "error",
     "no-extra-label": "error",
     "no-implicit-globals": "error",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,10 @@ repos:
       - --settings-path
       - ./setup.cfg
       - .
+- repo: local
+  hooks:
+  - id: eslint
+    name: eslint
+    language: system
+    entry: sh -c 'npm run eslint'
+    files: .js$

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
 env:
   - PYTHONPATH="$TRAVIS_BUILD_DIR/app/"
 cache:
-  - pip
   directories:
+    - $HOME/.cache/pip
     - node_modules
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ node_js:
   - "8"
 env:
   - PYTHONPATH="$TRAVIS_BUILD_DIR/app/"
+cache:
+  - pip
+  directories:
+    - node_modules
 install:
   - npm install
   - cp app/app/local_settings.py.dist app/app/local_settings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "3.6"
 node_js:
-  - "7"
+  - "8"
 env:
   - PYTHONPATH="$TRAVIS_BUILD_DIR/app/"
 install:
@@ -12,7 +12,6 @@ install:
   - pip install -r requirements/test.txt
 script:
   - npm run eslint
-  - npm run stylelint
   - pytest -p no:ethereum
 after_success:
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ sudo: false
 language: python
 python:
   - "3.6"
+node_js:
+  - "7"
 env:
   - PYTHONPATH="$TRAVIS_BUILD_DIR/app/"
 install:
+  - npm install
   - cp app/app/local_settings.py.dist app/app/local_settings.py
   - pip install -r requirements/test.txt
 script:
+  - npm run eslint
+  - npm run stylelint
   - pytest -p no:ethereum
 after_success:
   - pip install codecov


### PR DESCRIPTION
##### Description
The goal of this PR is to enable `eslint` to run via `pre-commit` and on Travis, to ensure JS styling on already styled files.

##### Checklist
- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
pre-commit, travis, git

##### Testing
- Tested the pre-commit with both failing and passing cases
- Tested Travis on `mbeacom/web`

