### PR TITLE
docker shell fixes

### DIFF
--- a/bin/docker-command.bash
+++ b/bin/docker-command.bash
@@ -12,8 +12,14 @@ if [ ! -z "${INSTALL_REQS}" ]; then
 fi
 
 # Provision the Django test environment.
-python manage.py createcachetable
-python manage.py collectstatic --noinput -i other &
-python manage.py migrate
-python manage.py get_prices
-python manage.py runserver 0.0.0.0:8000
+CONTAINER_NAME=$(cat /proc/self/cgroup | grep -o  -e "docker-.*.scope" | head -n 1 | sed "s/docker-\(.*\).scope/\\1/")
+if [ "$CONTAINER_NAME" == "shell" ]; then
+    python manage.py shell
+else
+    python manage.py createcachetable
+    python manage.py collectstatic --noinput -i other &
+    python manage.py migrate
+    python manage.py get_prices
+    python manage.py runserver 0.0.0.0:8000
+fi
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,22 @@ services:
     depends_on:
       - db
     stdin_open: true
+  shell:
+    restart: unless-stopped
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/code/app
+    env_file:
+      - app/app/local.env
+    build: .
+    volumes:
+      - .:/code
+    ports:
+      - "7999:7999"
+    depends_on:
+      - db
+    stdin_open: true
 
   testrpc:
     image: trufflesuite/ganache-cli

--- a/docs/RUNNING_LOCALLY_DOCKER.md
+++ b/docs/RUNNING_LOCALLY_DOCKER.md
@@ -139,5 +139,22 @@ Most people just start the stack normally, but run web outside of the standard f
 
 Details [here](https://github.com/docker/compose/issues/4677)
 
+#### bash shell
+
+`Q: How can I get a bash shell?`
+
+```
+docker-compose exec shell /bin/bash
+```
+
+
+#### bash shell
+
+`Q: How can I get a django management shell?`
+
+```
+docker-compose exec shell python3 app/manage.py shell
+```
+
 
 


### PR DESCRIPTION
This PR fixes a problem where if I 

`docker-compose up -d` then `docker-compose stop web; docker-compose run --service-ports web` 

as described [in the docs](https://github.com/gitcoinco/web/blob/master/docs/RUNNING_LOCALLY_DOCKER.md#ipdb)

i can no longer `exec` on the docker intance

```docker-compose exec web /bin/bash```

returns

```ERROR: No container found for web_1```

this is what `docker-compose ps` returns

```
Name                   Command                State             Ports
----------------------------------------------------------------------------------
web_db_1        docker-entrypoint.sh postgres    Up         0.0.0.0:5432->5432/tcp
web_node_1      bin/docker-node.sh               Exit 1
web_pgweb_1     /usr/bin/pgweb --bind=0.0. ...   Up         0.0.0.0:8081->8081/tcp
web_testrpc_1   node ./build/cli.node.js - ...   Up         0.0.0.0:8545->8545/tcp
web_web_1       /usr/local/bin/dumb-init - ...   Exit 143
web_web_run_1   /usr/local/bin/dumb-init - ...   Up         0.0.0.0:8000->8000/tcp

```

but none of those container names can be passed into docker-compose exec

Id expecteed that the ‘Up’ container names ( like web_web_run_1 ) is what i shoudl be able to do

# Workaround

This adds another container, called `shell` which is independent of the web server and can be connected to like so:

```docker-compose exec shell /bin/bash```

