### PR TITLE
dashboard: Tests cleanup.

### DIFF
--- a/app/dashboard/tests/__init__.py
+++ b/app/dashboard/tests/__init__.py
@@ -1,0 +1,7 @@
+from .test_dashboard_helpers import DashboardHelpersTest
+from .test_dashboard_models import DashboardModelsTest
+from .test_dashboard_utils import DashboardUtilsTest
+from .test_notifications import DashboardNotificationsTest
+
+__all__ = ['DashboardHelpersTest', 'DashboardModelsTest',
+           'DashboardUtilsTest', 'DashboardNotificationsTest']

--- a/app/dashboard/tests/test_dashboard_helpers.py
+++ b/app/dashboard/tests/test_dashboard_helpers.py
@@ -52,11 +52,18 @@ class DashboardHelpersTest(TestCase):
         sample_url = 'https://github.com/gitcoinco/web/issues/353'
         params = {'url': sample_url}
         with requests_mock.Mocker() as m:
-            m.get('https://api.github.com/repos/gitcoinco/web/issues/353', text='{ "title":"Increase Code Coverage by 4%", "body": "This bounty will be paid out to anyone who meaningfully increases the code coverage of the repository by 4%."}')
-            m.get('https://github.com/gitcoinco/web', text='<span class="lang">hello</span><span class="lang">world</span>')
+            m.get('https://api.github.com/repos/gitcoinco/web/issues/353',
+                  text='{ "title": "Increase Code Coverage by 4%",'
+                       '"body" : "This bounty will be paid out to anyone '
+                                 'who meaningfully increases the code coverage '
+                                 'of the repository by 4%."}')
+            m.get('https://github.com/gitcoinco/web',
+                  text='<span class="lang">hello</span><span class="lang">world</span>')
             request = self.factory.get('/sync/get_issue_details', params)
             response = json.loads(issue_details(request).content)
-            assert response['description'] == "This bounty will be paid out to anyone who meaningfully increases the code coverage of the repository by 4%."
+            assert response['description'] == "This bounty will be paid out to anyone who " \
+                                              "meaningfully increases the code coverage of " \
+                                              "the repository by 4%."
             assert response['keywords'] == ["web", "gitcoinco", "hello", "world"]
             assert response['title'] == "Increase Code Coverage by 4%"
 

--- a/app/dashboard/tests/test_dashboard_models.py
+++ b/app/dashboard/tests/test_dashboard_models.py
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 from datetime import date, datetime, timedelta
 
+import pytz
 from dashboard.models import Bounty, BountyFulfillment, Interest, Profile, Tip
 from economy.models import ConversionRate
 from test_plus.test import TestCase
@@ -37,7 +38,8 @@ class DashboardModelsTest(TestCase):
             to_currency='USDT',
         )
 
-    def test_bounty(self):
+    @staticmethod
+    def test_bounty():
         """Test the dashboard Bounty model."""
         fulfiller_profile = Profile.objects.create(
             data={},
@@ -48,14 +50,14 @@ class DashboardModelsTest(TestCase):
             title='foo',
             value_in_token=3,
             token_name='ETH',
-            web3_created=datetime(2008, 10, 31),
+            web3_created=datetime(2008, 10, 31, tzinfo=pytz.UTC),
             github_url='https://github.com/gitcoinco/web/issues/11',
             token_address='0x0',
             issue_description='hello world',
             bounty_owner_github_username='flintstone',
             is_open=False,
             accepted=True,
-            expires_date=datetime(2008, 11, 30),
+            expires_date=datetime(2008, 11, 30, tzinfo=pytz.UTC),
             idx_project_length=5,
             project_length='Months',
             bounty_type='Feature',
@@ -70,7 +72,7 @@ class DashboardModelsTest(TestCase):
             bounty=bounty,
             profile=fulfiller_profile,
         )
-        assert str(bounty) == 'foo 3 ETH 2008-10-31 00:00:00'
+        assert str(bounty) == 'foo 3 ETH 2008-10-31 00:00:00+00:00'
         assert bounty.url == '/issue/gitcoinco/web/11'
         assert bounty.title_or_desc == 'foo'
         assert bounty.issue_description_text == 'hello world'
@@ -90,7 +92,8 @@ class DashboardModelsTest(TestCase):
         assert bounty_fulfillment.profile.handle == 'fred'
         assert bounty_fulfillment.bounty.title == 'foo'
 
-    def test_tip(self):
+    @staticmethod
+    def test_tip():
         """Test the dashboard Tip model."""
         tip = Tip(
             emails=['foo@bar.com'],
@@ -107,7 +110,8 @@ class DashboardModelsTest(TestCase):
         assert tip.value_in_usdt == 14
         assert tip.status == 'PENDING'
 
-    def test_interest(self):
+    @staticmethod
+    def test_interest():
         """Test the dashboard Interest model."""
         profile = Profile(
             handle='foo',
@@ -117,12 +121,13 @@ class DashboardModelsTest(TestCase):
         )
         assert str(interest) == 'foo'
 
-    def test_profile(self):
+    @staticmethod
+    def test_profile():
         """Test the dashboard Profile model."""
         bounty = Bounty.objects.create(
             github_url='https://github.com/gitcoinco/web',
-            web3_created=date.today(),
-            expires_date=date.today() + timedelta(days=1),
+            web3_created=datetime.now(tz=pytz.UTC),
+            expires_date=datetime.now(tz=pytz.UTC) + timedelta(days=1),
             is_open=True,
             raw_data={},
             current_bounty=True,
@@ -131,7 +136,7 @@ class DashboardModelsTest(TestCase):
         tip = Tip.objects.create(
             emails=['foo@bar.com'],
             github_url='https://github.com/gitcoinco/web',
-            expires_date=date.today() + timedelta(days=1),
+            expires_date=datetime.now(tz=pytz.UTC) + timedelta(days=1),
         )
         profile = Profile(
             handle='gitcoinco',

--- a/app/dashboard/tests/test_dashboard_utils.py
+++ b/app/dashboard/tests/test_dashboard_utils.py
@@ -23,10 +23,11 @@ from web3.main import Web3
 from web3.providers.rpc import HTTPProvider
 
 
-class DashboardUtilsTestCase(TestCase):
+class DashboardUtilsTest(TestCase):
     """Define tests for dashboard utils."""
 
-    def test_get_web3(self):
+    @staticmethod
+    def test_get_web3():
         """Test the dashboard utility get_web3."""
         networks = ['mainnet', 'rinkeby', 'ropsten']
         for network in networks:

--- a/app/dashboard/tests/test_notifications.py
+++ b/app/dashboard/tests/test_notifications.py
@@ -25,7 +25,7 @@ from pytz import UTC
 from test_plus.test import TestCase
 
 
-class DashboardNotificationsTestCase(TestCase):
+class DashboardNotificationsTest(TestCase):
     """Define tests for dashboard notifications."""
 
     def setUp(self):


### PR DESCRIPTION
##### Description
* fixed timezone warnings
* added @staticmethod decorators where needed
* introduced consistent test naming scheme, all classes deriving from TestCase end with Test
* PEP8 line too long warnings fixed by splitting to multiline strings
* added __init__.py to let pytest find all tests when running `docker-compose exec web pytest app/dashboard/tests/*`

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
Dashboard tests.

##### Testing
Affects only dashboard tests.

##### Refers/Fixes
Refs: #607
