### PR TITLE
filters: enable MY Projects filter only for logged in users

### DIFF
--- a/app/assets/v2/css/sidebar_search.css
+++ b/app/assets/v2/css/sidebar_search.css
@@ -16,6 +16,13 @@
   margin-left: 5px;
 }
 
+.subheading .fa-github {
+  float: right;
+  margin-right: 5px;
+  margin-top: 4px;
+  font-size: 16px;
+}
+
 .sidebar_search .options {
   font-size: 14px;
 }

--- a/app/dashboard/templates/shared/sidebar_search.html
+++ b/app/dashboard/templates/shared/sidebar_search.html
@@ -62,25 +62,35 @@
     </div>
 
     <div class="col">
-      <div class="col-12 subheading font-body accordion">MY PROJECTS</div>
-      <div class="col-12 options panel">
-        <div class="form__radio option">
-          <input name="bounty_filter" id="createdByMe" type="radio" value="createdByMe" val-ui='Created'/>
-          <label class="filter-label" for=createdByMe>Created By Me</label>
+      {% if github_handle %}
+        <div class="col-12 subheading font-body accordion">MY PROJECTS</div>
+        <div class="col-12 options panel">
+          <div class="form__radio option">
+            <input name="bounty_filter" id="createdByMe" type="radio" value="createdByMe" val-ui='Created'/>
+            <label class="filter-label" for=createdByMe>Created By Me</label>
+          </div>
+          <div class="form__radio option">
+            <input name="bounty_filter" id="startedByMe" type="radio" value="startedByMe" val-ui='Started'/>
+            <label class="filter-label" for=startedByMe>Started By Me</label>
+          </div>
+          <div class="form__radio option">
+            <input name="bounty_filter" id="FulfilledByMe" type="radio" value="fulfilledByMe" val-ui='Fulfilled'/>
+            <label class="filter-label" for=FulfilledByMe>Fulfilled By Me</label>
+          </div>
+          <div class="form__radio option">
+            <input name="bounty_filter" id="all_bounty" type="radio" value="any" checked/>
+            <label class="filter-label" for=all_bounty>All</label>
+          </div>
         </div>
-        <div class="form__radio option">
-          <input name="bounty_filter" id="startedByMe" type="radio" value="startedByMe" val-ui='Started'/>
-          <label class="filter-label" for=startedByMe>Started By Me</label>
+      {% else %}
+      <a href="{% url "github:github_auth" %}?redirect_uri={{ request.get_full_path }}"
+            onclick="dataLayer.push({'event': 'login'});">
+        <div class="col-12 subheading font-body">
+            MY PROJECTS
+            <i class="fab fa-github" style="float: right"></i>
         </div>
-        <div class="form__radio option">
-          <input name="bounty_filter" id="FulfilledByMe" type="radio" value="fulfilledByMe" val-ui='Fulfilled'/>
-          <label class="filter-label" for=FulfilledByMe>Fulfilled By Me</label>
-        </div>
-        <div class="form__radio option">
-          <input name="bounty_filter" id="all_bounty" type="radio" value="any" checked/>
-          <label class="filter-label" for=all_bounty>All</label>
-        </div>
-      </div>
+      </a>
+      {% endif %}
     </div>
 
     <div class="col">


### PR DESCRIPTION
##### Description

If the user hasn't logged in, the while `My Projects` tab is clickable with the gitcoin icon that encourages folks to login to github.
Post that , the page refreshes -> and the filters appear as usual

![x](https://user-images.githubusercontent.com/5358146/38210564-6db2f10c-36d5-11e8-9749-cb79bed79be3.gif)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css

##### Fixes
- https://github.com/gitcoinco/web/issues/769

