### PR TITLE
Add ipdb and django shell access to docker setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 
 .PHONY: help
 
+PROJECT_DIR := $(subst -,, $(shell pwd | xargs basename))
+CONTAINER_NAME := $(addsuffix _web_1, $(PROJECT_DIR))
+WEB_CONTAINER_ID := $(shell docker inspect --format="{{.Id}}" $(CONTAINER_NAME))
+
 compress-images: ## Compress and optimize images throughout the repository. Requires optipng, svgo, and jpeg-recompress.
 	@./scripts/compress_images.bash
 
@@ -45,6 +49,13 @@ compilemessages: ## Execute compilemessages for translations on the web containe
 
 makemessages: ## Execute makemessages for translations on the web container.
 	@docker-compose exec web python3 app/manage.py makemessages
+
+get_ipdb_shell: ## Drop into the active Django shell for inspection via ipdb.
+	@echo "Attaching to container: ($(CONTAINER_NAME)) - ($(WEB_CONTAINER_ID))"
+	@docker attach $(WEB_CONTAINER_ID)
+
+get_django_shell: ## Open a standard Django shell.
+	@docker-compose exec web python3 app/manage.py shell
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     depends_on:
       - db
     stdin_open: true
+    tty: true
 
   testrpc:
     image: trufflesuite/ganache-cli

--- a/docs/RUNNING_LOCALLY_DOCKER.md
+++ b/docs/RUNNING_LOCALLY_DOCKER.md
@@ -140,3 +140,9 @@ Add `import ipdb;ipdb.set_trace()` to the method you want to inspect, you then r
 `Q: How can I access the Django shell, similar to: python manage.py shell ?`
 
 Simply run: `make get_django_shell` or `docker-compose exec web python app/manage.py shell`
+
+#### Access BASH
+
+`Q: I want to inspect or manipulate the container via bash.  How can I access the root shell of the container?`
+
+Run: `docker-compose exec web bash`

--- a/docs/RUNNING_LOCALLY_DOCKER.md
+++ b/docs/RUNNING_LOCALLY_DOCKER.md
@@ -133,11 +133,10 @@ GITHUB_CLIENT_SECRET=<COPY_FROM_GITHUB>
 
 `Q: what's the best way to import ipdb; ipdb.set_trace() a HTTP request via docker?`
 
-You need to run the web container with tty enabled and inspect the interactive shell.
+Add `import ipdb;ipdb.set_trace()` to the method you want to inspect, you then run: `make get_ipdb_shell` to drop into the active shell for inspection.
 
-Most people just start the stack normally, but run web outside of the standard flow. For instance, you'd want to run your service containers via something like `docker-compose up -d` then `docker-compose stop web; docker-compose run --service-ports web`
+#### Access Django Shell
 
-Details [here](https://github.com/docker/compose/issues/4677)
+`Q: How can I access the Django shell, similar to: python manage.py shell ?`
 
-
-
+Simply run: `make get_django_shell` or `docker-compose exec web python app/manage.py shell`


### PR DESCRIPTION
##### Description

The goal of this PR is to introduce entrypoints for `ipdb` and the django shell via `make` commands.
The method used in this PR allows us to inspect the ipdb shell and the django shells without an additional container in our compose stack.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Testing
Tested with multiple `web` repo directories to ensure the parent directory name (first part of compose image name) is properly detected.

##### Refers/Fixes
Ref #861 - This PR aims to handle the same case as this PR.
