### PR TITLE
Modify setup_lang to use User

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1062,7 +1062,7 @@ class Profile(SuperModel):
         return access_token
 
     def get_profile_preferred_language(self):
-        return settings.LANGUAGE_CODE if self.pref_lang_code is None else self.pref_lang_code
+        return settings.LANGUAGE_CODE if not self.pref_lang_code else self.pref_lang_code
 
 @receiver(user_logged_in)
 def post_login(sender, request, user, **kwargs):
@@ -1268,7 +1268,7 @@ class ToolVote(models.Model):
     value = models.IntegerField(default=0)
 
     @property
-    def tool(self): 
+    def tool(self):
         try:
             return Tool.objects.filter(votes__in=[self.pk]).first()
         except:

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -390,9 +390,12 @@ def bounty_uninterested(to_email, bounty, interest):
 
 def setup_lang(to_email):
     try:
-        from dashboard.models import Profile
-        profile = Profile.objects.filter(email=to_email).first()
-        preferred_language = profile.get_profile_preferred_language()
+        from django.contrib.auth.models import User
+        user = User.objects.select_related('profile').filter(email=to_email).first()
+        if user and hasattr(user, 'profile'):
+            preferred_language = user.profile.get_profile_preferred_language()
+        else:
+            preferred_language = settings.LANGUAGE_CODE
         translation.activate(preferred_language)
-    except Profile.DoesNotExist:
+    except User.DoesNotExist:
         print("Could not determine recipient preferred email, using default.")

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -389,13 +389,22 @@ def bounty_uninterested(to_email, bounty, interest):
 
 
 def setup_lang(to_email):
+    """Activate the User's language preferences based on their email address.
+
+    Args:
+        to_email (str): The email address to lookup language preferences for.
+
+    """
+    from django.contrib.auth.models import User
+    user = None
+
     try:
-        from django.contrib.auth.models import User
+        user = User.objects.select_related('profile').get(email=to_email)
+    except User.MultipleObjectsReturned:
         user = User.objects.select_related('profile').filter(email=to_email).first()
-        if user and hasattr(user, 'profile'):
-            preferred_language = user.profile.get_profile_preferred_language()
-        else:
-            preferred_language = settings.LANGUAGE_CODE
-        translation.activate(preferred_language)
     except User.DoesNotExist:
         print("Could not determine recipient preferred email, using default.")
+
+    if user and hasattr(user, 'profile'):
+        preferred_language = user.profile.get_profile_preferred_language()
+        translation.activate(preferred_language)

--- a/app/marketing/tests/test_mails.py
+++ b/app/marketing/tests/test_mails.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Handle marketing mail related tests.
+
+Copyright (C) 2018 Gitcoin Core
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from dashboard.models import Profile
+from marketing.mails import setup_lang
+from test_plus.test import TestCase
+
+
+class MarketingMailsTest(TestCase):
+    """Define tests for marketing mails."""
+
+    def setUp(self):
+        """Perform setup for the testcase."""
+        self.email = 'user1@gitcoin.co'
+        self.user = self.make_user('user1')
+        self.user.email = self.email
+        self.user.profile = Profile.objects.create(
+            user=self.user,
+            handle='user1',
+            last_sync_date=timezone.now(),
+            data={},
+            repos_data={}
+        )
+        self.user.save()
+
+    @patch('django.utils.translation.activate')
+    def test_setup_lang(self, mock_translation_activate):
+        """Test the marketing mails setup_lang method."""
+        setup_lang(self.email)
+        assert mock_translation_activate.call_count == 1
+        mock_translation_activate.assert_called_once_with('en-us')
+
+    @patch('django.utils.translation.activate')
+    def test_setup_lang_no_user(self, mock_translation_activate):
+        """Test the marketing mails setup_lang method."""
+        setup_lang('bademail@gitcoin.co')
+        assert mock_translation_activate.call_count == 0


### PR DESCRIPTION
##### Description
The goal of this PR is to resolve `Profile` queries resulting in `None` and attempting to use `Profile` class methods by replacing the query for `Profile` to `User` for `setup_lang()` and falling back if the found user doesn't have a profile for whatever reason.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
i18n, notifications

##### Testing
Tested locally

##### Refers/Fixes
Fix #979 
Ref #810 