### PR TITLE
Github comments when user is warned/removed (in addition to the emails that are sent when this happens)

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -616,13 +616,9 @@ def maybe_post_on_craigslist(bounty):
     return False
 
 
-def maybe_notify_bounty_user_removed_to_slack(bounty, username, last_heard_from_user_days=None):
-
-    if not settings.SLACK_TOKEN:
-        return False
-    if bounty.get_natural_value() < 0.0001:
-        return False
-    if bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK:
+def maybe_notify_bounty_user_removed_to_slack(bounty, username):
+    if not settings.SLACK_TOKEN or bounty.get_natural_value() < 0.0001 or (
+       bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
     msg = f"@{username} has been removed from {bounty.github_url} due to inactivity on the github thread."
@@ -647,7 +643,7 @@ def maybe_notify_user_removed_github(bounty, username, last_heard_from_user_days
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
 
 
-def maybe_warn_user_removed_github(bounty, username, last_heard_from_user_days=None):
+def maybe_warn_user_removed_github(bounty, username):
     if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
@@ -658,12 +654,8 @@ def maybe_warn_user_removed_github(bounty, username, last_heard_from_user_days=N
 
 
 def maybe_notify_bounty_user_warned_removed_to_slack(bounty, username, last_heard_from_user_days=None):
-
-    if not settings.SLACK_TOKEN:
-        return False
-    if bounty.get_natural_value() < 0.0001:
-        return False
-    if bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK:
+    if not settings.SLACK_TOKEN or bounty.get_natural_value() < 0.0001 or (
+       bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
     msg = f"@{username} has warned about inactivity ({last_heard_from_user_days} days) on {bounty.github_url}"

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -416,6 +416,7 @@ def amount_usdt_open_work():
     bounties = Bounty.objects.filter(network='mainnet', current_bounty=True, idx_status__in=['open', 'submitted'])
     return round(sum([b.value_in_usdt_now for b in bounties if b.value_in_usdt_now]), 2)
 
+
 def maybe_market_tip_to_github(tip):
     """Post a Github comment for the specified Tip.
 
@@ -613,3 +614,24 @@ def maybe_post_on_craigslist(bounty):
                     # in case of invalid links
                     return False
     return False
+
+
+def maybe_notify_user_removed_github(bounty, username):
+    if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
+       bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
+        return False
+
+    msg = f"@{username} has been removed from this issue due to inactivity on the github thread.  @{username} if you believe this was done in error, please <a href={bounty.url}>go to the bounty</a> and click 'start work' again."
+
+    post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
+
+
+def maybe_warn_user_removed_github(bounty, username):
+    if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
+       bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
+        return False
+
+    msg = f"@{username} are you still working on this issue?"
+
+    post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
+

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -231,7 +231,7 @@ def maybe_market_tip_to_slack(tip, event_name):
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)
-        channel = 'bounties'
+        channel = 'notif-gitcoin'
         sc.api_call("chat.postMessage", channel=channel, text=msg)
     except Exception as e:
         print(e)
@@ -629,7 +629,7 @@ def maybe_notify_bounty_user_removed_to_slack(bounty, username, last_heard_from_
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)
-        channel = 'bounties'
+        channel = 'notif-gitcoin'
         sc.api_call("chat.postMessage", channel=channel, text=msg)
     except Exception as e:
         print(e)
@@ -670,7 +670,7 @@ def maybe_notify_bounty_user_warned_removed_to_slack(bounty, username, last_hear
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)
-        channel = 'bounties'
+        channel = 'notif-gitcoin'
         sc.api_call("chat.postMessage", channel=channel, text=msg)
     except Exception as e:
         print(e)

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -634,4 +634,3 @@ def maybe_warn_user_removed_github(bounty, username):
     msg = f"@{username} are you still working on this issue?"
 
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
-

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from dashboard.models import Bounty, Interest
 from github.utils import get_interested_actions
 from marketing.mails import bounty_startwork_expire_warning, bounty_startwork_expired
+from dashboard.notifications import maybe_notify_user_removed_github, maybe_warn_user_removed_github
 
 warnings.filterwarnings("ignore", category=DeprecationWarning) 
 logging.getLogger("requests").setLevel(logging.WARNING)
@@ -97,11 +98,17 @@ class Command(BaseCommand):
 
                         if should_delete_interest:
                             print(f'executing should_delete_interest for {interest.profile} / {bounty.github_url} ')
+                            # commenting on the GH issue
+                            maybe_notify_user_removed_github(bounty, interest.profile.handle)
+                            # send email
                             bounty_startwork_expired(interest.profile.email, bounty, interest, last_heard_from_user_days)
                             interest.delete()
 
                         elif should_warn_user:
                             print(f'executing should_warn_user for {interest.profile} / {bounty.github_url} ')
+                            # commenting on the GH issue
+                            maybe_warn_user_removed_github(bounty, interest.profile.handle)
+                            # send email
                             bounty_startwork_expire_warning(interest.profile.email, bounty, interest, last_heard_from_user_days)
 
                     except Exception as e:

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -25,14 +25,14 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from dashboard.models import Bounty, Interest
-from dashboard.notifications import maybe_notify_user_removed_github, maybe_warn_user_removed_github
-from github.utils import get_interested_actions
-from marketing.mails import (
-    bounty_startwork_expire_warning, bounty_startwork_expired, maybe_notify_bounty_user_removed_to_slack,
-    maybe_notify_bounty_user_warned_removed_to_slack,
+from dashboard.notifications import (
+    maybe_notify_bounty_user_removed_to_slack, maybe_notify_bounty_user_warned_removed_to_slack,
+    maybe_notify_user_removed_github, maybe_warn_user_removed_github,
 )
+from github.utils import get_interested_actions
+from marketing.mails import bounty_startwork_expire_warning, bounty_startwork_expired
 
-warnings.filterwarnings("ignore", category=DeprecationWarning) 
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
@@ -104,7 +104,7 @@ class Command(BaseCommand):
                             # commenting on the GH issue
                             maybe_notify_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
                             # commenting in slack
-                            maybe_notify_bounty_user_removed_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
+                            maybe_notify_bounty_user_removed_to_slack(bounty, interest.profile.handle)
                             # send email
                             bounty_startwork_expired(interest.profile.email, bounty, interest, last_heard_from_user_days)
                             interest.delete()
@@ -112,7 +112,7 @@ class Command(BaseCommand):
                         elif should_warn_user:
                             print(f'executing should_warn_user for {interest.profile} / {bounty.github_url} ')
                             # commenting on the GH issue
-                            maybe_warn_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
+                            maybe_warn_user_removed_github(bounty, interest.profile.handle)
                             # commenting in slack
                             maybe_notify_bounty_user_warned_removed_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
                             # send email

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -25,9 +25,9 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from dashboard.models import Bounty, Interest
+from dashboard.notifications import maybe_notify_user_removed_github, maybe_warn_user_removed_github
 from github.utils import get_interested_actions
 from marketing.mails import bounty_startwork_expire_warning, bounty_startwork_expired
-from dashboard.notifications import maybe_notify_user_removed_github, maybe_warn_user_removed_github
 
 warnings.filterwarnings("ignore", category=DeprecationWarning) 
 logging.getLogger("requests").setLevel(logging.WARNING)


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Github comments from gitcoinbot when a user is removed from the issue.

[example issue](https://github.com/gitcoinco/web/issues/540)

This gives context to anyone looking back at the thread to try and figure out what is going on with the issue that the github bot has kicked them off of the issue.

In addition, this PR will enable notifications to slack so that we can deal with it internally

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
bot

##### Testing
tested

##### Refers/Fixes
self