### PR TITLE
html: removed extra css link from header.html

### DIFF
--- a/app/retail/templates/shared/head.html
+++ b/app/retail/templates/shared/head.html
@@ -51,7 +51,6 @@
         <link rel="stylesheet" href="{% static "v2/css/external_bounties/bounties.css" %}" />
     {% endif %}
 
-    <link rel="stylesheet" href="{% static "v2/css/bounty.css" %}" />
     {% if request.path == '/ios' %}
     <link rel="stylesheet" href="{% static "v2/css/toolbox.css" %}">
     <link rel="stylesheet" href="{% static "v2/css/card.css" %}">


### PR DESCRIPTION
Forgot to remove this ! Sorry 😅 

![screenshot-2018-3-29 gitcoin grow open source 1](https://user-images.githubusercontent.com/5358146/38071511-5c550b1e-333f-11e8-84bb-d8add96c9afa.jpg)


@mbeacom white still looks better :P 