### PR TITLE
bounty: css letter spacing fix for h1..h6

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -299,6 +299,7 @@ a.btn{
 #bounty_details #issue_description h4,
 #bounty_details #issue_description h5,
 #bounty_details #issue_description h6 {
+  letter-spacing: 1px;
   font-size: 16px;
   margin-top: 15px;
   text-transform: none;


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
<img width="1440" alt="screen shot 2018-03-31 at 8 56 15 pm" src="https://user-images.githubusercontent.com/5358146/38164709-08269b1e-3526-11e8-95e2-d05d07e87520.png">

^Removing the extra letter spacing for the description section

After fix

<img width="1440" alt="screen shot 2018-03-31 at 8 59 55 pm" src="https://user-images.githubusercontent.com/5358146/38164738-8514b6ec-3526-11e8-8b36-b68ae2a4991e.png">


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
- css
