### PR TITLE
new nav for auth/login for site

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -29,6 +29,13 @@ span {
   border-radius: 2px;
 }
 
+.nav-link.login img {
+  width: 35px;
+  height: 35px;
+  filter: invert(100%);
+  margin-right: 10px;
+}
+
 .navbar-nav .nav-link:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }

--- a/app/dashboard/templates/shared/nav_auth.html
+++ b/app/dashboard/templates/shared/nav_auth.html
@@ -62,11 +62,11 @@
       </a>
     </div>
   </div>
-{% else %}
-<a class="nav-link" href="{% url 'social:begin' 'github' %}?next={{ request.get_full_path }}"
-  onclick="dataLayer.push({'event': 'login'});">
-  {% trans "Login" %}
-</a>
-{% endif %}
 <img class="nav_avatar" width=50 height=50
   src="{% url "avatar" %}?repo=https://github.com/{% if user and user.username %}{{ user.username }}{% else %}Self{% endif %}">
+{% else %}
+<a class="nav-link login" href="{% url 'social:begin' 'github' %}?next={{ request.get_full_path }}"
+  onclick="dataLayer.push({'event': 'login'});">
+  <img src="{% static "v2/images/social/github.png" %} ">{% trans "Login" %}
+</a>
+{% endif %}

--- a/app/retail/templates/shared/nav.html
+++ b/app/retail/templates/shared/nav.html
@@ -42,10 +42,6 @@
       <a class="nav-link{% if active == 'help' %} selected{% endif %}" href="{% url "help" %}">{% trans "Help" %}</a>
     </nav>
     <img class="mr-5" src="{% static "v2/images/spaceship.png" %}" width="52" height="45" />
-    {% if active|is_in_list:'about,slack,home,help,mission' %}
-      <a class="btn btn-outline-info pl-4 pr-4 pulseClick" role="button" href="{% url 'get_gitcoin' %}">{% trans "Get Started" %} ⚡️</a>
-    {% else %}
       {% include 'shared/nav_auth.html' with source='authed' %}
-    {% endif %}
   </div>
 </nav>


### PR DESCRIPTION
##### Description

refreshes the nav of the site

* landing/about/etc pages now show login option instead of the 'get gitcoin' button
* login button shows github logo instead of blockie [screenshot -- left is logged out, right is logged in](http://bits.owocki.com/221E2M2B0y09)

why

* increases conversion rate by showing one clear action instead of the insane get gitcoin modal
* unifies nav across the site

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
ui

##### Testing
tested in a bunch of resolutions

##### Refers/Fixes
self