### PR TITLE
dashboard: fix filter uri

### DIFF
--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -210,7 +210,7 @@ var get_search_URI = function() {
 
     $.each ($('input[name=' + key + ']:checked'), function() {
       if (key === 'tech_stack' && $(this).val()) {
-        keywords += $(this).val() + ', ';
+        keywords += $(this).val() + ',';
       } else if ($(this).val()) {
         filters.push($(this).val());
       }
@@ -236,7 +236,7 @@ var get_search_URI = function() {
         }
 
         if (_value !== 'any')
-          uri += '&' + _key + '=' + _value;
+          uri += _key + '=' + _value + '&';
       });
 
       // TODO: Check if value myself is needed for coinbase
@@ -249,13 +249,16 @@ var get_search_URI = function() {
     if (val !== 'any' &&
         key !== 'bounty_filter' &&
         key !== 'bounty_owner_address') {
-      uri += '&' + key + '=' + val;
+      uri += key + '=' + val + '&';
     }
   }
 
   if (localStorage['keywords']) {
-    localStorage['keywords'].split(',').forEach(function(v, k) {
-      keywords += v + ', ';
+    localStorage['keywords'].split(',').forEach(function(v, pos, arr) {
+      keywords += v;
+      if (arr.length < pos + 1) {
+        keywords += ',';
+      }
     });
   }
 


### PR DESCRIPTION
##### Description

- `/api/v0.1/bounties/?&` -> `/api/v0.1/bounties/?`
- `.net, pop, &` -> `.net,pop&`

###### Before

uri : `/api/v0.1/bounties/?&network=mainnet,any&tech_stack=&raw_data=c, pop, &coinbase=unknown&order_by=-web3_created`

<img width="1440" alt="screen shot 2018-05-05 at 7 28 04 pm" src="https://user-images.githubusercontent.com/5358146/39664659-002f2e46-50a4-11e8-849e-715eaa42da5c.png">

###### After

uri : `/api/v0.1/bounties/?network=mainnet&tech_stack=&&raw_data=.net,pop&coinbase=unknown&order_by=-web3_created`

<img width="1440" alt="screen shot 2018-05-05 at 7 24 00 pm" src="https://user-images.githubusercontent.com/5358146/39664658-fff94272-50a3-11e8-88d0-f93e199438d3.png">

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- js 

@mbeacom I see `tech_stack` being added to the uri but the value always seems to be empty
and the backend doesn't filter via that keyword
All the tech_stack selected options end up in `raw_data`
