### PR TITLE
view on github button on bounties

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -120,10 +120,10 @@ var callbacks = {
     val = val.replace(/script/ig, 'scr_i_pt');
     var ui_body = val;
 
-    if(ui_body.length > 300){
-      ui_body = ui_body.substring(0,400) + "... <BR><BR><BR>";
-      ui_body = ui_body + "<a class='button button--primary' href='"+result['github_url']+"'><span class='font-caption'>View issue on github</span></a>";
-      ui_body = ui_body + "<br><br>";
+    if (ui_body.length > 300) {
+      ui_body = ui_body.substring(0, 400) + '... <BR><BR><BR>';
+      ui_body = ui_body + "<a class='button button--primary' href='" + result['github_url'] + "'><span class='font-caption'>View issue on github</span></a>";
+      ui_body = ui_body + '<br><br>';
     }
 
     ui_body = converter.makeHtml(ui_body);

--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -120,6 +120,12 @@ var callbacks = {
     val = val.replace(/script/ig, 'scr_i_pt');
     var ui_body = val;
 
+    if(ui_body.length > 300){
+      ui_body = ui_body.substring(0,400) + "... <BR><BR><BR>";
+      ui_body = ui_body + "<a class='button button--primary' href='"+result['github_url']+"'><span class='font-caption'>View issue on github</span></a>";
+      ui_body = ui_body + "<br><br>";
+    }
+
     ui_body = converter.makeHtml(ui_body);
 
     return [ 'issue_description', ui_body ];


### PR DESCRIPTION
##### Description

we've gotten some customer feedback that we are not doing a great job of showing issue scope and people would rather read it on github.

i think thats fair, and we shouldn't pretend to be the *collaboration* layer for OSS.  we are the incentivization layer and we good with that.

this PR takes the bounty detail page and removes any issue desc after 300 chars and instead shows a 'view on github' button.

[screenshot](http://bits.owocki.com/2d2i0d2e3A2U/Screen%20Shot%202018-04-12%20at%209.40.01%20PM.png)


##### Checklist

- x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
UI!


##### Testing
i done tested it

##### Refers/Fixes
self