### PR TITLE
Add left margin for activity time

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -398,7 +398,6 @@ a.btn {
 
 .stop-work {
   float: right;
-  margin-right: 10px;
 }
 
 @media (max-width: 575px) {
@@ -459,7 +458,7 @@ a.btn {
 
 @media (min-width: 768px) {
   .activity-time {
-    margin-left: 10px;
+    margin-left: 0.625rem;
   }
 }
 

--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -457,6 +457,12 @@ a.btn {
   }
 }
 
+@media (min-width: 768px) {
+  .activity-time {
+    margin-left: 10px;
+  }
+}
+
 #add_interest form > div {
   margin-top: 10px;
 }


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

The activity time ("34 minutes ago") is squished to the 'Stop work' button (refer to the below screenshot).

![image](https://user-images.githubusercontent.com/7039523/39656431-5543d524-4fc5-11e8-8023-99510a8026bd.png)

This PR adds a bit of left margin to the activity time.

After:

![image](https://user-images.githubusercontent.com/7039523/39656464-9a589000-4fc5-11e8-84bd-df192db3083d.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
