### PR TITLE
twitter.com/gitcoinfeed

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -92,27 +92,27 @@ def maybe_market_to_twitter(bounty, event_name):
         ]
     elif event_name == 'increase_payout':
         tweet_txts = [
-            'Increased Payout on {} {} {}'
+            'Increased Payout on {} {} {}\n{}'
         ]
     elif event_name == 'start_work':
         tweet_txts = [
-            'Work started on {} {} {}'
+            'Work started on {} {} {}\n{}'
         ]
     elif event_name == 'stop_work':
         tweet_txts = [
-            'Work stopped on {} {} {}'
+            'Work stopped on {} {} {}\n{}'
         ]
     elif event_name == 'work_done':
         tweet_txts = [
-            'Work done on {} {} {}'
+            'Work done on {} {} {}\n{}'
         ]
     elif event_name == 'work_submitted':
         tweet_txts = [
-            'Work submitted on {} {} {}'
+            'Work submitted on {} {} {}\n{}'
         ]
     elif event_name == 'killed_bounty':
         tweet_txts = [
-            'Bounty killed on {} {} {}'
+            'Bounty killed on {} {} {}\n{}'
         ]
 
     random.shuffle(tweet_txts)

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -84,16 +84,35 @@ def maybe_market_to_twitter(bounty, event_name):
             "Gitcoin open task of the day is worth {} {} {} ⚡️ \n\n{}",
             "Task of the day 💰 {} {} {} ⚡️ \n\n{}",
         ]
-    if event_name == 'new_bounty':
+    elif event_name == 'new_bounty':
         tweet_txts = tweet_txts + [
             "Extra! Extra 🗞🗞 New Funded Issue, Read all about it 👇  {} {} {} \n\n{}",
             "Hot off the blockchain! 🔥🔥🔥 There's a new task worth {} {} {} \n\n{}",
             "💰 New Task Alert.. 💰 Earn {} {} {} for working on this 👇 \n\n{}",
         ]
-    if event_name  == 'increased_bounty':
-        tweet_txts = tweet_txts + [
-            "Looking for paid Open Source work? Earn {} {} {} and boost your reputation by completing this task \n\n{}",
-            "Ding ding ding!! A bounty was just increased to {} {} {}! Someone must really want you to work on this task \n\n{}"
+    elif event_name == 'increase_payout':
+        tweet_txts = [
+            'Increased Payout on {} {} {}'
+        ]
+    elif event_name == 'start_work':
+        tweet_txts = [
+            'Work started on {} {} {}'
+        ]
+    elif event_name == 'stop_work':
+        tweet_txts = [
+            'Work stopped on {} {} {}'
+        ]
+    elif event_name == 'work_done':
+        tweet_txts = [
+            'Work done on {} {} {}'
+        ]
+    elif event_name == 'work_submitted':
+        tweet_txts = [
+            'Work submitted on {} {} {}'
+        ]
+    elif event_name == 'killed_bounty':
+        tweet_txts = [
+            'Bounty killed on {} {} {}'
         ]
 
     random.shuffle(tweet_txts)

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -39,6 +39,7 @@ from dashboard.models import (
 )
 from dashboard.notifications import (
     maybe_market_tip_to_email, maybe_market_tip_to_github, maybe_market_tip_to_slack, maybe_market_to_slack,
+    maybe_market_to_twitter,
 )
 from dashboard.utils import get_bounty, get_bounty_id, has_tx_mined, web3_process_bounty
 from gas.utils import conf_time_spread, eth_usd_conv_rate, recommend_min_gas_price_to_confirm_in_time
@@ -128,6 +129,7 @@ def new_interest(request, bounty_id):
         bounty.interested.add(interest)
         record_user_action(Profile.objects.get(pk=profile_id).handle, 'start_work', interest)
         maybe_market_to_slack(bounty, 'start_work')
+        maybe_market_to_twitter(bounty, 'start_work')
     except Interest.MultipleObjectsReturned:
         bounty_ids = bounty.interested \
             .filter(profile_id=profile_id) \
@@ -173,8 +175,9 @@ def remove_interest(request, bounty_id):
         interest = Interest.objects.get(profile_id=profile_id, bounty=bounty)
         record_user_action(Profile.objects.get(pk=profile_id).handle, 'stop_work', interest)
         bounty.interested.remove(interest)
-        maybe_market_to_slack(bounty, 'stop_work')
         interest.delete()
+        maybe_market_to_slack(bounty, 'stop_work')
+        maybe_market_to_twitter(bounty, 'stop_work')
     except Interest.DoesNotExist:
         return JsonResponse({
             'errors': ['You haven\'t expressed interest on this bounty.'],

--- a/app/marketing/management/commands/remarket_tweet.py
+++ b/app/marketing/management/commands/remarket_tweet.py
@@ -28,8 +28,6 @@ class Command(BaseCommand):
     help = 'sends bounties quotes to twitter'
 
     def handle(self, *args, **options):
-        return  # per 2018/01/22 convo with vivek / kevin, these tweets have low engagement
-        # we are going to test manually promoting these tweets for a week and come back to revisit this
         bounties = Bounty.objects.filter(
             current_bounty=True,
             network='mainnet',
@@ -40,4 +38,4 @@ class Command(BaseCommand):
         bounty = bounties.order_by('?').first()
         print(bounty)
         did_tweet = maybe_market_to_twitter(bounty, 'remarket_bounty')
-        print(did_tweet)
+        print("did tweet", did_tweet)


### PR DESCRIPTION
Tweets about changes to bounties to https://twitter.com/gitcoinfeed

This allows the app to market to twitter again, after Vivek and I disabled it in January.  By taking our twitter presence and merging it into two different boths (getgitcoin - the main one) and (gitcoinfeed - just a firehose), we are able to balance the needs of our audience.

must be merged with https://gitlab.com/Owocki/gitcoin_server/merge_requests/6