### PR TITLE
css: prettified start work dialog box to match style +  stop work button

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -278,8 +278,7 @@ a.btn {
 
 .started-status-column .button--primary,
 #right_actions .button--primary,
-#btn-white,
-.btn-white {
+#btn-white {
   padding: 6px 15px;
   box-shadow: none;
   font-size: 12px;
@@ -293,9 +292,7 @@ a.btn {
   margin-bottom: 10px;
 }
 
-#btn-white,
-.btn-white,
-.btn-white:hover {
+#btn-white {
   background-color: #FFFFFF;
   border: 1px solid #979797;
   color: #0D0764;
@@ -486,7 +483,7 @@ a.btn {
 
 #add_interest form .filter-label {
   display: inline;
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 
 .add-interest-options > .option {
@@ -495,4 +492,10 @@ a.btn {
 
 .btn-interested {
   float: right;
+  padding: 0.375rem 0.9375rem;
+  font-size: 12px;
+}
+
+.close:hover, .close:focus {
+  box-shadow: none;
 }

--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -36,6 +36,7 @@ body {
   height: 2px;
   width: 50%;
 }
+
 .progress-bar.expired .progress {
   background-color: #f7981b;
 }
@@ -276,7 +277,8 @@ a.btn {
 
 .started-status-column .button--primary,
 #right_actions .button--primary,
-#btn-white {
+#btn-white,
+.btn-white {
   padding: 6px 15px;
   box-shadow: none;
   font-size: 12px;
@@ -290,7 +292,10 @@ a.btn {
   margin-bottom: 10px;
 }
 
-#btn-white {
+#btn-white,
+.btn-white,
+.btn-white:hover {
+  background-color: #FFFFFF;
   border: 1px solid #979797;
   color: #0D0764;
   border-radius: 3px;
@@ -449,32 +454,22 @@ a.btn {
   }
 }
 
-
-.interest-modal-title {
-  display: inline-block;
-  width: 100%;
+#add_interest form > div {
+  margin-top: 10px;
 }
 
 .add-interest-modal {
-  height:auto;
-  width:100%;
+  height: auto;
+  width: 100%;
 }
 
-.add-interest-modal__form {
+#add_interest form {
   padding:1em;
   width:100%;
 }
 
-.add-interest-modal__form--item {
-  padding-top:1em;
-}
-
-.add-interest-modal__form--submit {
-  margin-top:1em;
-}
-
-.add-interest-modal__form--textarea {
-  height:8em;
+#issue-message {
+  min-height: 6em;
 }
 
 .add-interest-options {
@@ -482,21 +477,16 @@ a.btn {
   flex-direction: row;
   justify-content: flex-start;
 }
-.add-interest-modal__form .checkbox_container input {
-  opacity: 100;
-  width: 20px;
-  position: initial;
+
+#add_interest form .filter-label {
+  display: inline;
+  margin-left: 10px;
 }
 
 .add-interest-options > .option {
-  width: auto !important;
+  width: auto;
 }
 
-.btn-interested, .btn-interested:hover {
-  border-radius:0.2em;
-  color: black;
-  border: black 1px solid;
-}
-.btn-interested:hover {
-  background-color: #eee;
+.btn-interested {
+  float: right;
 }

--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -199,6 +199,7 @@ body {
   margin-bottom: 5px;
   display: block;
 }
+
 #network a{
   color: #fb9470;
   font-weight: bold;
@@ -398,6 +399,11 @@ a.btn {
   margin: 5px;
 }
 
+.stop-work {
+  float: right;
+  margin-right: 10px;
+}
+
 @media (max-width: 575px) {
 
   #timer {
@@ -464,8 +470,8 @@ a.btn {
 }
 
 #add_interest form {
-  padding:1em;
-  width:100%;
+  padding: 1em;
+  width: 100%;
 }
 
 #issue-message {
@@ -473,7 +479,7 @@ a.btn {
 }
 
 .add-interest-options {
-  display:flex;
+  display: flex;
   flex-direction: row;
   justify-content: flex-start;
 }

--- a/app/dashboard/templates/addinterest.html
+++ b/app/dashboard/templates/addinterest.html
@@ -16,18 +16,18 @@
 {% endcomment %}
 {% load i18n static %}
 <div id="add_interest" class="white-light-bg">
-  <div class="container-fluid">
-    <div class="row closebtn">
+  <div class="row">
+    <div class="col-12 closebtn">
       <a rel="modal:close" href="javascript:void" class="close" aria-label="Close dialog">
         <span aria-hidden="true">&times;</span>
       </a>
     </div>
-    <div class="text-center interest-modal-title">
-      <h5 class="col mt-2 mb-2">{% trans "Great to see that you're interested in this project!" %}</h5>
+    <div class="col-12">
+      <h5 class="text-center font-title">{% trans "Great to see that you're interested in this project!" %}</h5>
     </div>
-    <div class="row">
-      <form class="add-interest-modal__form">
-        <label class="add-interest-modal__form--item">{% trans "Do you have any questions about this ticket?" %}</label>
+    <div class="col-12">
+      <form class="font-body">
+        <label class="mt-2">{% trans "Do you have any questions about this ticket?" %}</label>
         <div class="add-interest-options options">
           <div class="form__radio option">
             <input type="radio" id="interest-question-true" name="interest-question" value="true" checked="checked" />
@@ -38,31 +38,35 @@
             <label for="interest-question-false">{% trans "No" %}</label>
           </div>
         </div>
-        <div class="add-interest-modal__form--item">
-          <div>
-            <label for="issue-message">
-              {% trans "Anything the project owner should know?" %}
-            </label>
-            <textarea id="issue-message" class="add-interest-modal__form--textarea form__input"></textarea>
-          </div>
+        <div>
+          <label for="issue-message">
+            {% trans "Anything the project owner should know?" %}
+          </label>
+          <textarea id="issue-message" class="form__input"></textarea>
         </div>
-        <div class="add-interest-modal__form--item">
+        <div>
           <div class=checkbox_container>
-            <input type="checkbox" id="checkbox2" class="add-interest-modal__form form__input" value="1">
-            <label for="checkbox2">
-              {% trans "I understand that if anyone has started work on this ticket before me, they may have precedence." %}
-            </label>
+            <input type="checkbox" id="checkbox2" class="form__input" value="1">
+            <span class="checkbox"></span>
+            <div class="filter-label">
+              <label for="checkbox2">
+                {% trans "I understand that if anyone has started work on this ticket before me, they may have precedence." %}
+              </label>
+            </div>
           </div>
         </div>
-        <div class="add-interest-modal__form--item">
+        <div>
           <div class=checkbox_container>
-            <input type="checkbox" id="checkbox1" class="add-interest-modal__form form__input" value="1">
-            <label for="checkbox1">
-              {% trans "I agree to keep the funder informed of my progress every few days." %}
-            </label>
+            <input type="checkbox" id="checkbox1" class="form__input" value="1">
+            <span class="checkbox"></span>
+            <div class="filter-label">
+              <label for="checkbox1">
+                {% trans "I agree to keep the funder informed of my progress every few days." %}
+              </label>
+            </div>
           </div>
         </div>
-        <button class="add-interest-modal__form--submit row btn btn-sm btn-darkBlue btn-interested float-right" type="submit">{% trans "Submit" %}</button>
+        <button class="row btn btn-sm btn-white btn-interested" type="submit">{% trans "Submit" %}</button>
       </form>
     </div>
   </div>

--- a/app/dashboard/templates/addinterest.html
+++ b/app/dashboard/templates/addinterest.html
@@ -66,7 +66,7 @@
             </div>
           </div>
         </div>
-        <button class="row btn btn-sm btn-white btn-interested" type="submit">{% trans "Submit" %}</button>
+        <button class="row button button--primary btn-interested" type="submit">{% trans "Submit" %}</button>
       </form>
     </div>
   </div>

--- a/app/dashboard/templates/bounty_details.html
+++ b/app/dashboard/templates/bounty_details.html
@@ -262,7 +262,7 @@
               [[:text]]
             </div>
             [[if uninterest_possible]]
-              <div>
+              <div class="stop-work">
                 <span title="<div class='tooltip-info tooltip-sm'>Remove this user's started work on the bounty</div>">
                   <a id="remove-[[:name]]" class="button button--primary" role="button" href="remove-handle">
                     <span class="font-smaller-4">Stop work</span>


### PR DESCRIPTION
##### Description


<img width="1440" alt="screen shot 2018-05-02 at 6 23 22 pm" src="https://user-images.githubusercontent.com/5358146/39524262-fc7f6b14-4e35-11e8-99b0-6eb3ca1df9c0.png">



<img width="1440" alt="screen shot 2018-05-02 at 8 46 23 pm" src="https://user-images.githubusercontent.com/5358146/39531925-e92a0ede-4e49-11e8-9c5c-17ffd61b5b52.png">



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
- css

@PixelantDesign @SaptakS thoughts ? 