### PR TITLE
Fixed Contributing Link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Check out the [CHANGELOG](./CHANGELOG.md) for details about recent changes to th
 
 Also,
 
-* want to become a contributor ? Checkout our [guidelines](./docs/CONTRIBUTING.md).
+* want to become a contributor ? Checkout our [guidelines](./CONTRIBUTING.md).
 * [check out the gitcoinco organization-wide repo](https://github.com/gitcoinco/gitcoinco).
 * check out the open issues list, especially the [discussion](https://github.com/gitcoinco/web/issues?q=is%3Aissue+is%3Aopen+label%3Adiscussion) label and [easy-pickings](https://github.com/gitcoinco/web/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy-pickings).
 


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Contributing Link in README.md doesn't work : On clicking the link provided in first bullet point (link for guidelines) under heading On Github, it takes the user to 404 Not found page.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Refers/Fixes
 Fixes: #755 