### PR TITLE
bounty: hide timeline on cancelled bounties

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -212,7 +212,7 @@ var callbacks = {
       } else {
         $('#timer').hide();
       }
-    } else if (result['status'] === 'done') {
+    } else if (result['status'] === 'done' || result['status'] === 'cancelled') {
       $('#timer').hide();
     } else {
       response.shift();


### PR DESCRIPTION

##### Description

As of now, time left section is displayed canceled bounties which seems irrelevant.
Example: https://gitcoin.co/issue/thelostone-mc/web/411

###### Fix  
<img width="1440" alt="screen shot 2018-04-19 at 10 43 05 am" src="https://user-images.githubusercontent.com/5358146/38972509-9a910cae-43be-11e8-8eb8-e0b33795af0f.png">


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- js 
