### PR TITLE
workaround for web3 sync issues

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -680,7 +680,16 @@ def sync_web3(request):
                 print('* getting bounty')
                 bounty = get_bounty(bounty_id, network)
                 print('* processing bounty')
-                did_change, _, _ = web3_process_bounty(bounty)
+                did_change = False
+                max_tries_attempted = False
+                counter = 0
+                while not did_change and not max_tries_attempted:
+                    did_change, _, _ = web3_process_bounty(bounty)
+                    if not did_change:
+                        print("RETRYING")
+                        time.sleep(3)
+                        counter += 1
+                        max_tries_attempted = counter > 3
                 result = {
                     'status': '200',
                     'msg': "success",


### PR DESCRIPTION
Today we started seeing some issues wherein we would take some action (submit work, kill bounty, etc), and the system would not be able to pull updated data from infura, even after the tx had been confirmed.

on the presumption that this is some sort of state inconsistency issue upstream to us (likely at our web3 provider)... i am building some resilience into the `sync/web3` endpoint by allowing it to retry up to 3 times if it does not receive the changes from the upstream provider.