### PR TITLE
Fix broken running locally link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,11 +80,13 @@ Technically, the system is architected:
 
 [For more information on the HTTPS API, please view the api README](API.md)
 
-## Running Locally with Docker (Recommended)
+## Running locally
+
+### With Docker (Recommended)
 
 [For more information on running the app locally, please view the running locally README](RUNNING_LOCALLY_DOCKER.md)
 
-## Running Locally without Docker
+### Without Docker
 
 [For more information on running the app locally, please view the running locally README](RUNNING_LOCALLY.md)
 


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->

'Running locally' link in the Table of contents was broken as we didn't have a corresponding section with the href `running-locally`

This PR adds in a new heading, thereby creating a ref for the 'Running locally' link.

Also changed the level of the sub-headings and the text (With Docker, Without docker).

Removed 'Running locally' before those headings as it seemed a bit redundant after the inclusion of the link.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
