### PR TITLE
verboseness of gitcoinbot reminders

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -632,22 +632,37 @@ def maybe_notify_bounty_user_removed_to_slack(bounty, username):
     return True
 
 
+#todo: DRY with expiration_start_work
+num_days_back_to_warn = 3
+num_days_back_to_delete_interest = 10
+
+
 def maybe_notify_user_removed_github(bounty, username, last_heard_from_user_days=None):
     if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
-    msg = f"@{username} has been removed from this issue due to inactivity ({last_heard_from_user_days} days) on the github thread.  @{username} if you believe this was done in error, please <a href={bounty.url}>go to the bounty</a> and click 'start work' again."
+    msg = f"""@{username} has been removed from this issue due to inactivity ({last_heard_from_user_days} days) on the github thread.  @{username} if you believe this was done in error, please <a href={bounty.url}>go to the bounty</a> and click 'start work' again.
+* [x] warning 1 ({num_days_back_to_warn} days)
+* [x] warning 2 ({num_days_back_to_warn * 2} days)
+* [x] auto removal ({num_days_back_to_delete_interest} days)
+"""
 
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
 
 
-def maybe_warn_user_removed_github(bounty, username):
+def maybe_warn_user_removed_github(bounty, username, last_heard_from_user_days):
     if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
-    msg = f"@{username} are you still working on this issue?"
+    first_warning = 'x'
+    second_warning = 'x' if last_heard_from_user_days > num_days_back_to_warn else ''
+    msg = f"""@{username} are you still working on this issue?
+* [{first_warning}] warning 1 ({num_days_back_to_warn} days)
+* [{second_warning}] warning 2 ({num_days_back_to_warn * 2} days)
+* [x] auto removal ({num_days_back_to_delete_interest} days)
+"""
 
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
 

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -642,6 +642,9 @@ def maybe_notify_user_removed_github(bounty, username, last_heard_from_user_days
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
+    if not last_heard_from_user_days:
+        last_heard_from_user_days = num_days_back_to_delete_interest
+
     msg = f"""@{username} has been removed from this issue due to inactivity ({last_heard_from_user_days} days) on the github thread.  @{username} if you believe this was done in error, please <a href={bounty.url}>go to the bounty</a> and click 'start work' again.
 * [x] warning 1 ({num_days_back_to_warn} days)
 * [x] warning 2 ({num_days_back_to_warn * 2} days)

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -46,6 +46,7 @@ class Command(BaseCommand):
             print('not running start work expiration because DEBUG is on')
             return
 
+        #todo: DRY with dashboard/notifications.py
         num_days_back_to_warn = 3
         num_days_back_to_delete_interest = 10
 
@@ -78,6 +79,7 @@ class Command(BaseCommand):
                         if not actions:
                             should_warn_user = True
                             should_delete_interest = False
+                            last_heard_from_user_days = (datetime.now() - interest.created.replace(tzinfo=None)).days
                             print(" - no actions")
                         else:
                             # example format: 2018-01-26T17:56:31Z'
@@ -102,7 +104,7 @@ class Command(BaseCommand):
                         if should_delete_interest:
                             print(f'executing should_delete_interest for {interest.profile} / {bounty.github_url} ')
                             # commenting on the GH issue
-                            maybe_notify_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
+                            maybe_notify_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days, last_heard_from_user_days)
                             # commenting in slack
                             maybe_notify_bounty_user_removed_to_slack(bounty, interest.profile.handle)
                             # send email
@@ -112,7 +114,7 @@ class Command(BaseCommand):
                         elif should_warn_user:
                             print(f'executing should_warn_user for {interest.profile} / {bounty.github_url} ')
                             # commenting on the GH issue
-                            maybe_warn_user_removed_github(bounty, interest.profile.handle)
+                            maybe_warn_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
                             # commenting in slack
                             maybe_notify_bounty_user_warned_removed_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
                             # send email

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
+import pytz
 from dashboard.models import Bounty, Interest
 from dashboard.notifications import (
     maybe_notify_bounty_user_removed_to_slack, maybe_notify_bounty_user_warned_removed_to_slack,
@@ -79,20 +80,20 @@ class Command(BaseCommand):
                         if not actions:
                             should_warn_user = True
                             should_delete_interest = False
-                            last_heard_from_user_days = (datetime.now() - interest.created.replace(tzinfo=None)).days
+                            last_heard_from_user_days = (timezone.now() - interest.created).days
                             print(" - no actions")
                         else:
                             # example format: 2018-01-26T17:56:31Z'
                             action_times = [datetime.strptime(action['created_at'], '%Y-%m-%dT%H:%M:%SZ') for action in actions if action.get('created_at')]
-                            last_action_by_user = max(action_times)
+                            last_action_by_user = max(action_times).replace(tzinfo=pytz.UTC)
 
                             # if user hasn't commented since they expressed interest, handled this condition
                             # per https://github.com/gitcoinco/web/issues/462#issuecomment-368384384
-                            if last_action_by_user < interest.created.replace(tzinfo=None):
-                                last_action_by_user = interest.created.replace(tzinfo=None)
+                            if last_action_by_user.replace() < interest.created:
+                                last_action_by_user = interest.created
 
                             # some small calcs
-                            delta_now_vs_last_action = datetime.now() - last_action_by_user
+                            delta_now_vs_last_action = timezone.now() - last_action_by_user
                             last_heard_from_user_days = delta_now_vs_last_action.days
 
                             # decide action params


### PR DESCRIPTION
adds the following copy to gitcoin bot warnings about removal for non-action on an issue:

* [x] warning 1 (3 days)
* [x] warning 2 (6 days)
* [x] auto removal (10 days)
