### PR TITLE
issue 115 duplicated emails

### DIFF
--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -249,10 +249,10 @@ def get_bounty(bounty_enum, network):
 
 
 # processes a bounty returned by get_bounty
-def web3_process_bounty(bounty_data):
+def web3_process_bounty(bounty_data, dry_run=False):
     did_change, old_bounty, new_bounty = process_bounty_details(bounty_data)
 
-    if did_change and new_bounty:
+    if did_change and new_bounty and not dry_run:
         _from = old_bounty.pk if old_bounty else None
         print(f"- processing changes, {_from} => {new_bounty.pk}")
         process_bounty_changes(old_bounty, new_bounty)

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -865,7 +865,7 @@ def sync_web3(request):
                 counter = 0
                 url = None
                 while not did_change and not max_tries_attempted:
-                    did_change, _, new_bounty = web3_process_bounty(bounty)
+                    did_change, _, new_bounty = web3_process_bounty(bounty, True)
                     if not did_change:
                         print("RETRYING")
                         time.sleep(3)


### PR DESCRIPTION
`web3_process_bounty` where email, as well slack etc, are sent, Is used in two places

* `sync_web3` in dashboard/views
* `sync_geth` in command

with opened browser to access `sync_web3`, it's possible there is a *race*

Since in `sync_web3`, it simply requires two fields (`did_change` and `url`). We could have `dry_run` parameter to control if `web3_process_bounty` should handle changed bounty, or return information only.