### PR TITLE
Display tips in user profile only if they exist

### DIFF
--- a/app/dashboard/templates/profile_details.html
+++ b/app/dashboard/templates/profile_details.html
@@ -80,12 +80,9 @@
               {% endif %}
               <div>
                 <div>
-                  <h4>{% blocktrans %}{{profile.handle}} has received these tips{% endblocktrans %}</h4>
-                  <div class="text-center">
-                    {% if tips|length == 0 %} 
-                      {% trans "No tips found" %}
-                    {% endif %} 
-                    {% if tips|length > 0 %}
+                  {% if tips|length > 0 %}
+                    <h4>{% blocktrans %}{{profile.handle}} has received these tips{% endblocktrans %}</h4>
+                    <div class="text-center">
                       <div class="row">
                         <div class="col-3">
                           {% trans "From" %}
@@ -124,9 +121,9 @@
                             </div>
                           </div>
                         </div>
-                      {% endfor %} 
-                    {% endif %}
-                  </div>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
                 </div>
               </div>
               <div>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Currently, in the user profile, we display the tips section even if the user hasn't received any tips. This PR only displays the tips if they exist.

**Motivation**

![image](https://user-images.githubusercontent.com/7039523/39718110-e76b3f28-51fa-11e8-90e6-1fd9858180fe.png)


In the above screenshot, you can find 'No tips found' below 'has received these tips' which doesn't make sense.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
