### PR TITLE
Slack Welcomebot on AWS Lambda

### DIFF
--- a/ops/lambdas/welcombot/Makefile
+++ b/ops/lambdas/welcombot/Makefile
@@ -1,0 +1,32 @@
+# Help
+.DEFAULT_GOAL := help
+
+.PHONY: help
+
+init: ## Initialize the Zappa project for our AWS Lambda function and API Gateway.
+	@echo "Attempting to initialize Zappa"
+	@zappa init
+	@echo "Zappa initialized. Update domain_name and certificate_arn in zappa_settings.json, then run: make deploy && make certify"
+
+deploy: ## Deploy the welcomebot project for the first time. Run this once.
+	@echo "Deploying Welcomebot"
+	@zappa deploy welcomebot
+	@echo "Welcomebot deployed!"
+
+update: ## Update the welcomebot project.
+	@echo "Updating Welcomebot"
+	@zappa update welcomebot
+	@echo "Welcomebot updated!"
+
+undeploy: ## Undeploy the welcomebot.
+	@echo "Undeploying Welcomebot"
+	@zappa undeploy welcomebot
+	@echo "Welcomebot undeployed!"
+
+certify: ## Certify the AWS ACM certificate and establish your CNAME for welcomebot.
+	@echo "Certifying Welcomebot"
+	@zappa certify welcomebot
+	@echo "Welcomebot certified!"
+
+help: ## Display command information and usage instructions. Ex: make or make help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/ops/lambdas/welcombot/README.md
+++ b/ops/lambdas/welcombot/README.md
@@ -1,0 +1,11 @@
+# Gitcoin Slack Welcomebot
+
+The Gitcoin Slack Welcomebot is a [Flask](http://flask.pocoo.org/) application meant to run on [AWS Lambda](https://aws.amazon.com/lambda/) using [Zappa](https://github.com/Miserlou/Zappa).
+
+
+This bot is intended to be ran as Python 3.6 AWS Lambda function.
+
+Get started with the welcomebot by running `make init`.
+
+You will need to follow the Slack Bot setup instructions outlined in the [Python Slack Event API client](https://github.com/slackapi/python-slack-events-api) documentation.
+

--- a/ops/lambdas/welcombot/app.py
+++ b/ops/lambdas/welcombot/app.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Define the Gitcoin Slack Welcome Bot flask app.
+
+Copyright (C) 2018 Gitcoin Core
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+import os
+
+from flask import Flask
+from slackclient import SlackClient
+from slackeventsapi import SlackEventAdapter
+
+SLACK_VERIFICATION_TOKEN = os.environ.get('SLACK_VERIFICATION_TOKEN', '')
+SLACK_WELCOMEBOT_TOKEN = os.environ.get('SLACK_WELCOMEBOT_TOKEN', '')
+app = Flask(__name__)
+
+
+def get_default_message():
+    """Return the Gitcoin Welcomebot message."""
+    return """
+Welcome to Gitcoin! :gitcoin:
+
+Gitcoin's mission is to *Grow Open Source*.
+
+A few quick facts:
+- We are mission driven.  Check out our mission: https://gitcoin.co/mission
+- We aren't an ICO.  There is no Gitcoin token.
+- We are a community of blockchain developers.
+
+Here's how to get started in the community
+- Say hey :wave: in #community-intros
+- Join the community livestream every Friday at 5pm EST: https://gitcoin.co/livestream
+
+We believe that a great way to build new skills is to learn by doing, and Gitcoin's core product (Bounties) supports that.
+
+Here's how to get started with bounties:
+- Developer? Check out the open bounties at https://gitcoin.co/explorer
+- Repo Owner? Accellerate your dev progress by posting a bounty of your own at https://gitcoin.co/new
+- Send a tip to any github username with https://gitcoin.co/tip
+
+We have more details in our onboarding guide at https://gitcoin.co/onboard . We also have a FAQ and tutorials available at https://gitcoin.co/help
+
+If you have any feedback for the team, or just want to say hi, this is them:
+- @owocki, @vivek, @Pixelant, @mbeacom, @coderberry, @justin-bean
+
+See you around! :spock-hand:
+Welcome_bot (and the Gitcoin Team)
+
+"""
+
+
+MESSAGE = get_default_message()
+
+
+@app.route('/')
+def index():
+    """Handle the index route."""
+    return ""
+
+
+slack_events_adapter = SlackEventAdapter(
+    SLACK_VERIFICATION_TOKEN, '/slack/events', app)
+
+
+@slack_events_adapter.on('team_join')
+def new_user_welcome(event):
+    """Handle team_join slack events by sending the user our welcome message."""
+    sc = SlackClient(SLACK_WELCOMEBOT_TOKEN)
+    user = event.get('event', {}).get('user', {}).get('id', '')
+    if user:
+        channel = sc.api_call('im.open', user=user)
+        channel_id = channel['channel']['id']
+        sc.api_call(
+            'chat.postMessage',
+            channel=channel_id,
+            unfurl_links=False,
+            text=MESSAGE,
+            as_user=True)
+
+
+# Serve the slack welcomebot flask app.
+if __name__ == '__main__':
+    app.run()

--- a/ops/lambdas/welcombot/requirements.txt
+++ b/ops/lambdas/welcombot/requirements.txt
@@ -1,0 +1,4 @@
+zappa
+flask
+slackeventsapi
+slackclient

--- a/ops/lambdas/welcombot/zappa_settings.json
+++ b/ops/lambdas/welcombot/zappa_settings.json
@@ -1,0 +1,14 @@
+{
+    "welcomebot": {
+        "app_function": "app.app",
+        "aws_region": "us-west-2",
+        "profile_name": "default",
+        "project_name": "welcombot",
+        "runtime": "python3.6",
+        "s3_bucket": "",
+        "domain": "",
+        "slim_handler": true,
+        "certificate_arn": "",
+        "cloudwatch_log_level": "ERROR"
+    }
+}


### PR DESCRIPTION
##### Description

The goal of this PR is to offload the functionality of `slack_welcomebot.py` management command to avoid high CPU utilization (95%) on the production servers by offloading the welcomebot to AWS Lambda and use the Slack Events API versus the RTM API.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
welcomebot, slack

##### Testing
Tested on private slack community and AWS account.

##### Refers/Fixes
Refs: #874, #1012
