### PR TITLE
css: fixed explorer overflow on mobile

### DIFF
--- a/app/assets/v2/css/search_bar.css
+++ b/app/assets/v2/css/search_bar.css
@@ -84,18 +84,28 @@
   font-size: 9px;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
+
+  .title-row {
+    display: inline-block;
+  }
+
+  .title-row .bounty-info {
+    margin-bottom: 10px;
+  }
+
+  .title-row .bounty-info #modifiers {
+    padding-left: 20px;
+  }
+
   .search-area {
     margin-bottom: 10px;
     margin-left: 0px;
   }
 
-  .save_search {
-    margin-left: 0;
-  }
-
   .search_bar #new_search {
     margin-left: 0;
+    margin-bottom: 10px;
   }
 
   .search_bar #new_search,
@@ -111,6 +121,7 @@
     padding-right: 15px;
   }
 
+  .save_search,
   .filter-tags {
     display: none;
   }


### PR DESCRIPTION
- removed save button on mobile (as discussed with @PixelantDesign )
- fixed up the css overflow! sorry about that @owocki  😅 

<img width="403" alt="screen shot 2018-03-26 at 10 36 08 pm" src="https://user-images.githubusercontent.com/5358146/37921074-574f517e-3146-11e8-915e-6504b1b2c483.png">


Fixes: #705

@mbeacom quick fix ^_^
