### PR TITLE
css: set limit for image in issue description

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -352,6 +352,7 @@ a.btn {
 }
 
 #bounty_details #issue_description img {
+  max-height: 50rem;
   max-width: 100%;
 }
 

--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -352,8 +352,9 @@ a.btn {
 }
 
 #bounty_details #issue_description img {
-  max-height: 50rem;
-  max-width: 100%;
+  max-height: 30rem;
+  max-width: 30rem;
+  cursor: pointer;
 }
 
 #bounty_details #issue_description h1,
@@ -525,4 +526,10 @@ a.btn {
 
 .close:hover, .close:focus {
   box-shadow: none;
+}
+
+.modal.magnify,
+.modal .magnify {
+  width: auto;
+  height: auto;
 }

--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -500,6 +500,20 @@ var build_detail_page = function(result) {
     }
   }
 
+  $('#bounty_details #issue_description img').on('click', function() {
+
+    var content = $.parseHTML(
+      '<div><div class="row"><div class="col-12 closebtn">' +
+        '<a id="" rel="modal:close" href="javascript:void" class="close" aria-label="Close dialog">' +
+          '<span aria-hidden="true">&times;</span>' +
+        '</a>' +
+      '</div>' +
+      '<div class="col-12"><img class="magnify" src="' + $(this).attr('src') + '"/></div></div></div>');
+
+    var modal = $(content).appendTo('body').modal({
+      modalClass: 'modal magnify'
+    });
+  });
 };
 
 var do_actions = function(result) {

--- a/app/dashboard/templates/addinterest.html
+++ b/app/dashboard/templates/addinterest.html
@@ -18,7 +18,7 @@
 <div id="add_interest" class="white-light-bg">
   <div class="row">
     <div class="col-12 closebtn">
-      <a rel="modal:close" href="javascript:void" class="close" aria-label="Close dialog">
+      <a rel=#close-modal" href="javascript:void" class="close" aria-label="Close dialog">
         <span aria-hidden="true">&times;</span>
       </a>
     </div>


### PR DESCRIPTION
##### Description

- image is restricted in height & width 
- on click -> opens dialog with original image size

![screenshot-2018-5-8 build new gitcoin landing page gitcoinco funded issue detail gitcoin](https://user-images.githubusercontent.com/5358146/39771322-5055fc70-530f-11e8-82c1-1f1198c9d150.png)

![x1](https://user-images.githubusercontent.com/5358146/40003274-8efbee3a-57b0-11e8-9ed1-d3c9e0474f75.gif)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css
- js

##### Fixes
 - #1105

@PixelantDesign was this what you had in mind ? ^_^
