### PR TITLE
Add admin link to navbar for staff and switch settings icon

### DIFF
--- a/app/dashboard/templates/shared/nav_auth.html
+++ b/app/dashboard/templates/shared/nav_auth.html
@@ -43,7 +43,7 @@
         {% trans "View Profile" %}
       </a>
       <a class="dropdown-item" href="{% url "email_settings" email_key %}">
-        <i class="far fa-envelope"></i>
+        <i class="fas fa-cog"></i>
         {% trans "Manage Settings" %}
       </a>
       {% if unclaimed_tips %}
@@ -54,6 +54,13 @@
             {% blocktrans %}Claim ${{ tip.value_in_usdt_now }} Tip {% endblocktrans %}
           </a>
         {% endfor %}
+      {% endif %}
+      {% if user.is_staff %}
+      <div class="dropdown-divider"></div>
+      <a class="dropdown-item" href="{% url "admin:index" %}">
+        <i class="fas fa-user-secret"></i>
+        {% trans "Administration" %}
+      </a>
       {% endif %}
       <div class="dropdown-divider"></div>
       <a class="dropdown-item" href="{% url "logout" %}?next={{ request.get_full_path }}">


### PR DESCRIPTION
##### Description

The goal of this PR is to introduce a navbar option for staff members that links to the django admin for easy access.  Additionally, this PR modifies the font awesome icon used for `Manage Settings` from `email` to `cog` to align with the changes from `Manage Email Settings` to `Manage Settings`

###### Without staff priv:

<img width="234" alt="screenshot 2018-04-16 13 54 49" src="https://user-images.githubusercontent.com/7315957/38826566-32d6447c-417e-11e8-95ca-de84a5b3ffef.png">

###### With staff priv:

<img width="227" alt="screenshot 2018-04-16 13 59 53" src="https://user-images.githubusercontent.com/7315957/38826651-75a2854a-417e-11e8-82aa-3a24453823d3.png">

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
navbar, ui

##### Testing
Tested locally as a user with and without `user.is_staff == True`
