### PR TITLE
css: set limit for image in issue description

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -352,6 +352,7 @@ a.btn {
 }
 
 #bounty_details #issue_description img {
+  max-height: 50rem;
   max-width: 100%;
 }
 


### PR DESCRIPTION
##### Description
![screenshot-2018-5-8 build new gitcoin landing page gitcoinco funded issue detail gitcoin](https://user-images.githubusercontent.com/5358146/39771322-5055fc70-530f-11e8-82c1-1f1198c9d150.png)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css

##### Fixes
 - #1105

@PixelantDesign was this what you had in mind ? ^_^
