### PR TITLE
escalation not removal

### DIFF
--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -486,6 +486,19 @@ def process_bounty_details(bounty_details):
 
 
 def record_user_action(event_name, old_bounty, new_bounty):
+    """Records a user action 
+
+    Args:
+        event_name (string): the event
+        old_bounty (Bounty): the old_bounty
+        new_bounty (Bounty): the new_bounty
+
+    Raises:
+        None
+
+    Returns:
+        None
+    """
     user_profile = None
     fulfillment = None
     try:

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -940,7 +940,7 @@ class Profile(SuperModel):
     def has_abandoned_work(self):
         user_actions = UserAction.objects.filter(
             profile=self,
-            action='bounty_abandonment_final',
+            action='bounty_removed_by_staff',
             )
         return user_actions.exists()
 

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -937,7 +937,7 @@ class Profile(SuperModel):
         tipped_for = Tip.objects.filter(username__iexact=self.handle).order_by('-id')
         return on_repo | tipped_for
 
-    def has_abandoned_work(self):
+    def has_been_removed_by_staff(self):
         user_actions = UserAction.objects.filter(
             profile=self,
             action='bounty_removed_by_staff',

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -717,12 +717,12 @@ def maybe_post_on_craigslist(bounty):
     return False
 
 
-def maybe_notify_bounty_user_removed_to_slack(bounty, username):
+def maybe_notify_bounty_user_escalated_to_slack(bounty, username, last_heard_from_user_days):
     if not settings.SLACK_TOKEN or bounty.get_natural_value() < 0.0001 or (
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
 
-    msg = f"@{username} has been removed from {bounty.github_url} due to inactivity on the github thread."
+    msg = f"@vivek, {bounty.github_url} is being escalated to you, due to inactivity for {last_heard_from_user_days} days from @{username} on the github thread."
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)
@@ -739,7 +739,7 @@ num_days_back_to_warn = 3
 num_days_back_to_delete_interest = 6
 
 
-def maybe_notify_user_removed_github(bounty, username, last_heard_from_user_days=None):
+def maybe_notify_user_escalated_github(bounty, username, last_heard_from_user_days=None):
     if (not settings.GITHUB_CLIENT_ID) or (bounty.get_natural_value() < 0.0001) or (
        bounty.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK):
         return False
@@ -749,10 +749,10 @@ def maybe_notify_user_removed_github(bounty, username, last_heard_from_user_days
 
     status_header = get_status_header(bounty)
 
-    msg = f"""{status_header}@{username} has been removed for inactivity and [the issue]({bounty.url}) has been returned to an ‘Open’ Status. Let us know if you believe this has been done in error!
+    msg = f"""{status_header}@{username} due to inactivity, we have escalated [this issue]({bounty.url}) to Gitcoin's moderation team. Let us know if you believe this has been done in error!
 
 * [x] warning ({num_days_back_to_warn} days)
-* [x] auto removal ({num_days_back_to_delete_interest} days)
+* [x] escalation to mods ({num_days_back_to_delete_interest} days)
 """
 
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)
@@ -765,7 +765,7 @@ def maybe_warn_user_removed_github(bounty, username, last_heard_from_user_days):
 
     msg = f"""@{username} Hello from Gitcoin Core - are you still working on this issue? Please submit a WIP PR or comment back within the next 3 days or you will be removed from this ticket and it will be returned to an ‘Open’ status. Please let us know if you have questions!
 * [x] warning ({num_days_back_to_warn} days)
-* [ ] auto removal ({num_days_back_to_delete_interest} days)
+* [ ] escalation to mods ({num_days_back_to_delete_interest} days)
 """
 
     post_issue_comment(bounty.org_name, bounty.github_repo_name, bounty.github_issue_number, msg)

--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -386,4 +386,3 @@ def record_user_action_on_interest(interest, event_name, last_heard_from_user_da
             'interest_pk': interest.pk,
             'last_heard_from_user_days': last_heard_from_user_days,
         })
-

--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -374,3 +374,16 @@ def get_ordinal_repr(num):
     else:
         suffix = ordinal_suffixes.get(num % 10, 'th')
     return f'{num}{suffix}'
+
+
+
+def record_user_action_on_interest(interest, event_name, last_heard_from_user_days):
+    UserAction.objects.create(
+        profile=interest.profile,
+        action=event_name,
+        metadata={
+            'bounties': list(interest.bounty_set.values_list('pk', flat=True)),
+            'interest_pk': interest.pk,
+            'last_heard_from_user_days': last_heard_from_user_days,
+        })
+

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -44,8 +44,7 @@ from dashboard.notifications import (
     maybe_market_tip_to_email, maybe_market_tip_to_github, maybe_market_tip_to_slack, maybe_market_to_slack,
     maybe_market_to_twitter, maybe_market_to_user_slack,
 )
-from dashboard.utils import get_bounty, get_bounty_id, has_tx_mined, web3_process_bounty
-from dashboard.utils import record_user_action_on_interest
+from dashboard.utils import get_bounty, get_bounty_id, has_tx_mined, record_user_action_on_interest, web3_process_bounty
 from gas.utils import conf_time_spread, eth_usd_conv_rate, recommend_min_gas_price_to_confirm_in_time
 from github.utils import (
     get_auth_url, get_github_emails, get_github_primary_email, get_github_user_data, is_github_token_valid,

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -180,9 +180,9 @@ def new_interest(request, bounty_id):
             'success': False},
             status=401)
 
-    if profile.has_abandoned_work():
+    if profile.has_been_removed_by_staff():
         return JsonResponse({
-            'error': _('Due to a prior abandoned bounty, you are unable to start work at this time. Please contact support.'),
+            'error': _('Because a staff member has had to remove you from a bounty in the past, you are unable to start more work at this time. Please contact support.'),
             'success': False},
             status=401)
 

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -27,26 +27,16 @@ from django.utils import timezone
 import pytz
 from dashboard.models import Bounty, Interest, UserAction
 from dashboard.notifications import (
-    maybe_notify_bounty_user_removed_to_slack, maybe_notify_bounty_user_warned_removed_to_slack,
-    maybe_notify_user_removed_github, maybe_warn_user_removed_github,
+    maybe_notify_bounty_user_escalated_to_slack, maybe_notify_bounty_user_warned_removed_to_slack,
+    maybe_notify_user_escalated_github, maybe_warn_user_removed_github,
 )
+from dashboard.utils import record_user_action_on_interest
 from github.utils import get_interested_actions
 from marketing.mails import bounty_startwork_expire_warning, bounty_startwork_expired
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
-
-
-def record_user_action(interest, event_name, last_heard_from_user_days):
-    UserAction.objects.create(
-        profile=interest.profile,
-        action=event_name,
-        metadata={
-            'bounties': list(interest.bounty_set.values_list('pk', flat=True)),
-            'interest_pk': interest.pk,
-            'last_heard_from_user_days': last_heard_from_user_days,
-        })
 
 
 class Command(BaseCommand):
@@ -61,6 +51,7 @@ class Command(BaseCommand):
         # TODO: DRY with dashboard/notifications.py
         num_days_back_to_warn = 3
         num_days_back_to_delete_interest = 6
+        num_days_back_to_ignore_bc_mods_got_it = 9
 
         days = [i * 3 for i in range(1, 15)]
         days.reverse()
@@ -87,6 +78,7 @@ class Command(BaseCommand):
                             bounty.github_url, interest.profile.handle, interest.profile.email)
                         should_warn_user = False
                         should_delete_interest = False
+                        should_ignore = False
                         last_heard_from_user_days = None
 
                         if not actions:
@@ -111,32 +103,38 @@ class Command(BaseCommand):
                             # decide action params
                             should_warn_user = last_heard_from_user_days >= num_days_back_to_warn
                             should_delete_interest = last_heard_from_user_days >= num_days_back_to_delete_interest
+                            should_ignore = last_heard_from_user_days >= num_days_back_to_ignore_bc_mods_got_it
 
                             print(f"- its been {last_heard_from_user_days} days since we heard from the user")
+                        if should_ignore:
+                            print(f'executing should_ignore for {interest.profile} / {bounty.github_url} ')
 
-                        if should_delete_interest:
+                        elif should_delete_interest:
                             print(f'executing should_delete_interest for {interest.profile} / {bounty.github_url} ')
 
-                            record_user_action(interest, 'bounty_abandonment_final', last_heard_from_user_days)
-
-                            interest.delete()
+                            record_user_action_on_interest(interest, 'bounty_abandonment_escalation_to_mods', last_heard_from_user_days)
 
                             # commenting on the GH issue
-                            maybe_notify_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
+                            maybe_notify_user_escalated_github(bounty, interest.profile.handle, last_heard_from_user_days)
+                            
                             # commenting in slack
-                            maybe_notify_bounty_user_removed_to_slack(bounty, interest.profile.handle)
+                            maybe_notify_bounty_user_escalated_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
+                            
                             # send email
                             bounty_startwork_expired(interest.profile.email, bounty, interest, last_heard_from_user_days)
 
                         elif should_warn_user:
 
-                            record_user_action(interest, 'bounty_abandonment_warning', last_heard_from_user_days)
+                            record_user_action_on_interest(interest, 'bounty_abandonment_warning', last_heard_from_user_days)
 
                             print(f'executing should_warn_user for {interest.profile} / {bounty.github_url} ')
+                            
                             # commenting on the GH issue
                             maybe_warn_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
+                            
                             # commenting in slack
                             maybe_notify_bounty_user_warned_removed_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
+                            
                             # send email
                             bounty_startwork_expire_warning(interest.profile.email, bounty, interest, last_heard_from_user_days)
 

--- a/app/marketing/tests/management/commands/test_expiration_start_work.py
+++ b/app/marketing/tests/management/commands/test_expiration_start_work.py
@@ -111,7 +111,7 @@ class TestExpiraionStartWork(TestCase):
         Command().handle()
 
         assert mock_bounty_startwork_expire_warning.call_count == 0
-        assert mock_bounty_startwork_expired.call_count == 1
+        assert mock_bounty_startwork_expired.call_count == 0
 
     @patch('marketing.management.commands.expiration_start_work.get_interested_actions', return_value=actions_warning)
     @patch('marketing.management.commands.expiration_start_work.bounty_startwork_expire_warning')


### PR DESCRIPTION

##### Description
* expiration script escalates to @vs77bb if a user is MIA, but does not do removal itself
* changes the 'did user abanadon work and can't start another task' functionality to be only IFF the user has been removed from another task by a staff member.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
start/  stop work 

##### Refers/Fixes
self/ vivek idea on slack