### PR TITLE
hotfix: wait for approval to issue bounty

### DIFF
--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -324,11 +324,24 @@ $(document).ready(function() {
             value: 0,
             gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9))
           },
-          function(result, errors) {
+          function(error, result) {
+            if(error){
+              console.error(error);
+              _alert(
+                {
+                  message:
+                    gettext('There was an error.  Please try again or contact support.')
+                },
+                'error'
+              );
+              unloading_button($('.js-submit'));
+              return;
+            }
             var txid = result;
             var link_url = etherscan_tx_url(txid);
-            _alert({ message: 'Token approval transaction (1 of 2) has been sent to web3.  <a href="' + link_url + '">Once that tx is confirmed</a>, you will be prompted to confirm submission of this bounty (tx 2 of 2)' }, 'info');
+            _alert({ message: 'Token approval transaction (1 of 2) has been sent to web3.  <a target=new href="' + link_url + '">Once that tx is confirmed</a>, you will be prompted to confirm submission of this bounty (tx 2 of 2)' }, 'info');
             callFunctionWhenTransactionMined(txid, function() {
+              _alert({ message: 'Tx 1 of 2 confirmed.  Please confirm the second transaction.' }, 'success');
               approve_success_callback();
             });
           }

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -302,7 +302,7 @@ $(document).ready(function() {
             value: eth_amount,
             gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9)),
             gas: web3.toHex(318730),
-            gasLimit: web3.toHex(318730),
+            gasLimit: web3.toHex(318730)
           },
           web3Callback // callback for web3
         );

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -300,7 +300,9 @@ $(document).ready(function() {
             // {from: x, to: y}
             from: account,
             value: eth_amount,
-            gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9))
+            gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9)),
+            gas: web3.toHex(318730),
+            gasLimit: web3.toHex(318730),
           },
           web3Callback // callback for web3
         );
@@ -325,7 +327,7 @@ $(document).ready(function() {
             gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9))
           },
           function(error, result) {
-            if(error){
+            if (error) {
               console.error(error);
               _alert(
                 {
@@ -339,6 +341,7 @@ $(document).ready(function() {
             }
             var txid = result;
             var link_url = etherscan_tx_url(txid);
+
             _alert({ message: 'Token approval transaction (1 of 2) has been sent to web3.  <a target=new href="' + link_url + '">Once that tx is confirmed</a>, you will be prompted to confirm submission of this bounty (tx 2 of 2)' }, 'info');
             callFunctionWhenTransactionMined(txid, function() {
               _alert({ message: 'Tx 1 of 2 confirmed.  Please confirm the second transaction.' }, 'success');

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -324,7 +324,14 @@ $(document).ready(function() {
             value: 0,
             gasPrice: web3.toHex($('#gasPrice').val() * Math.pow(10, 9))
           },
-          approve_success_callback
+          function(result, errors) {
+            var txid = result;
+            var link_url = etherscan_tx_url(txid);
+            _alert({ message: 'Token approval transaction (1 of 2) has been sent to web3.  <a href="' + link_url + '">Once that tx is confirmed</a>, you will be prompted to confirm submission of this bounty (tx 2 of 2)' }, 'info');
+            callFunctionWhenTransactionMined(txid, function() {
+              approve_success_callback();
+            });
+          }
         );
       }
     }

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -62,6 +62,8 @@ def amount(request):
     try:
         amount = request.GET.get('amount')
         denomination = request.GET.get('denomination', 'ETH')
+        if denomination == 'DAI':
+            denomination = 'USDT'
         if denomination == 'ETH':
             amount_in_eth = float(amount)
         else:


### PR DESCRIPTION
Today, Greg from MakerDAO was having trouble submitting his DAO bounties to the platform.  

Specificially, what was happeneing was that on the new bounty page.

1. He called `approval()` to give the contract approval to send the coins.
2. He immediately then called `issueAndActivateBounty()` to issue the bounty.
3. becuase the tx from 1 had not been confirmed by the network yet, metamask presumed that his second transaction would error out.  it also presents an insanely high bgas price to the end user
4. this is made worse by an issue in metamask where a user can't successfully override the gas price in the tx confirmation window

This PR solves that by waiting for the tx from 1 to mine before attempting 2.

# Future Work

1. In the future, we could batch up the transactions using web3js batch ( which i haven't had any luck with thus far)
2) we could also create an atomic contract which manages the `approval()` and the `issueAndActivateBounty` all in one call, and just use that in web3js