### PR TITLE
current year in copyright email section

### DIFF
--- a/app/retail/templates/emails/template.html
+++ b/app/retail/templates/emails/template.html
@@ -221,7 +221,7 @@
                     </td>
                     <td width="300" valign="middle" id="copyright">
                         <p>
-                            <span>&copy; 2017 Gitcoin Core, Inc.</span>
+                            <span>&copy; {% now "Y" %} Gitcoin Core, Inc.</span>
                         </p>
                     </td>
                 </tr>


### PR DESCRIPTION
##### Description
Emails should contain actual year in copyright section.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
emails

##### Testing
printed html to console :wink: 
##### Refers/Fixes
Fixes #765 
