### PR TITLE
make expiration status less inclusive

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -333,8 +333,6 @@ class Bounty(SuperModel):
         and therefore cannot ever be claimed again"""
         return self.past_expiration_date and not self.can_submit_after_expiration_date
 
-
-
     @property
     def status(self):
         """Determine the status of the Bounty.

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -331,7 +331,7 @@ class Bounty(SuperModel):
     def past_hard_expiration_date(self):
         """Return true IFF issue is past smart contract expiration date
         and therefore cannot ever be claimed again"""
-        return self.past_expiration_date and self.can_submit_after_expiration_date
+        return self.past_expiration_date and not self.can_submit_after_expiration_date
 
 
 

--- a/app/dashboard/tests/test_dashboard_models.py
+++ b/app/dashboard/tests/test_dashboard_models.py
@@ -94,8 +94,6 @@ class DashboardModelsTest(TestCase):
     @staticmethod
     def test_bounty_expired():
         """Test the status and details of an expired bounty."""
-        fulfiller_profile = Profile.objects.create(
-            data={}, handle='fred', email='fred@localhost')
         bounty = Bounty.objects.create(
             title='foo',
             value_in_token=3,

--- a/app/dashboard/tests/test_dashboard_models.py
+++ b/app/dashboard/tests/test_dashboard_models.py
@@ -81,7 +81,7 @@ class DashboardModelsTest(TestCase):
         assert bounty.is_hunter('flintstone') is False
         assert bounty.is_funder('fred') is False
         assert bounty.is_funder('flintstone') is True
-        assert bounty.status == 'expired'
+        assert bounty.status == 'done'
         assert bounty.value_true == 3e-18
         assert bounty.value_in_eth == 3
         assert bounty.value_in_usdt_now == 0
@@ -90,6 +90,31 @@ class DashboardModelsTest(TestCase):
         assert bounty.get_github_api_url() == 'https://api.github.com/repos/gitcoinco/web/issues/11'
         assert bounty_fulfillment.profile.handle == 'fred'
         assert bounty_fulfillment.bounty.title == 'foo'
+
+    @staticmethod
+    def test_bounty_expired():
+        """Test the status and details of an expired bounty."""
+        fulfiller_profile = Profile.objects.create(
+            data={}, handle='fred', email='fred@localhost')
+        bounty = Bounty.objects.create(
+            title='foo',
+            value_in_token=3,
+            token_name='ETH',
+            web3_created=datetime(2008, 10, 31, tzinfo=pytz.UTC),
+            github_url='https://github.com/gitcoinco/web/issues/12',
+            token_address='0x0',
+            issue_description='hello world',
+            bounty_owner_github_username='flintstone',
+            is_open=False,
+            accepted=False,
+            expires_date=datetime(2008, 11, 30, tzinfo=pytz.UTC),
+            idx_project_length=5,
+            project_length='Months',
+            bounty_type='Feature',
+            experience_level='Intermediate',
+            raw_data={},
+        )
+        assert bounty.status == 'expired'
 
     @staticmethod
     def test_tip():


### PR DESCRIPTION
##### Description
This PR makes the expiration status less inclusive.

Before, if a bounty was past its expiration date and had no fulfillments it would be marked as expired

Now, after this change, the bounty will only be status expired if its past its expiration date if
* it was one of the bounties that existed before https://github.com/Bounties-Network/StandardBounties/issues/25
* and it's past its expiration date

otherwise, it will revert to one of the following statuses: open, started, submitted, done.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
db

##### Testing
tested it

##### Refers/Fixes
https://gitcoincommunity.slack.com/archives/G9ZRKFS68/p1524066432000794

