### PR TITLE
Add CR fixtures and disable get_prices by default

### DIFF
--- a/app/economy/fixtures/initial.json
+++ b/app/economy/fixtures/initial.json
@@ -1,0 +1,18900 @@
+[{
+  "model": "economy.conversionrate",
+  "pk": 1,
+  "fields": {
+    "created_on": "2018-05-16T16:48:43.937Z",
+    "modified_on": "2018-05-16T16:48:43.937Z",
+    "from_amount": 1.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:43.937Z",
+    "source": "stablecoin",
+    "from_currency": "USDT",
+    "to_currency": "DAI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 2,
+  "fields": {
+    "created_on": "2018-05-16T16:48:43.954Z",
+    "modified_on": "2018-05-16T16:48:43.954Z",
+    "from_amount": 1.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:43.937Z",
+    "source": "stablecoin",
+    "from_currency": "DAI",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 3,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.380Z",
+    "modified_on": "2018-05-16T16:48:45.380Z",
+    "from_amount": 1.0,
+    "to_amount": 0.1378395725,
+    "timestamp": "2018-05-16T16:48:45.380Z",
+    "source": "etherdelta",
+    "from_currency": "VERI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 4,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.384Z",
+    "modified_on": "2018-05-16T16:48:45.384Z",
+    "from_amount": 0.1378395725,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.380Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VERI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 5,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.386Z",
+    "modified_on": "2018-05-16T16:48:45.386Z",
+    "from_amount": 7.25481066041466,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.380Z",
+    "source": "etherdelta",
+    "from_currency": "VERI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 6,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.389Z",
+    "modified_on": "2018-05-16T16:48:45.390Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00030205,
+    "timestamp": "2018-05-16T16:48:45.390Z",
+    "source": "etherdelta",
+    "from_currency": "0x7e9e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 7,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.394Z",
+    "modified_on": "2018-05-16T16:48:45.394Z",
+    "from_amount": 0.00030205,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.390Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x7e9e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 8,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.398Z",
+    "modified_on": "2018-05-16T16:48:45.398Z",
+    "from_amount": 3310.7101473266,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.390Z",
+    "source": "etherdelta",
+    "from_currency": "0x7e9e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 9,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.402Z",
+    "modified_on": "2018-05-16T16:48:45.402Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0176854935,
+    "timestamp": "2018-05-16T16:48:45.402Z",
+    "source": "etherdelta",
+    "from_currency": "EOS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 10,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.405Z",
+    "modified_on": "2018-05-16T16:48:45.405Z",
+    "from_amount": 0.0176854935,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.402Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EOS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 11,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.407Z",
+    "modified_on": "2018-05-16T16:48:45.407Z",
+    "from_amount": 56.5435168659557,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.402Z",
+    "source": "etherdelta",
+    "from_currency": "EOS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 12,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.413Z",
+    "modified_on": "2018-05-16T16:48:45.413Z",
+    "from_amount": 1.0,
+    "to_amount": 3.5e-07,
+    "timestamp": "2018-05-16T16:48:45.413Z",
+    "source": "etherdelta",
+    "from_currency": "KIN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 13,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.416Z",
+    "modified_on": "2018-05-16T16:48:45.416Z",
+    "from_amount": 3.5e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.413Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "KIN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 14,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.418Z",
+    "modified_on": "2018-05-16T16:48:45.418Z",
+    "from_amount": 2857142.85714286,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.413Z",
+    "source": "etherdelta",
+    "from_currency": "KIN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 15,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.421Z",
+    "modified_on": "2018-05-16T16:48:45.421Z",
+    "from_amount": 1.0,
+    "to_amount": 0.022955,
+    "timestamp": "2018-05-16T16:48:45.421Z",
+    "source": "etherdelta",
+    "from_currency": "PPT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 16,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.424Z",
+    "modified_on": "2018-05-16T16:48:45.424Z",
+    "from_amount": 0.022955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.421Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PPT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 17,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.428Z",
+    "modified_on": "2018-05-16T16:48:45.428Z",
+    "from_amount": 43.5634937922021,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.421Z",
+    "source": "etherdelta",
+    "from_currency": "PPT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 18,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.432Z",
+    "modified_on": "2018-05-16T16:48:45.432Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001135497,
+    "timestamp": "2018-05-16T16:48:45.432Z",
+    "source": "etherdelta",
+    "from_currency": "PPP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 19,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.435Z",
+    "modified_on": "2018-05-16T16:48:45.435Z",
+    "from_amount": 0.001135497,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.432Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PPP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 20,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.438Z",
+    "modified_on": "2018-05-16T16:48:45.438Z",
+    "from_amount": 880.671635416034,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.432Z",
+    "source": "etherdelta",
+    "from_currency": "PPP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 21,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.441Z",
+    "modified_on": "2018-05-16T16:48:45.441Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001815005,
+    "timestamp": "2018-05-16T16:48:45.441Z",
+    "source": "etherdelta",
+    "from_currency": "SER",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 22,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.447Z",
+    "modified_on": "2018-05-16T16:48:45.447Z",
+    "from_amount": 0.0001815005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.441Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SER"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 23,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.450Z",
+    "modified_on": "2018-05-16T16:48:45.450Z",
+    "from_amount": 5509.62669524326,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.441Z",
+    "source": "etherdelta",
+    "from_currency": "SER",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 24,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.453Z",
+    "modified_on": "2018-05-16T16:48:45.453Z",
+    "from_amount": 1.0,
+    "to_amount": 1.7999e-05,
+    "timestamp": "2018-05-16T16:48:45.453Z",
+    "source": "etherdelta",
+    "from_currency": "0xebbd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 25,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.457Z",
+    "modified_on": "2018-05-16T16:48:45.457Z",
+    "from_amount": 1.7999e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.453Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xebbd"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 26,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.463Z",
+    "modified_on": "2018-05-16T16:48:45.463Z",
+    "from_amount": 55558.6421467859,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.453Z",
+    "source": "etherdelta",
+    "from_currency": "0xebbd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 27,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.467Z",
+    "modified_on": "2018-05-16T16:48:45.467Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004799445,
+    "timestamp": "2018-05-16T16:48:45.467Z",
+    "source": "etherdelta",
+    "from_currency": "0x12b3",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 28,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.470Z",
+    "modified_on": "2018-05-16T16:48:45.471Z",
+    "from_amount": 0.0004799445,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.467Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x12b3"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 29,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.473Z",
+    "modified_on": "2018-05-16T16:48:45.473Z",
+    "from_amount": 2083.5742466056,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.467Z",
+    "source": "etherdelta",
+    "from_currency": "0x12b3",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 30,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.478Z",
+    "modified_on": "2018-05-16T16:48:45.478Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001705,
+    "timestamp": "2018-05-16T16:48:45.478Z",
+    "source": "etherdelta",
+    "from_currency": "WTT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 31,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.482Z",
+    "modified_on": "2018-05-16T16:48:45.482Z",
+    "from_amount": 0.001705,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.478Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WTT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 32,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.485Z",
+    "modified_on": "2018-05-16T16:48:45.485Z",
+    "from_amount": 586.510263929619,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.478Z",
+    "source": "etherdelta",
+    "from_currency": "WTT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 33,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.489Z",
+    "modified_on": "2018-05-16T16:48:45.489Z",
+    "from_amount": 0.001705,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.478Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WTT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 34,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.493Z",
+    "modified_on": "2018-05-16T16:48:45.493Z",
+    "from_amount": 1.0,
+    "to_amount": 3.145e-05,
+    "timestamp": "2018-05-16T16:48:45.493Z",
+    "source": "etherdelta",
+    "from_currency": "0x3c4a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 35,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.499Z",
+    "modified_on": "2018-05-16T16:48:45.499Z",
+    "from_amount": 3.145e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.493Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3c4a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 36,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.501Z",
+    "modified_on": "2018-05-16T16:48:45.501Z",
+    "from_amount": 31796.5023847377,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.493Z",
+    "source": "etherdelta",
+    "from_currency": "0x3c4a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 37,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.504Z",
+    "modified_on": "2018-05-16T16:48:45.504Z",
+    "from_amount": 1.0,
+    "to_amount": 3.95035e-05,
+    "timestamp": "2018-05-16T16:48:45.504Z",
+    "source": "etherdelta",
+    "from_currency": "0x8d80",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 38,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.507Z",
+    "modified_on": "2018-05-16T16:48:45.507Z",
+    "from_amount": 3.95035e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.504Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8d80"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 39,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.512Z",
+    "modified_on": "2018-05-16T16:48:45.512Z",
+    "from_amount": 25314.2126647006,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.504Z",
+    "source": "etherdelta",
+    "from_currency": "0x8d80",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 40,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.516Z",
+    "modified_on": "2018-05-16T16:48:45.516Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000353944,
+    "timestamp": "2018-05-16T16:48:45.516Z",
+    "source": "etherdelta",
+    "from_currency": "0x3883",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 41,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.520Z",
+    "modified_on": "2018-05-16T16:48:45.520Z",
+    "from_amount": 0.000353944,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.516Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3883"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 42,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.523Z",
+    "modified_on": "2018-05-16T16:48:45.523Z",
+    "from_amount": 2825.30569807653,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.516Z",
+    "source": "etherdelta",
+    "from_currency": "0x3883",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 43,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.529Z",
+    "modified_on": "2018-05-16T16:48:45.529Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004013495,
+    "timestamp": "2018-05-16T16:48:45.529Z",
+    "source": "etherdelta",
+    "from_currency": "PLR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 44,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.533Z",
+    "modified_on": "2018-05-16T16:48:45.533Z",
+    "from_amount": 0.0004013495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.529Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PLR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 45,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.536Z",
+    "modified_on": "2018-05-16T16:48:45.536Z",
+    "from_amount": 2491.5939847938,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.529Z",
+    "source": "etherdelta",
+    "from_currency": "PLR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 46,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.538Z",
+    "modified_on": "2018-05-16T16:48:45.538Z",
+    "from_amount": 0.0004013495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.529Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PLR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 47,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.546Z",
+    "modified_on": "2018-05-16T16:48:45.546Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000221,
+    "timestamp": "2018-05-16T16:48:45.546Z",
+    "source": "etherdelta",
+    "from_currency": "XRL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 48,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.556Z",
+    "modified_on": "2018-05-16T16:48:45.556Z",
+    "from_amount": 0.000221,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.546Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "XRL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 49,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.558Z",
+    "modified_on": "2018-05-16T16:48:45.558Z",
+    "from_amount": 4524.88687782805,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.546Z",
+    "source": "etherdelta",
+    "from_currency": "XRL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 50,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.560Z",
+    "modified_on": "2018-05-16T16:48:45.561Z",
+    "from_amount": 0.000221,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.546Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "XRL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 51,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.565Z",
+    "modified_on": "2018-05-16T16:48:45.565Z",
+    "from_amount": 1.0,
+    "to_amount": 1.05e-06,
+    "timestamp": "2018-05-16T16:48:45.565Z",
+    "source": "etherdelta",
+    "from_currency": "0x8e56",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 52,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.568Z",
+    "modified_on": "2018-05-16T16:48:45.569Z",
+    "from_amount": 1.05e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.565Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8e56"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 53,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.571Z",
+    "modified_on": "2018-05-16T16:48:45.571Z",
+    "from_amount": 952380.952380952,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.565Z",
+    "source": "etherdelta",
+    "from_currency": "0x8e56",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 54,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.574Z",
+    "modified_on": "2018-05-16T16:48:45.574Z",
+    "from_amount": 1.0,
+    "to_amount": 9.7495e-06,
+    "timestamp": "2018-05-16T16:48:45.574Z",
+    "source": "etherdelta",
+    "from_currency": "RLX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 55,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.586Z",
+    "modified_on": "2018-05-16T16:48:45.587Z",
+    "from_amount": 9.7495e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.574Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "RLX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 56,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.589Z",
+    "modified_on": "2018-05-16T16:48:45.589Z",
+    "from_amount": 102569.362531412,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.574Z",
+    "source": "etherdelta",
+    "from_currency": "RLX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 57,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.594Z",
+    "modified_on": "2018-05-16T16:48:45.594Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002103005,
+    "timestamp": "2018-05-16T16:48:45.594Z",
+    "source": "etherdelta",
+    "from_currency": "PAY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 58,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.598Z",
+    "modified_on": "2018-05-16T16:48:45.598Z",
+    "from_amount": 0.002103005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.594Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PAY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 59,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.600Z",
+    "modified_on": "2018-05-16T16:48:45.600Z",
+    "from_amount": 475.510043960904,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.594Z",
+    "source": "etherdelta",
+    "from_currency": "PAY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 60,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.603Z",
+    "modified_on": "2018-05-16T16:48:45.603Z",
+    "from_amount": 1.0,
+    "to_amount": 1.095e-07,
+    "timestamp": "2018-05-16T16:48:45.603Z",
+    "source": "etherdelta",
+    "from_currency": "EXRN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 61,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.605Z",
+    "modified_on": "2018-05-16T16:48:45.605Z",
+    "from_amount": 1.095e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.603Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EXRN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 62,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.607Z",
+    "modified_on": "2018-05-16T16:48:45.607Z",
+    "from_amount": 9132420.0913242,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.603Z",
+    "source": "etherdelta",
+    "from_currency": "EXRN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 63,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.621Z",
+    "modified_on": "2018-05-16T16:48:45.621Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0195007615,
+    "timestamp": "2018-05-16T16:48:45.621Z",
+    "source": "etherdelta",
+    "from_currency": "OMG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 64,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.625Z",
+    "modified_on": "2018-05-16T16:48:45.625Z",
+    "from_amount": 0.0195007615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.621Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "OMG"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 65,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.628Z",
+    "modified_on": "2018-05-16T16:48:45.628Z",
+    "from_amount": 51.2800487304047,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.621Z",
+    "source": "etherdelta",
+    "from_currency": "OMG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 66,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.631Z",
+    "modified_on": "2018-05-16T16:48:45.631Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00070825,
+    "timestamp": "2018-05-16T16:48:45.631Z",
+    "source": "etherdelta",
+    "from_currency": "POWR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 67,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.633Z",
+    "modified_on": "2018-05-16T16:48:45.633Z",
+    "from_amount": 0.00070825,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.631Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "POWR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 68,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.635Z",
+    "modified_on": "2018-05-16T16:48:45.635Z",
+    "from_amount": 1411.93081539005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.631Z",
+    "source": "etherdelta",
+    "from_currency": "POWR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 69,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.638Z",
+    "modified_on": "2018-05-16T16:48:45.638Z",
+    "from_amount": 1.0,
+    "to_amount": 7.375e-05,
+    "timestamp": "2018-05-16T16:48:45.638Z",
+    "source": "etherdelta",
+    "from_currency": "0x0d62",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 70,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.642Z",
+    "modified_on": "2018-05-16T16:48:45.642Z",
+    "from_amount": 7.375e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.638Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0d62"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 71,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.651Z",
+    "modified_on": "2018-05-16T16:48:45.652Z",
+    "from_amount": 13559.3220338983,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.638Z",
+    "source": "etherdelta",
+    "from_currency": "0x0d62",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 72,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.656Z",
+    "modified_on": "2018-05-16T16:48:45.656Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000411015,
+    "timestamp": "2018-05-16T16:48:45.656Z",
+    "source": "etherdelta",
+    "from_currency": "INT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 73,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.662Z",
+    "modified_on": "2018-05-16T16:48:45.662Z",
+    "from_amount": 0.000411015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.656Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "INT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 74,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.664Z",
+    "modified_on": "2018-05-16T16:48:45.664Z",
+    "from_amount": 2433.00122866562,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.656Z",
+    "source": "etherdelta",
+    "from_currency": "INT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 75,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.666Z",
+    "modified_on": "2018-05-16T16:48:45.667Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00065,
+    "timestamp": "2018-05-16T16:48:45.667Z",
+    "source": "etherdelta",
+    "from_currency": "0x2c32",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 76,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.669Z",
+    "modified_on": "2018-05-16T16:48:45.669Z",
+    "from_amount": 0.00065,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.667Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2c32"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 77,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.672Z",
+    "modified_on": "2018-05-16T16:48:45.672Z",
+    "from_amount": 1538.46153846154,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.667Z",
+    "source": "etherdelta",
+    "from_currency": "0x2c32",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 78,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.678Z",
+    "modified_on": "2018-05-16T16:48:45.679Z",
+    "from_amount": 1.0,
+    "to_amount": 2e-05,
+    "timestamp": "2018-05-16T16:48:45.679Z",
+    "source": "etherdelta",
+    "from_currency": "0xe13e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 79,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.688Z",
+    "modified_on": "2018-05-16T16:48:45.688Z",
+    "from_amount": 2e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.679Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe13e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 80,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.691Z",
+    "modified_on": "2018-05-16T16:48:45.691Z",
+    "from_amount": 50000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.679Z",
+    "source": "etherdelta",
+    "from_currency": "0xe13e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 81,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.695Z",
+    "modified_on": "2018-05-16T16:48:45.695Z",
+    "from_amount": 1.0,
+    "to_amount": 0.430000004,
+    "timestamp": "2018-05-16T16:48:45.695Z",
+    "source": "etherdelta",
+    "from_currency": "0x4c0f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 82,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.699Z",
+    "modified_on": "2018-05-16T16:48:45.699Z",
+    "from_amount": 0.430000004,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.695Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4c0f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 83,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.701Z",
+    "modified_on": "2018-05-16T16:48:45.701Z",
+    "from_amount": 2.32558137371552,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.695Z",
+    "source": "etherdelta",
+    "from_currency": "0x4c0f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 84,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.705Z",
+    "modified_on": "2018-05-16T16:48:45.705Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00029475,
+    "timestamp": "2018-05-16T16:48:45.705Z",
+    "source": "etherdelta",
+    "from_currency": "ZAP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 85,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.713Z",
+    "modified_on": "2018-05-16T16:48:45.713Z",
+    "from_amount": 0.00029475,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.705Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ZAP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 86,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.723Z",
+    "modified_on": "2018-05-16T16:48:45.723Z",
+    "from_amount": 3392.70568278202,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.705Z",
+    "source": "etherdelta",
+    "from_currency": "ZAP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 87,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.727Z",
+    "modified_on": "2018-05-16T16:48:45.727Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001105,
+    "timestamp": "2018-05-16T16:48:45.727Z",
+    "source": "etherdelta",
+    "from_currency": "0x5a3c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 88,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.732Z",
+    "modified_on": "2018-05-16T16:48:45.732Z",
+    "from_amount": 0.0001105,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.727Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5a3c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 89,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.735Z",
+    "modified_on": "2018-05-16T16:48:45.735Z",
+    "from_amount": 9049.77375565611,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.727Z",
+    "source": "etherdelta",
+    "from_currency": "0x5a3c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 90,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.737Z",
+    "modified_on": "2018-05-16T16:48:45.737Z",
+    "from_amount": 0.0001105,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.727Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5a3c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 91,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.741Z",
+    "modified_on": "2018-05-16T16:48:45.741Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0022055,
+    "timestamp": "2018-05-16T16:48:45.741Z",
+    "source": "etherdelta",
+    "from_currency": "ZRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 92,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.751Z",
+    "modified_on": "2018-05-16T16:48:45.751Z",
+    "from_amount": 0.0022055,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.741Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ZRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 93,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.755Z",
+    "modified_on": "2018-05-16T16:48:45.755Z",
+    "from_amount": 453.41192473362,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.741Z",
+    "source": "etherdelta",
+    "from_currency": "ZRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 94,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.760Z",
+    "modified_on": "2018-05-16T16:48:45.760Z",
+    "from_amount": 1.0,
+    "to_amount": 1.2904e-05,
+    "timestamp": "2018-05-16T16:48:45.760Z",
+    "source": "etherdelta",
+    "from_currency": "0x3635",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 95,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.764Z",
+    "modified_on": "2018-05-16T16:48:45.764Z",
+    "from_amount": 1.2904e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.760Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3635"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 96,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.767Z",
+    "modified_on": "2018-05-16T16:48:45.767Z",
+    "from_amount": 77495.3502789833,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.760Z",
+    "source": "etherdelta",
+    "from_currency": "0x3635",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 97,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.772Z",
+    "modified_on": "2018-05-16T16:48:45.772Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000322499,
+    "timestamp": "2018-05-16T16:48:45.772Z",
+    "source": "etherdelta",
+    "from_currency": "0xb621",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 98,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.782Z",
+    "modified_on": "2018-05-16T16:48:45.782Z",
+    "from_amount": 0.000322499,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.772Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xb621"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 99,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.788Z",
+    "modified_on": "2018-05-16T16:48:45.788Z",
+    "from_amount": 3100.78480863507,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.772Z",
+    "source": "etherdelta",
+    "from_currency": "0xb621",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 100,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.793Z",
+    "modified_on": "2018-05-16T16:48:45.793Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002925,
+    "timestamp": "2018-05-16T16:48:45.793Z",
+    "source": "etherdelta",
+    "from_currency": "QSP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 101,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.798Z",
+    "modified_on": "2018-05-16T16:48:45.798Z",
+    "from_amount": 0.0002925,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.793Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "QSP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 102,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.801Z",
+    "modified_on": "2018-05-16T16:48:45.801Z",
+    "from_amount": 3418.80341880342,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.793Z",
+    "source": "etherdelta",
+    "from_currency": "QSP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 103,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.805Z",
+    "modified_on": "2018-05-16T16:48:45.805Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002208885,
+    "timestamp": "2018-05-16T16:48:45.805Z",
+    "source": "etherdelta",
+    "from_currency": "0x05f4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 104,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.814Z",
+    "modified_on": "2018-05-16T16:48:45.814Z",
+    "from_amount": 0.0002208885,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.805Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x05f4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 105,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.821Z",
+    "modified_on": "2018-05-16T16:48:45.821Z",
+    "from_amount": 4527.17094823859,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.805Z",
+    "source": "etherdelta",
+    "from_currency": "0x05f4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 106,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.825Z",
+    "modified_on": "2018-05-16T16:48:45.825Z",
+    "from_amount": 0.0002208885,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.805Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x05f4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 107,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.830Z",
+    "modified_on": "2018-05-16T16:48:45.830Z",
+    "from_amount": 1.0,
+    "to_amount": 0.500045,
+    "timestamp": "2018-05-16T16:48:45.830Z",
+    "source": "etherdelta",
+    "from_currency": "0xbbff",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 108,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.834Z",
+    "modified_on": "2018-05-16T16:48:45.834Z",
+    "from_amount": 0.500045,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.830Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xbbff"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 109,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.837Z",
+    "modified_on": "2018-05-16T16:48:45.837Z",
+    "from_amount": 1.99982001619854,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.830Z",
+    "source": "etherdelta",
+    "from_currency": "0xbbff",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 110,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.840Z",
+    "modified_on": "2018-05-16T16:48:45.840Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00129,
+    "timestamp": "2018-05-16T16:48:45.840Z",
+    "source": "etherdelta",
+    "from_currency": "BMC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 111,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.851Z",
+    "modified_on": "2018-05-16T16:48:45.851Z",
+    "from_amount": 0.00129,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.840Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BMC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 112,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.855Z",
+    "modified_on": "2018-05-16T16:48:45.855Z",
+    "from_amount": 775.193798449612,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.840Z",
+    "source": "etherdelta",
+    "from_currency": "BMC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 113,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.861Z",
+    "modified_on": "2018-05-16T16:48:45.861Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0265,
+    "timestamp": "2018-05-16T16:48:45.861Z",
+    "source": "etherdelta",
+    "from_currency": "0x89d2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 114,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.865Z",
+    "modified_on": "2018-05-16T16:48:45.865Z",
+    "from_amount": 0.0265,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.861Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x89d2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 115,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.868Z",
+    "modified_on": "2018-05-16T16:48:45.868Z",
+    "from_amount": 37.7358490566038,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.861Z",
+    "source": "etherdelta",
+    "from_currency": "0x89d2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 116,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.871Z",
+    "modified_on": "2018-05-16T16:48:45.871Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00049505,
+    "timestamp": "2018-05-16T16:48:45.871Z",
+    "source": "etherdelta",
+    "from_currency": "0xf406",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 117,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.874Z",
+    "modified_on": "2018-05-16T16:48:45.874Z",
+    "from_amount": 0.00049505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.871Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf406"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 118,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.887Z",
+    "modified_on": "2018-05-16T16:48:45.887Z",
+    "from_amount": 2019.99798000202,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.871Z",
+    "source": "etherdelta",
+    "from_currency": "0xf406",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 119,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.893Z",
+    "modified_on": "2018-05-16T16:48:45.893Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001075,
+    "timestamp": "2018-05-16T16:48:45.893Z",
+    "source": "etherdelta",
+    "from_currency": "0x5fc6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 120,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.898Z",
+    "modified_on": "2018-05-16T16:48:45.898Z",
+    "from_amount": 0.001075,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.893Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5fc6"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 121,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.901Z",
+    "modified_on": "2018-05-16T16:48:45.901Z",
+    "from_amount": 930.232558139535,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.893Z",
+    "source": "etherdelta",
+    "from_currency": "0x5fc6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 122,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.905Z",
+    "modified_on": "2018-05-16T16:48:45.905Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001220005,
+    "timestamp": "2018-05-16T16:48:45.905Z",
+    "source": "etherdelta",
+    "from_currency": "KICK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 123,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.916Z",
+    "modified_on": "2018-05-16T16:48:45.916Z",
+    "from_amount": 0.0001220005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.905Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "KICK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 124,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.924Z",
+    "modified_on": "2018-05-16T16:48:45.925Z",
+    "from_amount": 8196.68771849296,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.905Z",
+    "source": "etherdelta",
+    "from_currency": "KICK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 125,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.932Z",
+    "modified_on": "2018-05-16T16:48:45.932Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001565105,
+    "timestamp": "2018-05-16T16:48:45.932Z",
+    "source": "etherdelta",
+    "from_currency": "0x275b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 126,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.936Z",
+    "modified_on": "2018-05-16T16:48:45.937Z",
+    "from_amount": 0.0001565105,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.932Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x275b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 127,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.940Z",
+    "modified_on": "2018-05-16T16:48:45.940Z",
+    "from_amount": 6389.34767954866,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.932Z",
+    "source": "etherdelta",
+    "from_currency": "0x275b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 128,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.951Z",
+    "modified_on": "2018-05-16T16:48:45.952Z",
+    "from_amount": 1.0,
+    "to_amount": 9.82555e-05,
+    "timestamp": "2018-05-16T16:48:45.952Z",
+    "source": "etherdelta",
+    "from_currency": "TRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 129,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.959Z",
+    "modified_on": "2018-05-16T16:48:45.959Z",
+    "from_amount": 9.82555e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.952Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "TRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 130,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.964Z",
+    "modified_on": "2018-05-16T16:48:45.964Z",
+    "from_amount": 10177.5473128731,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.952Z",
+    "source": "etherdelta",
+    "from_currency": "TRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 131,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.968Z",
+    "modified_on": "2018-05-16T16:48:45.969Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000525,
+    "timestamp": "2018-05-16T16:48:45.968Z",
+    "source": "etherdelta",
+    "from_currency": "0xd780",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 132,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.973Z",
+    "modified_on": "2018-05-16T16:48:45.973Z",
+    "from_amount": 0.000525,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.968Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd780"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 133,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.987Z",
+    "modified_on": "2018-05-16T16:48:45.987Z",
+    "from_amount": 1904.7619047619,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.968Z",
+    "source": "etherdelta",
+    "from_currency": "0xd780",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 134,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.992Z",
+    "modified_on": "2018-05-16T16:48:45.992Z",
+    "from_amount": 1.0,
+    "to_amount": 6.7245e-06,
+    "timestamp": "2018-05-16T16:48:45.992Z",
+    "source": "etherdelta",
+    "from_currency": "0x351d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 135,
+  "fields": {
+    "created_on": "2018-05-16T16:48:45.998Z",
+    "modified_on": "2018-05-16T16:48:45.998Z",
+    "from_amount": 6.7245e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.992Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x351d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 136,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.001Z",
+    "modified_on": "2018-05-16T16:48:46.001Z",
+    "from_amount": 148709.941259573,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:45.992Z",
+    "source": "etherdelta",
+    "from_currency": "0x351d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 137,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.004Z",
+    "modified_on": "2018-05-16T16:48:46.004Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00040755,
+    "timestamp": "2018-05-16T16:48:46.004Z",
+    "source": "etherdelta",
+    "from_currency": "SONM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 138,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.012Z",
+    "modified_on": "2018-05-16T16:48:46.013Z",
+    "from_amount": 0.00040755,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.004Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SONM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 139,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.021Z",
+    "modified_on": "2018-05-16T16:48:46.021Z",
+    "from_amount": 2453.68666421298,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.004Z",
+    "source": "etherdelta",
+    "from_currency": "SONM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 140,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.026Z",
+    "modified_on": "2018-05-16T16:48:46.026Z",
+    "from_amount": 1.0,
+    "to_amount": 4.32e-05,
+    "timestamp": "2018-05-16T16:48:46.026Z",
+    "source": "etherdelta",
+    "from_currency": "MBRS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 141,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.031Z",
+    "modified_on": "2018-05-16T16:48:46.031Z",
+    "from_amount": 4.32e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.026Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MBRS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 142,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.035Z",
+    "modified_on": "2018-05-16T16:48:46.035Z",
+    "from_amount": 23148.1481481481,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.026Z",
+    "source": "etherdelta",
+    "from_currency": "MBRS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 143,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.039Z",
+    "modified_on": "2018-05-16T16:48:46.039Z",
+    "from_amount": 1.0,
+    "to_amount": 0.004475555,
+    "timestamp": "2018-05-16T16:48:46.039Z",
+    "source": "etherdelta",
+    "from_currency": "BCAP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 144,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.048Z",
+    "modified_on": "2018-05-16T16:48:46.048Z",
+    "from_amount": 0.004475555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.039Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BCAP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 145,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.055Z",
+    "modified_on": "2018-05-16T16:48:46.055Z",
+    "from_amount": 223.435976096819,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.039Z",
+    "source": "etherdelta",
+    "from_currency": "BCAP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 146,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.060Z",
+    "modified_on": "2018-05-16T16:48:46.060Z",
+    "from_amount": 1.0,
+    "to_amount": 6.5e-06,
+    "timestamp": "2018-05-16T16:48:46.060Z",
+    "source": "etherdelta",
+    "from_currency": "0x7e43",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 147,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.066Z",
+    "modified_on": "2018-05-16T16:48:46.066Z",
+    "from_amount": 6.5e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.060Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x7e43"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 148,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.069Z",
+    "modified_on": "2018-05-16T16:48:46.069Z",
+    "from_amount": 153846.153846154,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.060Z",
+    "source": "etherdelta",
+    "from_currency": "0x7e43",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 149,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.072Z",
+    "modified_on": "2018-05-16T16:48:46.072Z",
+    "from_amount": 1.0,
+    "to_amount": 6.1e-06,
+    "timestamp": "2018-05-16T16:48:46.072Z",
+    "source": "etherdelta",
+    "from_currency": "EDT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 150,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.081Z",
+    "modified_on": "2018-05-16T16:48:46.082Z",
+    "from_amount": 6.1e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.072Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 151,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.088Z",
+    "modified_on": "2018-05-16T16:48:46.088Z",
+    "from_amount": 163934.426229508,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.072Z",
+    "source": "etherdelta",
+    "from_currency": "EDT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 152,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.093Z",
+    "modified_on": "2018-05-16T16:48:46.093Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002884335,
+    "timestamp": "2018-05-16T16:48:46.093Z",
+    "source": "etherdelta",
+    "from_currency": "0xc27a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 153,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.098Z",
+    "modified_on": "2018-05-16T16:48:46.098Z",
+    "from_amount": 0.0002884335,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.093Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc27a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 154,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.101Z",
+    "modified_on": "2018-05-16T16:48:46.101Z",
+    "from_amount": 3467.00365942236,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.093Z",
+    "source": "etherdelta",
+    "from_currency": "0xc27a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 155,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.104Z",
+    "modified_on": "2018-05-16T16:48:46.104Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001269875,
+    "timestamp": "2018-05-16T16:48:46.104Z",
+    "source": "etherdelta",
+    "from_currency": "0x81be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 156,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.108Z",
+    "modified_on": "2018-05-16T16:48:46.108Z",
+    "from_amount": 0.0001269875,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.104Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x81be"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 157,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.121Z",
+    "modified_on": "2018-05-16T16:48:46.121Z",
+    "from_amount": 7874.79082586869,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.104Z",
+    "source": "etherdelta",
+    "from_currency": "0x81be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 158,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.127Z",
+    "modified_on": "2018-05-16T16:48:46.127Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000195,
+    "timestamp": "2018-05-16T16:48:46.127Z",
+    "source": "etherdelta",
+    "from_currency": "0xe25b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 159,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.132Z",
+    "modified_on": "2018-05-16T16:48:46.132Z",
+    "from_amount": 0.000195,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.127Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe25b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 160,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.135Z",
+    "modified_on": "2018-05-16T16:48:46.135Z",
+    "from_amount": 5128.20512820513,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.127Z",
+    "source": "etherdelta",
+    "from_currency": "0xe25b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 161,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.139Z",
+    "modified_on": "2018-05-16T16:48:46.139Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000525095,
+    "timestamp": "2018-05-16T16:48:46.139Z",
+    "source": "etherdelta",
+    "from_currency": "SPARTA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 162,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.151Z",
+    "modified_on": "2018-05-16T16:48:46.151Z",
+    "from_amount": 0.000525095,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.139Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SPARTA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 163,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.157Z",
+    "modified_on": "2018-05-16T16:48:46.157Z",
+    "from_amount": 1904.41729591788,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.139Z",
+    "source": "etherdelta",
+    "from_currency": "SPARTA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 164,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.162Z",
+    "modified_on": "2018-05-16T16:48:46.162Z",
+    "from_amount": 1.0,
+    "to_amount": 4.44785e-05,
+    "timestamp": "2018-05-16T16:48:46.162Z",
+    "source": "etherdelta",
+    "from_currency": "0x147b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 165,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.166Z",
+    "modified_on": "2018-05-16T16:48:46.166Z",
+    "from_amount": 4.44785e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.162Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x147b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 166,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.169Z",
+    "modified_on": "2018-05-16T16:48:46.169Z",
+    "from_amount": 22482.772575514,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.162Z",
+    "source": "etherdelta",
+    "from_currency": "0x147b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 167,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.172Z",
+    "modified_on": "2018-05-16T16:48:46.172Z",
+    "from_amount": 1.0,
+    "to_amount": 100.00004955,
+    "timestamp": "2018-05-16T16:48:46.172Z",
+    "source": "etherdelta",
+    "from_currency": "0xef24",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 168,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.177Z",
+    "modified_on": "2018-05-16T16:48:46.177Z",
+    "from_amount": 100.00004955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.172Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xef24"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 169,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.187Z",
+    "modified_on": "2018-05-16T16:48:46.187Z",
+    "from_amount": 0.00999999504500246,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.172Z",
+    "source": "etherdelta",
+    "from_currency": "0xef24",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 170,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.191Z",
+    "modified_on": "2018-05-16T16:48:46.191Z",
+    "from_amount": 100.00004955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.172Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xef24"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 171,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.197Z",
+    "modified_on": "2018-05-16T16:48:46.197Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001506,
+    "timestamp": "2018-05-16T16:48:46.197Z",
+    "source": "etherdelta",
+    "from_currency": "0xb6ed",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 172,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.201Z",
+    "modified_on": "2018-05-16T16:48:46.201Z",
+    "from_amount": 0.001506,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.197Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xb6ed"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 173,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.204Z",
+    "modified_on": "2018-05-16T16:48:46.204Z",
+    "from_amount": 664.010624169987,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.197Z",
+    "source": "etherdelta",
+    "from_currency": "0xb6ed",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 174,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.207Z",
+    "modified_on": "2018-05-16T16:48:46.207Z",
+    "from_amount": 1.0,
+    "to_amount": 9.2505e-06,
+    "timestamp": "2018-05-16T16:48:46.207Z",
+    "source": "etherdelta",
+    "from_currency": "ATS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 175,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.218Z",
+    "modified_on": "2018-05-16T16:48:46.218Z",
+    "from_amount": 9.2505e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.207Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ATS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 176,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.223Z",
+    "modified_on": "2018-05-16T16:48:46.224Z",
+    "from_amount": 108102.264742446,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.207Z",
+    "source": "etherdelta",
+    "from_currency": "ATS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 177,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.230Z",
+    "modified_on": "2018-05-16T16:48:46.230Z",
+    "from_amount": 1.0,
+    "to_amount": 6.60035e-05,
+    "timestamp": "2018-05-16T16:48:46.230Z",
+    "source": "etherdelta",
+    "from_currency": "0xd895",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 178,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.234Z",
+    "modified_on": "2018-05-16T16:48:46.234Z",
+    "from_amount": 6.60035e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.230Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd895"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 179,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.237Z",
+    "modified_on": "2018-05-16T16:48:46.237Z",
+    "from_amount": 15150.7117046823,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.230Z",
+    "source": "etherdelta",
+    "from_currency": "0xd895",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 180,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.241Z",
+    "modified_on": "2018-05-16T16:48:46.241Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000112225,
+    "timestamp": "2018-05-16T16:48:46.241Z",
+    "source": "etherdelta",
+    "from_currency": "LEND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 181,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.252Z",
+    "modified_on": "2018-05-16T16:48:46.253Z",
+    "from_amount": 0.000112225,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.241Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LEND"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 182,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.257Z",
+    "modified_on": "2018-05-16T16:48:46.257Z",
+    "from_amount": 8910.67052795723,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.241Z",
+    "source": "etherdelta",
+    "from_currency": "LEND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 183,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.263Z",
+    "modified_on": "2018-05-16T16:48:46.263Z",
+    "from_amount": 1.0,
+    "to_amount": 0.004726631,
+    "timestamp": "2018-05-16T16:48:46.263Z",
+    "source": "etherdelta",
+    "from_currency": "SALT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 184,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.267Z",
+    "modified_on": "2018-05-16T16:48:46.267Z",
+    "from_amount": 0.004726631,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.263Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SALT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 185,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.270Z",
+    "modified_on": "2018-05-16T16:48:46.270Z",
+    "from_amount": 211.567181783389,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.263Z",
+    "source": "etherdelta",
+    "from_currency": "SALT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 186,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.273Z",
+    "modified_on": "2018-05-16T16:48:46.273Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000325,
+    "timestamp": "2018-05-16T16:48:46.273Z",
+    "source": "etherdelta",
+    "from_currency": "RC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 187,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.281Z",
+    "modified_on": "2018-05-16T16:48:46.281Z",
+    "from_amount": 0.000325,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.273Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "RC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 188,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.288Z",
+    "modified_on": "2018-05-16T16:48:46.288Z",
+    "from_amount": 3076.92307692308,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.273Z",
+    "source": "etherdelta",
+    "from_currency": "RC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 189,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.293Z",
+    "modified_on": "2018-05-16T16:48:46.293Z",
+    "from_amount": 1.0,
+    "to_amount": 3.502e-05,
+    "timestamp": "2018-05-16T16:48:46.293Z",
+    "source": "etherdelta",
+    "from_currency": "0xc72f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 190,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.297Z",
+    "modified_on": "2018-05-16T16:48:46.297Z",
+    "from_amount": 3.502e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.293Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc72f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 191,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.300Z",
+    "modified_on": "2018-05-16T16:48:46.300Z",
+    "from_amount": 28555.1113649343,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.293Z",
+    "source": "etherdelta",
+    "from_currency": "0xc72f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 192,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.304Z",
+    "modified_on": "2018-05-16T16:48:46.304Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00120358,
+    "timestamp": "2018-05-16T16:48:46.304Z",
+    "source": "etherdelta",
+    "from_currency": "DRGN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 193,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.307Z",
+    "modified_on": "2018-05-16T16:48:46.307Z",
+    "from_amount": 0.00120358,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.304Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DRGN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 194,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.314Z",
+    "modified_on": "2018-05-16T16:48:46.314Z",
+    "from_amount": 830.854617059107,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.304Z",
+    "source": "etherdelta",
+    "from_currency": "DRGN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 195,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.325Z",
+    "modified_on": "2018-05-16T16:48:46.326Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00062,
+    "timestamp": "2018-05-16T16:48:46.326Z",
+    "source": "etherdelta",
+    "from_currency": "REAL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 196,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.330Z",
+    "modified_on": "2018-05-16T16:48:46.330Z",
+    "from_amount": 0.00062,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.326Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "REAL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 197,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.333Z",
+    "modified_on": "2018-05-16T16:48:46.333Z",
+    "from_amount": 1612.90322580645,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.326Z",
+    "source": "etherdelta",
+    "from_currency": "REAL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 198,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.337Z",
+    "modified_on": "2018-05-16T16:48:46.337Z",
+    "from_amount": 1.0,
+    "to_amount": 2.64445e-05,
+    "timestamp": "2018-05-16T16:48:46.337Z",
+    "source": "etherdelta",
+    "from_currency": "0x9c79",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 199,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.340Z",
+    "modified_on": "2018-05-16T16:48:46.340Z",
+    "from_amount": 2.64445e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.337Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9c79"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 200,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.344Z",
+    "modified_on": "2018-05-16T16:48:46.345Z",
+    "from_amount": 37815.0466070449,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.337Z",
+    "source": "etherdelta",
+    "from_currency": "0x9c79",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 201,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.355Z",
+    "modified_on": "2018-05-16T16:48:46.355Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002095995,
+    "timestamp": "2018-05-16T16:48:46.355Z",
+    "source": "etherdelta",
+    "from_currency": "MANA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 202,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.361Z",
+    "modified_on": "2018-05-16T16:48:46.361Z",
+    "from_amount": 0.0002095995,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.355Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MANA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 203,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.364Z",
+    "modified_on": "2018-05-16T16:48:46.364Z",
+    "from_amount": 4771.00374762344,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.355Z",
+    "source": "etherdelta",
+    "from_currency": "MANA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 204,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.368Z",
+    "modified_on": "2018-05-16T16:48:46.368Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00140015,
+    "timestamp": "2018-05-16T16:48:46.368Z",
+    "source": "etherdelta",
+    "from_currency": "0x9992",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 205,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.371Z",
+    "modified_on": "2018-05-16T16:48:46.371Z",
+    "from_amount": 0.00140015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.368Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9992"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 206,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.374Z",
+    "modified_on": "2018-05-16T16:48:46.374Z",
+    "from_amount": 714.209191872299,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.368Z",
+    "source": "etherdelta",
+    "from_currency": "0x9992",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 207,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.384Z",
+    "modified_on": "2018-05-16T16:48:46.384Z",
+    "from_amount": 1.0,
+    "to_amount": 3.176e-06,
+    "timestamp": "2018-05-16T16:48:46.384Z",
+    "source": "etherdelta",
+    "from_currency": "0x9a02",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 208,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.390Z",
+    "modified_on": "2018-05-16T16:48:46.390Z",
+    "from_amount": 3.176e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.384Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9a02"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 209,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.394Z",
+    "modified_on": "2018-05-16T16:48:46.394Z",
+    "from_amount": 314861.460957179,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.384Z",
+    "source": "etherdelta",
+    "from_currency": "0x9a02",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 210,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.398Z",
+    "modified_on": "2018-05-16T16:48:46.398Z",
+    "from_amount": 1.0,
+    "to_amount": 3e-05,
+    "timestamp": "2018-05-16T16:48:46.398Z",
+    "source": "etherdelta",
+    "from_currency": "XAI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 211,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.402Z",
+    "modified_on": "2018-05-16T16:48:46.402Z",
+    "from_amount": 3e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.398Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "XAI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 212,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.405Z",
+    "modified_on": "2018-05-16T16:48:46.405Z",
+    "from_amount": 33333.3333333333,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.398Z",
+    "source": "etherdelta",
+    "from_currency": "XAI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 213,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.408Z",
+    "modified_on": "2018-05-16T16:48:46.408Z",
+    "from_amount": 1.0,
+    "to_amount": 6.651e-05,
+    "timestamp": "2018-05-16T16:48:46.408Z",
+    "source": "etherdelta",
+    "from_currency": "VEE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 214,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.418Z",
+    "modified_on": "2018-05-16T16:48:46.418Z",
+    "from_amount": 6.651e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.408Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VEE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 215,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.423Z",
+    "modified_on": "2018-05-16T16:48:46.423Z",
+    "from_amount": 15035.3330326267,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.408Z",
+    "source": "etherdelta",
+    "from_currency": "VEE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 216,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.428Z",
+    "modified_on": "2018-05-16T16:48:46.428Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0012832885,
+    "timestamp": "2018-05-16T16:48:46.428Z",
+    "source": "etherdelta",
+    "from_currency": "0x80a7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 217,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.432Z",
+    "modified_on": "2018-05-16T16:48:46.432Z",
+    "from_amount": 0.0012832885,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.428Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x80a7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 218,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.435Z",
+    "modified_on": "2018-05-16T16:48:46.435Z",
+    "from_amount": 779.24800230034,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.428Z",
+    "source": "etherdelta",
+    "from_currency": "0x80a7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 219,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.439Z",
+    "modified_on": "2018-05-16T16:48:46.439Z",
+    "from_amount": 1.0,
+    "to_amount": 1.95105e-05,
+    "timestamp": "2018-05-16T16:48:46.439Z",
+    "source": "etherdelta",
+    "from_currency": "0xe34e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 220,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.445Z",
+    "modified_on": "2018-05-16T16:48:46.446Z",
+    "from_amount": 1.95105e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.439Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe34e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 221,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.455Z",
+    "modified_on": "2018-05-16T16:48:46.455Z",
+    "from_amount": 51254.452730581,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.439Z",
+    "source": "etherdelta",
+    "from_currency": "0xe34e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 222,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.460Z",
+    "modified_on": "2018-05-16T16:48:46.460Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00056495,
+    "timestamp": "2018-05-16T16:48:46.460Z",
+    "source": "etherdelta",
+    "from_currency": "BAT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 223,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.464Z",
+    "modified_on": "2018-05-16T16:48:46.464Z",
+    "from_amount": 0.00056495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.460Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BAT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 224,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.468Z",
+    "modified_on": "2018-05-16T16:48:46.468Z",
+    "from_amount": 1770.06814762368,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.460Z",
+    "source": "etherdelta",
+    "from_currency": "BAT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 225,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.473Z",
+    "modified_on": "2018-05-16T16:48:46.473Z",
+    "from_amount": 1.0,
+    "to_amount": 2.4e-05,
+    "timestamp": "2018-05-16T16:48:46.473Z",
+    "source": "etherdelta",
+    "from_currency": "GMT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 226,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.484Z",
+    "modified_on": "2018-05-16T16:48:46.484Z",
+    "from_amount": 2.4e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.473Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "GMT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 227,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.490Z",
+    "modified_on": "2018-05-16T16:48:46.490Z",
+    "from_amount": 41666.6666666667,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.473Z",
+    "source": "etherdelta",
+    "from_currency": "GMT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 228,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.495Z",
+    "modified_on": "2018-05-16T16:48:46.495Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0008301445,
+    "timestamp": "2018-05-16T16:48:46.495Z",
+    "source": "etherdelta",
+    "from_currency": "ERC20",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 229,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.499Z",
+    "modified_on": "2018-05-16T16:48:46.499Z",
+    "from_amount": 0.0008301445,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.495Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ERC20"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 230,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.502Z",
+    "modified_on": "2018-05-16T16:48:46.502Z",
+    "from_amount": 1204.60955893823,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.495Z",
+    "source": "etherdelta",
+    "from_currency": "ERC20",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 231,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.505Z",
+    "modified_on": "2018-05-16T16:48:46.506Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002525,
+    "timestamp": "2018-05-16T16:48:46.505Z",
+    "source": "etherdelta",
+    "from_currency": "ASTRO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 232,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.510Z",
+    "modified_on": "2018-05-16T16:48:46.510Z",
+    "from_amount": 0.002525,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.505Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ASTRO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 233,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.520Z",
+    "modified_on": "2018-05-16T16:48:46.521Z",
+    "from_amount": 396.039603960396,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.505Z",
+    "source": "etherdelta",
+    "from_currency": "ASTRO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 234,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.525Z",
+    "modified_on": "2018-05-16T16:48:46.525Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001424995,
+    "timestamp": "2018-05-16T16:48:46.525Z",
+    "source": "etherdelta",
+    "from_currency": "PFR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 235,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.531Z",
+    "modified_on": "2018-05-16T16:48:46.531Z",
+    "from_amount": 0.0001424995,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.525Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PFR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 236,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.534Z",
+    "modified_on": "2018-05-16T16:48:46.534Z",
+    "from_amount": 7017.56848269643,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.525Z",
+    "source": "etherdelta",
+    "from_currency": "PFR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 237,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.538Z",
+    "modified_on": "2018-05-16T16:48:46.538Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00295,
+    "timestamp": "2018-05-16T16:48:46.538Z",
+    "source": "etherdelta",
+    "from_currency": "ACC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 238,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.541Z",
+    "modified_on": "2018-05-16T16:48:46.542Z",
+    "from_amount": 0.00295,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.538Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ACC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 239,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.552Z",
+    "modified_on": "2018-05-16T16:48:46.552Z",
+    "from_amount": 338.983050847458,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.538Z",
+    "source": "etherdelta",
+    "from_currency": "ACC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 240,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.556Z",
+    "modified_on": "2018-05-16T16:48:46.556Z",
+    "from_amount": 0.00295,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.538Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ACC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 241,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.561Z",
+    "modified_on": "2018-05-16T16:48:46.561Z",
+    "from_amount": 1.0,
+    "to_amount": 1.3e-07,
+    "timestamp": "2018-05-16T16:48:46.561Z",
+    "source": "etherdelta",
+    "from_currency": "0x09d8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 242,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.566Z",
+    "modified_on": "2018-05-16T16:48:46.566Z",
+    "from_amount": 1.3e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.561Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x09d8"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 243,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.568Z",
+    "modified_on": "2018-05-16T16:48:46.568Z",
+    "from_amount": 7692307.69230769,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.561Z",
+    "source": "etherdelta",
+    "from_currency": "0x09d8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 244,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.572Z",
+    "modified_on": "2018-05-16T16:48:46.572Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001269,
+    "timestamp": "2018-05-16T16:48:46.572Z",
+    "source": "etherdelta",
+    "from_currency": "ADX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 245,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.575Z",
+    "modified_on": "2018-05-16T16:48:46.575Z",
+    "from_amount": 0.001269,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.572Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ADX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 246,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.590Z",
+    "modified_on": "2018-05-16T16:48:46.590Z",
+    "from_amount": 788.022064617809,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.572Z",
+    "source": "etherdelta",
+    "from_currency": "ADX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 247,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.597Z",
+    "modified_on": "2018-05-16T16:48:46.597Z",
+    "from_amount": 1.0,
+    "to_amount": 6.4e-05,
+    "timestamp": "2018-05-16T16:48:46.597Z",
+    "source": "etherdelta",
+    "from_currency": "0x6425",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 248,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.601Z",
+    "modified_on": "2018-05-16T16:48:46.601Z",
+    "from_amount": 6.4e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.597Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x6425"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 249,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.603Z",
+    "modified_on": "2018-05-16T16:48:46.603Z",
+    "from_amount": 15625.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.597Z",
+    "source": "etherdelta",
+    "from_currency": "0x6425",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 250,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.606Z",
+    "modified_on": "2018-05-16T16:48:46.606Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001525,
+    "timestamp": "2018-05-16T16:48:46.606Z",
+    "source": "etherdelta",
+    "from_currency": "SNGLS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 251,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.615Z",
+    "modified_on": "2018-05-16T16:48:46.615Z",
+    "from_amount": 0.0001525,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.606Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SNGLS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 252,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.622Z",
+    "modified_on": "2018-05-16T16:48:46.622Z",
+    "from_amount": 6557.37704918033,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.606Z",
+    "source": "etherdelta",
+    "from_currency": "SNGLS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 253,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.629Z",
+    "modified_on": "2018-05-16T16:48:46.629Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00442,
+    "timestamp": "2018-05-16T16:48:46.629Z",
+    "source": "etherdelta",
+    "from_currency": "0xd2fa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 254,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.633Z",
+    "modified_on": "2018-05-16T16:48:46.633Z",
+    "from_amount": 0.00442,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.629Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd2fa"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 255,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.636Z",
+    "modified_on": "2018-05-16T16:48:46.636Z",
+    "from_amount": 226.244343891403,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.629Z",
+    "source": "etherdelta",
+    "from_currency": "0xd2fa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 256,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.639Z",
+    "modified_on": "2018-05-16T16:48:46.640Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:46.640Z",
+    "source": "etherdelta",
+    "from_currency": "0x739a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 258,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.653Z",
+    "modified_on": "2018-05-16T16:48:46.653Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003715005,
+    "timestamp": "2018-05-16T16:48:46.653Z",
+    "source": "etherdelta",
+    "from_currency": "VIB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 259,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.659Z",
+    "modified_on": "2018-05-16T16:48:46.659Z",
+    "from_amount": 0.0003715005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.653Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VIB"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 260,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.663Z",
+    "modified_on": "2018-05-16T16:48:46.663Z",
+    "from_amount": 2691.78641751492,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.653Z",
+    "source": "etherdelta",
+    "from_currency": "VIB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 261,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.667Z",
+    "modified_on": "2018-05-16T16:48:46.667Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0019503125,
+    "timestamp": "2018-05-16T16:48:46.667Z",
+    "source": "etherdelta",
+    "from_currency": "MTX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 262,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.671Z",
+    "modified_on": "2018-05-16T16:48:46.672Z",
+    "from_amount": 0.0019503125,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.667Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MTX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 263,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.674Z",
+    "modified_on": "2018-05-16T16:48:46.675Z",
+    "from_amount": 512.738343214229,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.667Z",
+    "source": "etherdelta",
+    "from_currency": "MTX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 264,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.682Z",
+    "modified_on": "2018-05-16T16:48:46.682Z",
+    "from_amount": 0.0019503125,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.667Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MTX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 265,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.691Z",
+    "modified_on": "2018-05-16T16:48:46.691Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001495,
+    "timestamp": "2018-05-16T16:48:46.691Z",
+    "source": "etherdelta",
+    "from_currency": "0xb213",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 266,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.696Z",
+    "modified_on": "2018-05-16T16:48:46.696Z",
+    "from_amount": 0.0001495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.691Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xb213"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 267,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.699Z",
+    "modified_on": "2018-05-16T16:48:46.699Z",
+    "from_amount": 6688.96321070234,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.691Z",
+    "source": "etherdelta",
+    "from_currency": "0xb213",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 268,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.702Z",
+    "modified_on": "2018-05-16T16:48:46.703Z",
+    "from_amount": 1.0,
+    "to_amount": 8.83255e-05,
+    "timestamp": "2018-05-16T16:48:46.702Z",
+    "source": "etherdelta",
+    "from_currency": "EAGLE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 269,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.706Z",
+    "modified_on": "2018-05-16T16:48:46.706Z",
+    "from_amount": 8.83255e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.702Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EAGLE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 270,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.709Z",
+    "modified_on": "2018-05-16T16:48:46.710Z",
+    "from_amount": 11321.7587219999,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.702Z",
+    "source": "etherdelta",
+    "from_currency": "EAGLE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 271,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.724Z",
+    "modified_on": "2018-05-16T16:48:46.724Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0067345005,
+    "timestamp": "2018-05-16T16:48:46.724Z",
+    "source": "etherdelta",
+    "from_currency": "VEN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 272,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.732Z",
+    "modified_on": "2018-05-16T16:48:46.732Z",
+    "from_amount": 0.0067345005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.724Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VEN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 273,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.735Z",
+    "modified_on": "2018-05-16T16:48:46.735Z",
+    "from_amount": 148.489112147219,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.724Z",
+    "source": "etherdelta",
+    "from_currency": "VEN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 274,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.738Z",
+    "modified_on": "2018-05-16T16:48:46.738Z",
+    "from_amount": 0.0067345005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.724Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VEN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 275,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.743Z",
+    "modified_on": "2018-05-16T16:48:46.743Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003945,
+    "timestamp": "2018-05-16T16:48:46.743Z",
+    "source": "etherdelta",
+    "from_currency": "0x9231",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 276,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.756Z",
+    "modified_on": "2018-05-16T16:48:46.756Z",
+    "from_amount": 0.0003945,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.743Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9231"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 277,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.761Z",
+    "modified_on": "2018-05-16T16:48:46.761Z",
+    "from_amount": 2534.85424588086,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.743Z",
+    "source": "etherdelta",
+    "from_currency": "0x9231",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 278,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.766Z",
+    "modified_on": "2018-05-16T16:48:46.766Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003425,
+    "timestamp": "2018-05-16T16:48:46.766Z",
+    "source": "etherdelta",
+    "from_currency": "BLUE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 279,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.770Z",
+    "modified_on": "2018-05-16T16:48:46.771Z",
+    "from_amount": 0.0003425,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.766Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BLUE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 280,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.774Z",
+    "modified_on": "2018-05-16T16:48:46.774Z",
+    "from_amount": 2919.70802919708,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.766Z",
+    "source": "etherdelta",
+    "from_currency": "BLUE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 281,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.787Z",
+    "modified_on": "2018-05-16T16:48:46.787Z",
+    "from_amount": 1.0,
+    "to_amount": 1.055e-07,
+    "timestamp": "2018-05-16T16:48:46.787Z",
+    "source": "etherdelta",
+    "from_currency": "0x2859",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 282,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.793Z",
+    "modified_on": "2018-05-16T16:48:46.793Z",
+    "from_amount": 1.055e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.787Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2859"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 283,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.797Z",
+    "modified_on": "2018-05-16T16:48:46.797Z",
+    "from_amount": 9478672.98578199,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.787Z",
+    "source": "etherdelta",
+    "from_currency": "0x2859",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 284,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.802Z",
+    "modified_on": "2018-05-16T16:48:46.802Z",
+    "from_amount": 1.0,
+    "to_amount": 1.0545e-05,
+    "timestamp": "2018-05-16T16:48:46.802Z",
+    "source": "etherdelta",
+    "from_currency": "0x28de",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 285,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.807Z",
+    "modified_on": "2018-05-16T16:48:46.807Z",
+    "from_amount": 1.0545e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.802Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x28de"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 286,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.817Z",
+    "modified_on": "2018-05-16T16:48:46.818Z",
+    "from_amount": 94831.6737790422,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.802Z",
+    "source": "etherdelta",
+    "from_currency": "0x28de",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 287,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.826Z",
+    "modified_on": "2018-05-16T16:48:46.826Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00115,
+    "timestamp": "2018-05-16T16:48:46.826Z",
+    "source": "etherdelta",
+    "from_currency": "0x543f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 288,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.831Z",
+    "modified_on": "2018-05-16T16:48:46.831Z",
+    "from_amount": 0.00115,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.826Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x543f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 289,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.834Z",
+    "modified_on": "2018-05-16T16:48:46.834Z",
+    "from_amount": 869.565217391304,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.826Z",
+    "source": "etherdelta",
+    "from_currency": "0x543f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 290,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.839Z",
+    "modified_on": "2018-05-16T16:48:46.839Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000299,
+    "timestamp": "2018-05-16T16:48:46.839Z",
+    "source": "etherdelta",
+    "from_currency": "0xc148",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 291,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.845Z",
+    "modified_on": "2018-05-16T16:48:46.845Z",
+    "from_amount": 0.000299,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.839Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc148"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 292,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.855Z",
+    "modified_on": "2018-05-16T16:48:46.855Z",
+    "from_amount": 3344.48160535117,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.839Z",
+    "source": "etherdelta",
+    "from_currency": "0xc148",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 293,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.860Z",
+    "modified_on": "2018-05-16T16:48:46.860Z",
+    "from_amount": 1.0,
+    "to_amount": 0.005775,
+    "timestamp": "2018-05-16T16:48:46.860Z",
+    "source": "etherdelta",
+    "from_currency": "ENG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 294,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.864Z",
+    "modified_on": "2018-05-16T16:48:46.864Z",
+    "from_amount": 0.005775,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.860Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ENG"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 295,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.868Z",
+    "modified_on": "2018-05-16T16:48:46.868Z",
+    "from_amount": 173.160173160173,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.860Z",
+    "source": "etherdelta",
+    "from_currency": "ENG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 296,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.872Z",
+    "modified_on": "2018-05-16T16:48:46.873Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003175,
+    "timestamp": "2018-05-16T16:48:46.872Z",
+    "source": "etherdelta",
+    "from_currency": "EMV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 297,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.882Z",
+    "modified_on": "2018-05-16T16:48:46.882Z",
+    "from_amount": 0.0003175,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.872Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EMV"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 298,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.889Z",
+    "modified_on": "2018-05-16T16:48:46.889Z",
+    "from_amount": 3149.6062992126,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.872Z",
+    "source": "etherdelta",
+    "from_currency": "EMV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 299,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.893Z",
+    "modified_on": "2018-05-16T16:48:46.893Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00018,
+    "timestamp": "2018-05-16T16:48:46.893Z",
+    "source": "etherdelta",
+    "from_currency": "ATL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 300,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.898Z",
+    "modified_on": "2018-05-16T16:48:46.898Z",
+    "from_amount": 0.00018,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.893Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ATL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 301,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.901Z",
+    "modified_on": "2018-05-16T16:48:46.901Z",
+    "from_amount": 5555.55555555556,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.893Z",
+    "source": "etherdelta",
+    "from_currency": "ATL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 302,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.904Z",
+    "modified_on": "2018-05-16T16:48:46.904Z",
+    "from_amount": 0.00018,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.893Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ATL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 303,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.908Z",
+    "modified_on": "2018-05-16T16:48:46.908Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000152739,
+    "timestamp": "2018-05-16T16:48:46.908Z",
+    "source": "etherdelta",
+    "from_currency": "0x5629",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 304,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.920Z",
+    "modified_on": "2018-05-16T16:48:46.921Z",
+    "from_amount": 0.000152739,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.908Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5629"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 305,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.925Z",
+    "modified_on": "2018-05-16T16:48:46.925Z",
+    "from_amount": 6547.1163226157,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.908Z",
+    "source": "etherdelta",
+    "from_currency": "0x5629",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 306,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.930Z",
+    "modified_on": "2018-05-16T16:48:46.931Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0017,
+    "timestamp": "2018-05-16T16:48:46.931Z",
+    "source": "etherdelta",
+    "from_currency": "WABI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 307,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.935Z",
+    "modified_on": "2018-05-16T16:48:46.935Z",
+    "from_amount": 0.0017,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.931Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WABI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 308,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.939Z",
+    "modified_on": "2018-05-16T16:48:46.939Z",
+    "from_amount": 588.235294117647,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.931Z",
+    "source": "etherdelta",
+    "from_currency": "WABI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 309,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.942Z",
+    "modified_on": "2018-05-16T16:48:46.942Z",
+    "from_amount": 0.0017,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.931Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WABI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 310,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.957Z",
+    "modified_on": "2018-05-16T16:48:46.957Z",
+    "from_amount": 1.0,
+    "to_amount": 9e-05,
+    "timestamp": "2018-05-16T16:48:46.957Z",
+    "source": "etherdelta",
+    "from_currency": "0x5f53",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 311,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.964Z",
+    "modified_on": "2018-05-16T16:48:46.964Z",
+    "from_amount": 9e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.957Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5f53"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 312,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.968Z",
+    "modified_on": "2018-05-16T16:48:46.968Z",
+    "from_amount": 11111.1111111111,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.957Z",
+    "source": "etherdelta",
+    "from_currency": "0x5f53",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 313,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.972Z",
+    "modified_on": "2018-05-16T16:48:46.972Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00135,
+    "timestamp": "2018-05-16T16:48:46.972Z",
+    "source": "etherdelta",
+    "from_currency": "HBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 314,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.977Z",
+    "modified_on": "2018-05-16T16:48:46.977Z",
+    "from_amount": 0.00135,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.972Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "HBT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 315,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.988Z",
+    "modified_on": "2018-05-16T16:48:46.989Z",
+    "from_amount": 740.740740740741,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.972Z",
+    "source": "etherdelta",
+    "from_currency": "HBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 316,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.994Z",
+    "modified_on": "2018-05-16T16:48:46.994Z",
+    "from_amount": 1.0,
+    "to_amount": 0.006577705,
+    "timestamp": "2018-05-16T16:48:46.994Z",
+    "source": "etherdelta",
+    "from_currency": "TAAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 317,
+  "fields": {
+    "created_on": "2018-05-16T16:48:46.999Z",
+    "modified_on": "2018-05-16T16:48:46.999Z",
+    "from_amount": 0.006577705,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.994Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "TAAS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 318,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.002Z",
+    "modified_on": "2018-05-16T16:48:47.002Z",
+    "from_amount": 152.028709101427,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:46.994Z",
+    "source": "etherdelta",
+    "from_currency": "TAAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 319,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.005Z",
+    "modified_on": "2018-05-16T16:48:47.005Z",
+    "from_amount": 1.0,
+    "to_amount": 2.99e-07,
+    "timestamp": "2018-05-16T16:48:47.005Z",
+    "source": "etherdelta",
+    "from_currency": "DOM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 320,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.009Z",
+    "modified_on": "2018-05-16T16:48:47.009Z",
+    "from_amount": 2.99e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.005Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DOM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 321,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.019Z",
+    "modified_on": "2018-05-16T16:48:47.019Z",
+    "from_amount": 3344481.60535117,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.005Z",
+    "source": "etherdelta",
+    "from_currency": "DOM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 322,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.025Z",
+    "modified_on": "2018-05-16T16:48:47.025Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004296,
+    "timestamp": "2018-05-16T16:48:47.025Z",
+    "source": "etherdelta",
+    "from_currency": "0x39bb",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 323,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.030Z",
+    "modified_on": "2018-05-16T16:48:47.030Z",
+    "from_amount": 0.0004296,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.025Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x39bb"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 324,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.033Z",
+    "modified_on": "2018-05-16T16:48:47.033Z",
+    "from_amount": 2327.74674115456,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.025Z",
+    "source": "etherdelta",
+    "from_currency": "0x39bb",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 325,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.036Z",
+    "modified_on": "2018-05-16T16:48:47.036Z",
+    "from_amount": 0.0004296,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.025Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x39bb"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 326,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.040Z",
+    "modified_on": "2018-05-16T16:48:47.040Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00013365,
+    "timestamp": "2018-05-16T16:48:47.040Z",
+    "source": "etherdelta",
+    "from_currency": "EBCH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 327,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.048Z",
+    "modified_on": "2018-05-16T16:48:47.049Z",
+    "from_amount": 0.00013365,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.040Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EBCH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 328,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.056Z",
+    "modified_on": "2018-05-16T16:48:47.056Z",
+    "from_amount": 7482.22970445193,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.040Z",
+    "source": "etherdelta",
+    "from_currency": "EBCH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 329,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.061Z",
+    "modified_on": "2018-05-16T16:48:47.061Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000225,
+    "timestamp": "2018-05-16T16:48:47.061Z",
+    "source": "etherdelta",
+    "from_currency": "DOVU",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 330,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.066Z",
+    "modified_on": "2018-05-16T16:48:47.066Z",
+    "from_amount": 0.000225,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.061Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DOVU"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 331,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.069Z",
+    "modified_on": "2018-05-16T16:48:47.069Z",
+    "from_amount": 4444.44444444444,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.061Z",
+    "source": "etherdelta",
+    "from_currency": "DOVU",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 332,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.072Z",
+    "modified_on": "2018-05-16T16:48:47.072Z",
+    "from_amount": 1.0,
+    "to_amount": 8.85e-05,
+    "timestamp": "2018-05-16T16:48:47.072Z",
+    "source": "etherdelta",
+    "from_currency": "0xd0a4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 333,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.074Z",
+    "modified_on": "2018-05-16T16:48:47.074Z",
+    "from_amount": 8.85e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.072Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd0a4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 334,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.081Z",
+    "modified_on": "2018-05-16T16:48:47.081Z",
+    "from_amount": 11299.4350282486,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.072Z",
+    "source": "etherdelta",
+    "from_currency": "0xd0a4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 335,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.089Z",
+    "modified_on": "2018-05-16T16:48:47.089Z",
+    "from_amount": 1.0,
+    "to_amount": 1.0133e-05,
+    "timestamp": "2018-05-16T16:48:47.089Z",
+    "source": "etherdelta",
+    "from_currency": "0x5c3a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 336,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.093Z",
+    "modified_on": "2018-05-16T16:48:47.093Z",
+    "from_amount": 1.0133e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.089Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5c3a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 337,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.096Z",
+    "modified_on": "2018-05-16T16:48:47.096Z",
+    "from_amount": 98687.4568242376,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.089Z",
+    "source": "etherdelta",
+    "from_currency": "0x5c3a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 338,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.100Z",
+    "modified_on": "2018-05-16T16:48:47.100Z",
+    "from_amount": 1.0,
+    "to_amount": 1.41e-05,
+    "timestamp": "2018-05-16T16:48:47.100Z",
+    "source": "etherdelta",
+    "from_currency": "0x17f8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 339,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.104Z",
+    "modified_on": "2018-05-16T16:48:47.104Z",
+    "from_amount": 1.41e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.100Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x17f8"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 340,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.106Z",
+    "modified_on": "2018-05-16T16:48:47.106Z",
+    "from_amount": 70921.9858156028,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.100Z",
+    "source": "etherdelta",
+    "from_currency": "0x17f8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 341,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.110Z",
+    "modified_on": "2018-05-16T16:48:47.110Z",
+    "from_amount": 1.0,
+    "to_amount": 4.01e-05,
+    "timestamp": "2018-05-16T16:48:47.110Z",
+    "source": "etherdelta",
+    "from_currency": "SNOV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 342,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.122Z",
+    "modified_on": "2018-05-16T16:48:47.122Z",
+    "from_amount": 4.01e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.110Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SNOV"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 343,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.126Z",
+    "modified_on": "2018-05-16T16:48:47.126Z",
+    "from_amount": 24937.6558603491,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.110Z",
+    "source": "etherdelta",
+    "from_currency": "SNOV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 344,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.131Z",
+    "modified_on": "2018-05-16T16:48:47.131Z",
+    "from_amount": 1.0,
+    "to_amount": 3.075e-07,
+    "timestamp": "2018-05-16T16:48:47.131Z",
+    "source": "etherdelta",
+    "from_currency": "0xdb86",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 345,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.135Z",
+    "modified_on": "2018-05-16T16:48:47.135Z",
+    "from_amount": 3.075e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.131Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xdb86"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 346,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.137Z",
+    "modified_on": "2018-05-16T16:48:47.137Z",
+    "from_amount": 3252032.5203252,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.131Z",
+    "source": "etherdelta",
+    "from_currency": "0xdb86",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 347,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.140Z",
+    "modified_on": "2018-05-16T16:48:47.141Z",
+    "from_amount": 1.0,
+    "to_amount": 0.078,
+    "timestamp": "2018-05-16T16:48:47.140Z",
+    "source": "etherdelta",
+    "from_currency": "REP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 348,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.147Z",
+    "modified_on": "2018-05-16T16:48:47.148Z",
+    "from_amount": 0.078,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.140Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "REP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 349,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.155Z",
+    "modified_on": "2018-05-16T16:48:47.155Z",
+    "from_amount": 12.8205128205128,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.140Z",
+    "source": "etherdelta",
+    "from_currency": "REP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 350,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.160Z",
+    "modified_on": "2018-05-16T16:48:47.161Z",
+    "from_amount": 1.0,
+    "to_amount": 8.5536e-05,
+    "timestamp": "2018-05-16T16:48:47.160Z",
+    "source": "etherdelta",
+    "from_currency": "0x905e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 351,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.165Z",
+    "modified_on": "2018-05-16T16:48:47.165Z",
+    "from_amount": 8.5536e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.160Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x905e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 352,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.167Z",
+    "modified_on": "2018-05-16T16:48:47.167Z",
+    "from_amount": 11690.9839132061,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.160Z",
+    "source": "etherdelta",
+    "from_currency": "0x905e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 353,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.170Z",
+    "modified_on": "2018-05-16T16:48:47.170Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00061503,
+    "timestamp": "2018-05-16T16:48:47.170Z",
+    "source": "etherdelta",
+    "from_currency": "0x4524",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 354,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.173Z",
+    "modified_on": "2018-05-16T16:48:47.173Z",
+    "from_amount": 0.00061503,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.170Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4524"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 355,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.175Z",
+    "modified_on": "2018-05-16T16:48:47.176Z",
+    "from_amount": 1625.93694616523,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.170Z",
+    "source": "etherdelta",
+    "from_currency": "0x4524",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 356,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.186Z",
+    "modified_on": "2018-05-16T16:48:47.187Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0015349,
+    "timestamp": "2018-05-16T16:48:47.187Z",
+    "source": "etherdelta",
+    "from_currency": "0x4203",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 357,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.192Z",
+    "modified_on": "2018-05-16T16:48:47.192Z",
+    "from_amount": 0.0015349,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.187Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4203"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 358,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.196Z",
+    "modified_on": "2018-05-16T16:48:47.196Z",
+    "from_amount": 651.508241579256,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.187Z",
+    "source": "etherdelta",
+    "from_currency": "0x4203",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 359,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.201Z",
+    "modified_on": "2018-05-16T16:48:47.201Z",
+    "from_amount": 1.0,
+    "to_amount": 7.55005e-05,
+    "timestamp": "2018-05-16T16:48:47.201Z",
+    "source": "etherdelta",
+    "from_currency": "ONG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 360,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.206Z",
+    "modified_on": "2018-05-16T16:48:47.206Z",
+    "from_amount": 7.55005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.201Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ONG"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 361,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.210Z",
+    "modified_on": "2018-05-16T16:48:47.210Z",
+    "from_amount": 13244.9453977126,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.201Z",
+    "source": "etherdelta",
+    "from_currency": "ONG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 362,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.222Z",
+    "modified_on": "2018-05-16T16:48:47.222Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00011555,
+    "timestamp": "2018-05-16T16:48:47.222Z",
+    "source": "etherdelta",
+    "from_currency": "0x1829",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 363,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.228Z",
+    "modified_on": "2018-05-16T16:48:47.228Z",
+    "from_amount": 0.00011555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.222Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1829"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 364,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.232Z",
+    "modified_on": "2018-05-16T16:48:47.232Z",
+    "from_amount": 8654.26222414539,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.222Z",
+    "source": "etherdelta",
+    "from_currency": "0x1829",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 365,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.236Z",
+    "modified_on": "2018-05-16T16:48:47.236Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0025505,
+    "timestamp": "2018-05-16T16:48:47.236Z",
+    "source": "etherdelta",
+    "from_currency": "DICE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 366,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.240Z",
+    "modified_on": "2018-05-16T16:48:47.240Z",
+    "from_amount": 0.0025505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.236Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DICE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 367,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.243Z",
+    "modified_on": "2018-05-16T16:48:47.243Z",
+    "from_amount": 392.079984316801,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.236Z",
+    "source": "etherdelta",
+    "from_currency": "DICE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 368,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.255Z",
+    "modified_on": "2018-05-16T16:48:47.255Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002058,
+    "timestamp": "2018-05-16T16:48:47.255Z",
+    "source": "etherdelta",
+    "from_currency": "0xfdfe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 369,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.260Z",
+    "modified_on": "2018-05-16T16:48:47.260Z",
+    "from_amount": 0.0002058,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.255Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xfdfe"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 370,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.264Z",
+    "modified_on": "2018-05-16T16:48:47.264Z",
+    "from_amount": 4859.08649173955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.255Z",
+    "source": "etherdelta",
+    "from_currency": "0xfdfe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 371,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.267Z",
+    "modified_on": "2018-05-16T16:48:47.267Z",
+    "from_amount": 0.0002058,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.255Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xfdfe"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 372,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.271Z",
+    "modified_on": "2018-05-16T16:48:47.271Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001865,
+    "timestamp": "2018-05-16T16:48:47.271Z",
+    "source": "etherdelta",
+    "from_currency": "0xfae4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 373,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.275Z",
+    "modified_on": "2018-05-16T16:48:47.275Z",
+    "from_amount": 0.0001865,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.271Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xfae4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 374,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.284Z",
+    "modified_on": "2018-05-16T16:48:47.285Z",
+    "from_amount": 5361.93029490617,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.271Z",
+    "source": "etherdelta",
+    "from_currency": "0xfae4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 375,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.290Z",
+    "modified_on": "2018-05-16T16:48:47.291Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0149275005,
+    "timestamp": "2018-05-16T16:48:47.291Z",
+    "source": "etherdelta",
+    "from_currency": "0x358d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 376,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.296Z",
+    "modified_on": "2018-05-16T16:48:47.296Z",
+    "from_amount": 0.0149275005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.291Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x358d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 377,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.299Z",
+    "modified_on": "2018-05-16T16:48:47.299Z",
+    "from_amount": 66.9904516164645,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.291Z",
+    "source": "etherdelta",
+    "from_currency": "0x358d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 378,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.303Z",
+    "modified_on": "2018-05-16T16:48:47.303Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000126253,
+    "timestamp": "2018-05-16T16:48:47.303Z",
+    "source": "etherdelta",
+    "from_currency": "0xf3db",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 379,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.306Z",
+    "modified_on": "2018-05-16T16:48:47.306Z",
+    "from_amount": 0.000126253,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.303Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf3db"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 380,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.309Z",
+    "modified_on": "2018-05-16T16:48:47.309Z",
+    "from_amount": 7920.60386683881,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.303Z",
+    "source": "etherdelta",
+    "from_currency": "0xf3db",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 381,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.321Z",
+    "modified_on": "2018-05-16T16:48:47.321Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000300995,
+    "timestamp": "2018-05-16T16:48:47.321Z",
+    "source": "etherdelta",
+    "from_currency": "BBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 382,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.325Z",
+    "modified_on": "2018-05-16T16:48:47.325Z",
+    "from_amount": 0.000300995,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.321Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BBT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 383,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.329Z",
+    "modified_on": "2018-05-16T16:48:47.329Z",
+    "from_amount": 3322.31432415821,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.321Z",
+    "source": "etherdelta",
+    "from_currency": "BBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 384,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.333Z",
+    "modified_on": "2018-05-16T16:48:47.333Z",
+    "from_amount": 1.0,
+    "to_amount": 4.75e-05,
+    "timestamp": "2018-05-16T16:48:47.333Z",
+    "source": "etherdelta",
+    "from_currency": "0x1961",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 385,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.336Z",
+    "modified_on": "2018-05-16T16:48:47.336Z",
+    "from_amount": 4.75e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.333Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1961"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 386,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.339Z",
+    "modified_on": "2018-05-16T16:48:47.339Z",
+    "from_amount": 21052.6315789474,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.333Z",
+    "source": "etherdelta",
+    "from_currency": "0x1961",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 387,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.342Z",
+    "modified_on": "2018-05-16T16:48:47.342Z",
+    "from_amount": 1.0,
+    "to_amount": 1.14e-05,
+    "timestamp": "2018-05-16T16:48:47.342Z",
+    "source": "etherdelta",
+    "from_currency": "DENT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 388,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.351Z",
+    "modified_on": "2018-05-16T16:48:47.351Z",
+    "from_amount": 1.14e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.342Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DENT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 389,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.357Z",
+    "modified_on": "2018-05-16T16:48:47.357Z",
+    "from_amount": 87719.298245614,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.342Z",
+    "source": "etherdelta",
+    "from_currency": "DENT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 390,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.363Z",
+    "modified_on": "2018-05-16T16:48:47.363Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002615,
+    "timestamp": "2018-05-16T16:48:47.363Z",
+    "source": "etherdelta",
+    "from_currency": "0x910d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 391,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.368Z",
+    "modified_on": "2018-05-16T16:48:47.368Z",
+    "from_amount": 0.0002615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.363Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x910d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 392,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.371Z",
+    "modified_on": "2018-05-16T16:48:47.371Z",
+    "from_amount": 3824.09177820268,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.363Z",
+    "source": "etherdelta",
+    "from_currency": "0x910d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 393,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.374Z",
+    "modified_on": "2018-05-16T16:48:47.374Z",
+    "from_amount": 1.0,
+    "to_amount": 5.05e-06,
+    "timestamp": "2018-05-16T16:48:47.374Z",
+    "source": "etherdelta",
+    "from_currency": "0xf4fa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 394,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.386Z",
+    "modified_on": "2018-05-16T16:48:47.386Z",
+    "from_amount": 5.05e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.374Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf4fa"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 395,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.391Z",
+    "modified_on": "2018-05-16T16:48:47.391Z",
+    "from_amount": 198019.801980198,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.374Z",
+    "source": "etherdelta",
+    "from_currency": "0xf4fa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 396,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.396Z",
+    "modified_on": "2018-05-16T16:48:47.396Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000895,
+    "timestamp": "2018-05-16T16:48:47.396Z",
+    "source": "etherdelta",
+    "from_currency": "PGL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 397,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.401Z",
+    "modified_on": "2018-05-16T16:48:47.401Z",
+    "from_amount": 0.000895,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.396Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PGL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 398,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.405Z",
+    "modified_on": "2018-05-16T16:48:47.405Z",
+    "from_amount": 1117.31843575419,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.396Z",
+    "source": "etherdelta",
+    "from_currency": "PGL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 399,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.409Z",
+    "modified_on": "2018-05-16T16:48:47.409Z",
+    "from_amount": 1.0,
+    "to_amount": 3.05e-05,
+    "timestamp": "2018-05-16T16:48:47.409Z",
+    "source": "etherdelta",
+    "from_currency": "0x92a5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 400,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.420Z",
+    "modified_on": "2018-05-16T16:48:47.420Z",
+    "from_amount": 3.05e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.409Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x92a5"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 401,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.424Z",
+    "modified_on": "2018-05-16T16:48:47.424Z",
+    "from_amount": 32786.8852459016,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.409Z",
+    "source": "etherdelta",
+    "from_currency": "0x92a5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 402,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.428Z",
+    "modified_on": "2018-05-16T16:48:47.428Z",
+    "from_amount": 3.05e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.409Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x92a5"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 403,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.433Z",
+    "modified_on": "2018-05-16T16:48:47.433Z",
+    "from_amount": 1.0,
+    "to_amount": 9.144e-06,
+    "timestamp": "2018-05-16T16:48:47.433Z",
+    "source": "etherdelta",
+    "from_currency": "0x082e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 404,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.437Z",
+    "modified_on": "2018-05-16T16:48:47.437Z",
+    "from_amount": 9.144e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.433Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x082e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 405,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.440Z",
+    "modified_on": "2018-05-16T16:48:47.440Z",
+    "from_amount": 109361.329833771,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.433Z",
+    "source": "etherdelta",
+    "from_currency": "0x082e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 406,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.443Z",
+    "modified_on": "2018-05-16T16:48:47.444Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00250005,
+    "timestamp": "2018-05-16T16:48:47.444Z",
+    "source": "etherdelta",
+    "from_currency": "0xca48",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 407,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.456Z",
+    "modified_on": "2018-05-16T16:48:47.456Z",
+    "from_amount": 0.00250005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.444Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xca48"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 408,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.461Z",
+    "modified_on": "2018-05-16T16:48:47.461Z",
+    "from_amount": 399.992000159997,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.444Z",
+    "source": "etherdelta",
+    "from_currency": "0xca48",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 409,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.467Z",
+    "modified_on": "2018-05-16T16:48:47.467Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0025258,
+    "timestamp": "2018-05-16T16:48:47.467Z",
+    "source": "etherdelta",
+    "from_currency": "ETBS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 410,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.471Z",
+    "modified_on": "2018-05-16T16:48:47.471Z",
+    "from_amount": 0.0025258,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.467Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ETBS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 411,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.474Z",
+    "modified_on": "2018-05-16T16:48:47.474Z",
+    "from_amount": 395.914165808853,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.467Z",
+    "source": "etherdelta",
+    "from_currency": "ETBS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 412,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.477Z",
+    "modified_on": "2018-05-16T16:48:47.478Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000925015,
+    "timestamp": "2018-05-16T16:48:47.477Z",
+    "source": "etherdelta",
+    "from_currency": "SUB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 413,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.490Z",
+    "modified_on": "2018-05-16T16:48:47.490Z",
+    "from_amount": 0.000925015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.477Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SUB"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 414,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.493Z",
+    "modified_on": "2018-05-16T16:48:47.493Z",
+    "from_amount": 1081.06355032081,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.477Z",
+    "source": "etherdelta",
+    "from_currency": "SUB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 415,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.498Z",
+    "modified_on": "2018-05-16T16:48:47.499Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002002,
+    "timestamp": "2018-05-16T16:48:47.499Z",
+    "source": "etherdelta",
+    "from_currency": "0x98d4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 416,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.503Z",
+    "modified_on": "2018-05-16T16:48:47.503Z",
+    "from_amount": 0.002002,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.499Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x98d4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 417,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.505Z",
+    "modified_on": "2018-05-16T16:48:47.505Z",
+    "from_amount": 499.5004995005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.499Z",
+    "source": "etherdelta",
+    "from_currency": "0x98d4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 418,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.509Z",
+    "modified_on": "2018-05-16T16:48:47.509Z",
+    "from_amount": 1.0,
+    "to_amount": 8.125e-06,
+    "timestamp": "2018-05-16T16:48:47.509Z",
+    "source": "etherdelta",
+    "from_currency": "GEN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 419,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.520Z",
+    "modified_on": "2018-05-16T16:48:47.520Z",
+    "from_amount": 8.125e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.509Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "GEN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 420,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.524Z",
+    "modified_on": "2018-05-16T16:48:47.524Z",
+    "from_amount": 123076.923076923,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.509Z",
+    "source": "etherdelta",
+    "from_currency": "GEN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 421,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.529Z",
+    "modified_on": "2018-05-16T16:48:47.530Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0020745,
+    "timestamp": "2018-05-16T16:48:47.529Z",
+    "source": "etherdelta",
+    "from_currency": "0x26e7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 422,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.534Z",
+    "modified_on": "2018-05-16T16:48:47.534Z",
+    "from_amount": 0.0020745,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.529Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x26e7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 423,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.537Z",
+    "modified_on": "2018-05-16T16:48:47.537Z",
+    "from_amount": 482.043865991805,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.529Z",
+    "source": "etherdelta",
+    "from_currency": "0x26e7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 424,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.541Z",
+    "modified_on": "2018-05-16T16:48:47.541Z",
+    "from_amount": 1.0,
+    "to_amount": 1.395e-05,
+    "timestamp": "2018-05-16T16:48:47.541Z",
+    "source": "etherdelta",
+    "from_currency": "0xc509",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 425,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.550Z",
+    "modified_on": "2018-05-16T16:48:47.551Z",
+    "from_amount": 1.395e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.541Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc509"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 426,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.556Z",
+    "modified_on": "2018-05-16T16:48:47.557Z",
+    "from_amount": 71684.5878136201,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.541Z",
+    "source": "etherdelta",
+    "from_currency": "0xc509",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 427,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.560Z",
+    "modified_on": "2018-05-16T16:48:47.560Z",
+    "from_amount": 1.395e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.541Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc509"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 428,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.566Z",
+    "modified_on": "2018-05-16T16:48:47.566Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004206615,
+    "timestamp": "2018-05-16T16:48:47.566Z",
+    "source": "etherdelta",
+    "from_currency": "CMT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 429,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.570Z",
+    "modified_on": "2018-05-16T16:48:47.570Z",
+    "from_amount": 0.0004206615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.566Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CMT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 430,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.574Z",
+    "modified_on": "2018-05-16T16:48:47.574Z",
+    "from_amount": 2377.20827791467,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.566Z",
+    "source": "etherdelta",
+    "from_currency": "CMT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 431,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.583Z",
+    "modified_on": "2018-05-16T16:48:47.584Z",
+    "from_amount": 0.0004206615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.566Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CMT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 432,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.598Z",
+    "modified_on": "2018-05-16T16:48:47.598Z",
+    "from_amount": 1.0,
+    "to_amount": 3.55e-05,
+    "timestamp": "2018-05-16T16:48:47.598Z",
+    "source": "etherdelta",
+    "from_currency": "HQX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 433,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.605Z",
+    "modified_on": "2018-05-16T16:48:47.605Z",
+    "from_amount": 3.55e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.598Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "HQX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 434,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.609Z",
+    "modified_on": "2018-05-16T16:48:47.609Z",
+    "from_amount": 28169.014084507,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.598Z",
+    "source": "etherdelta",
+    "from_currency": "HQX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 435,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.631Z",
+    "modified_on": "2018-05-16T16:48:47.631Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002575,
+    "timestamp": "2018-05-16T16:48:47.631Z",
+    "source": "etherdelta",
+    "from_currency": "0x8542",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 436,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.640Z",
+    "modified_on": "2018-05-16T16:48:47.640Z",
+    "from_amount": 0.0002575,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.631Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8542"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 437,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.646Z",
+    "modified_on": "2018-05-16T16:48:47.646Z",
+    "from_amount": 3883.49514563107,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.631Z",
+    "source": "etherdelta",
+    "from_currency": "0x8542",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 438,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.651Z",
+    "modified_on": "2018-05-16T16:48:47.651Z",
+    "from_amount": 1.0,
+    "to_amount": 8.07e-06,
+    "timestamp": "2018-05-16T16:48:47.651Z",
+    "source": "etherdelta",
+    "from_currency": "10MT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 439,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.658Z",
+    "modified_on": "2018-05-16T16:48:47.659Z",
+    "from_amount": 8.07e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.651Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "10MT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 440,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.667Z",
+    "modified_on": "2018-05-16T16:48:47.667Z",
+    "from_amount": 123915.737298637,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.651Z",
+    "source": "etherdelta",
+    "from_currency": "10MT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 441,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.676Z",
+    "modified_on": "2018-05-16T16:48:47.676Z",
+    "from_amount": 1.0,
+    "to_amount": 1.63e-05,
+    "timestamp": "2018-05-16T16:48:47.676Z",
+    "source": "etherdelta",
+    "from_currency": "0xa15c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 442,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.684Z",
+    "modified_on": "2018-05-16T16:48:47.684Z",
+    "from_amount": 1.63e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.676Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa15c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 443,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.687Z",
+    "modified_on": "2018-05-16T16:48:47.687Z",
+    "from_amount": 61349.6932515337,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.676Z",
+    "source": "etherdelta",
+    "from_currency": "0xa15c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 444,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.691Z",
+    "modified_on": "2018-05-16T16:48:47.691Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003000005,
+    "timestamp": "2018-05-16T16:48:47.691Z",
+    "source": "etherdelta",
+    "from_currency": "0xafbe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 445,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.707Z",
+    "modified_on": "2018-05-16T16:48:47.707Z",
+    "from_amount": 0.0003000005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.691Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xafbe"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 446,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.713Z",
+    "modified_on": "2018-05-16T16:48:47.713Z",
+    "from_amount": 3333.32777778704,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.691Z",
+    "source": "etherdelta",
+    "from_currency": "0xafbe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 447,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.720Z",
+    "modified_on": "2018-05-16T16:48:47.720Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001600565,
+    "timestamp": "2018-05-16T16:48:47.720Z",
+    "source": "etherdelta",
+    "from_currency": "MTH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 448,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.726Z",
+    "modified_on": "2018-05-16T16:48:47.726Z",
+    "from_amount": 0.0001600565,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.720Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MTH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 449,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.738Z",
+    "modified_on": "2018-05-16T16:48:47.738Z",
+    "from_amount": 6247.7937478328,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.720Z",
+    "source": "etherdelta",
+    "from_currency": "MTH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 450,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.744Z",
+    "modified_on": "2018-05-16T16:48:47.744Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004245,
+    "timestamp": "2018-05-16T16:48:47.744Z",
+    "source": "etherdelta",
+    "from_currency": "0xf3b8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 451,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.751Z",
+    "modified_on": "2018-05-16T16:48:47.751Z",
+    "from_amount": 0.0004245,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.744Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf3b8"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 452,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.755Z",
+    "modified_on": "2018-05-16T16:48:47.755Z",
+    "from_amount": 2355.71260306243,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.744Z",
+    "source": "etherdelta",
+    "from_currency": "0xf3b8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 453,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.759Z",
+    "modified_on": "2018-05-16T16:48:47.759Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00295,
+    "timestamp": "2018-05-16T16:48:47.759Z",
+    "source": "etherdelta",
+    "from_currency": "0xdf99",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 454,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.773Z",
+    "modified_on": "2018-05-16T16:48:47.773Z",
+    "from_amount": 0.00295,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.759Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xdf99"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 455,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.776Z",
+    "modified_on": "2018-05-16T16:48:47.776Z",
+    "from_amount": 338.983050847458,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.759Z",
+    "source": "etherdelta",
+    "from_currency": "0xdf99",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 456,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.781Z",
+    "modified_on": "2018-05-16T16:48:47.781Z",
+    "from_amount": 0.00295,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.759Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xdf99"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 457,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.785Z",
+    "modified_on": "2018-05-16T16:48:47.785Z",
+    "from_amount": 1.0,
+    "to_amount": 9.29945e-05,
+    "timestamp": "2018-05-16T16:48:47.785Z",
+    "source": "etherdelta",
+    "from_currency": "0xc3af",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 458,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.788Z",
+    "modified_on": "2018-05-16T16:48:47.788Z",
+    "from_amount": 9.29945e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.785Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc3af"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 459,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.791Z",
+    "modified_on": "2018-05-16T16:48:47.791Z",
+    "from_amount": 10753.324121319,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.785Z",
+    "source": "etherdelta",
+    "from_currency": "0xc3af",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 460,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.793Z",
+    "modified_on": "2018-05-16T16:48:47.793Z",
+    "from_amount": 9.29945e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.785Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc3af"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 461,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.806Z",
+    "modified_on": "2018-05-16T16:48:47.806Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00013475,
+    "timestamp": "2018-05-16T16:48:47.806Z",
+    "source": "etherdelta",
+    "from_currency": "0x2a5c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 462,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.810Z",
+    "modified_on": "2018-05-16T16:48:47.810Z",
+    "from_amount": 0.00013475,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.806Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2a5c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 463,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.813Z",
+    "modified_on": "2018-05-16T16:48:47.813Z",
+    "from_amount": 7421.15027829314,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.806Z",
+    "source": "etherdelta",
+    "from_currency": "0x2a5c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 464,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.817Z",
+    "modified_on": "2018-05-16T16:48:47.817Z",
+    "from_amount": 1.0,
+    "to_amount": 1.1405000005,
+    "timestamp": "2018-05-16T16:48:47.817Z",
+    "source": "etherdelta",
+    "from_currency": "0x0560",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 465,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.820Z",
+    "modified_on": "2018-05-16T16:48:47.820Z",
+    "from_amount": 1.1405000005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.817Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0560"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 466,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.822Z",
+    "modified_on": "2018-05-16T16:48:47.822Z",
+    "from_amount": 0.87680841697641,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.817Z",
+    "source": "etherdelta",
+    "from_currency": "0x0560",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 467,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.825Z",
+    "modified_on": "2018-05-16T16:48:47.825Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0154500005,
+    "timestamp": "2018-05-16T16:48:47.825Z",
+    "source": "etherdelta",
+    "from_currency": "XHY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 468,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.832Z",
+    "modified_on": "2018-05-16T16:48:47.833Z",
+    "from_amount": 0.0154500005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.825Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "XHY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 469,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.840Z",
+    "modified_on": "2018-05-16T16:48:47.840Z",
+    "from_amount": 64.7249169991936,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.825Z",
+    "source": "etherdelta",
+    "from_currency": "XHY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 470,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.843Z",
+    "modified_on": "2018-05-16T16:48:47.844Z",
+    "from_amount": 0.0154500005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.825Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "XHY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 471,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.849Z",
+    "modified_on": "2018-05-16T16:48:47.850Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003,
+    "timestamp": "2018-05-16T16:48:47.849Z",
+    "source": "etherdelta",
+    "from_currency": "CSNO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 472,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.853Z",
+    "modified_on": "2018-05-16T16:48:47.853Z",
+    "from_amount": 0.0003,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.849Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CSNO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 473,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.856Z",
+    "modified_on": "2018-05-16T16:48:47.856Z",
+    "from_amount": 3333.33333333333,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.849Z",
+    "source": "etherdelta",
+    "from_currency": "CSNO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 474,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.859Z",
+    "modified_on": "2018-05-16T16:48:47.859Z",
+    "from_amount": 1.0,
+    "to_amount": 3.10005e-05,
+    "timestamp": "2018-05-16T16:48:47.859Z",
+    "source": "etherdelta",
+    "from_currency": "0x139d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 475,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.870Z",
+    "modified_on": "2018-05-16T16:48:47.871Z",
+    "from_amount": 3.10005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.859Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x139d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 476,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.875Z",
+    "modified_on": "2018-05-16T16:48:47.875Z",
+    "from_amount": 32257.5442331575,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.859Z",
+    "source": "etherdelta",
+    "from_currency": "0x139d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 477,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.879Z",
+    "modified_on": "2018-05-16T16:48:47.879Z",
+    "from_amount": 1.0,
+    "to_amount": 9.27885e-05,
+    "timestamp": "2018-05-16T16:48:47.879Z",
+    "source": "etherdelta",
+    "from_currency": "0xae73",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 478,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.884Z",
+    "modified_on": "2018-05-16T16:48:47.884Z",
+    "from_amount": 9.27885e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.879Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xae73"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 479,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.887Z",
+    "modified_on": "2018-05-16T16:48:47.887Z",
+    "from_amount": 10777.1976053067,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.879Z",
+    "source": "etherdelta",
+    "from_currency": "0xae73",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 480,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.890Z",
+    "modified_on": "2018-05-16T16:48:47.890Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0015295005,
+    "timestamp": "2018-05-16T16:48:47.890Z",
+    "source": "etherdelta",
+    "from_currency": "0xf833",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 481,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.897Z",
+    "modified_on": "2018-05-16T16:48:47.897Z",
+    "from_amount": 0.0015295005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.890Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf833"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 482,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.908Z",
+    "modified_on": "2018-05-16T16:48:47.908Z",
+    "from_amount": 653.808220396136,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.890Z",
+    "source": "etherdelta",
+    "from_currency": "0xf833",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 483,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.914Z",
+    "modified_on": "2018-05-16T16:48:47.914Z",
+    "from_amount": 1.0,
+    "to_amount": 3.705e-07,
+    "timestamp": "2018-05-16T16:48:47.914Z",
+    "source": "etherdelta",
+    "from_currency": "0x5d4d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 484,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.918Z",
+    "modified_on": "2018-05-16T16:48:47.918Z",
+    "from_amount": 3.705e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.914Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5d4d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 485,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.922Z",
+    "modified_on": "2018-05-16T16:48:47.922Z",
+    "from_amount": 2699055.33063428,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.914Z",
+    "source": "etherdelta",
+    "from_currency": "0x5d4d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 486,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.925Z",
+    "modified_on": "2018-05-16T16:48:47.925Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001220035,
+    "timestamp": "2018-05-16T16:48:47.925Z",
+    "source": "etherdelta",
+    "from_currency": "EPY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 487,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.935Z",
+    "modified_on": "2018-05-16T16:48:47.935Z",
+    "from_amount": 0.0001220035,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.925Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EPY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 488,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.942Z",
+    "modified_on": "2018-05-16T16:48:47.942Z",
+    "from_amount": 8196.48616638047,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.925Z",
+    "source": "etherdelta",
+    "from_currency": "EPY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 489,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.949Z",
+    "modified_on": "2018-05-16T16:48:47.949Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0055750005,
+    "timestamp": "2018-05-16T16:48:47.949Z",
+    "source": "etherdelta",
+    "from_currency": "ANT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 490,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.954Z",
+    "modified_on": "2018-05-16T16:48:47.954Z",
+    "from_amount": 0.0055750005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.949Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ANT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 491,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.958Z",
+    "modified_on": "2018-05-16T16:48:47.958Z",
+    "from_amount": 179.372181222226,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.949Z",
+    "source": "etherdelta",
+    "from_currency": "ANT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 492,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.961Z",
+    "modified_on": "2018-05-16T16:48:47.961Z",
+    "from_amount": 0.0055750005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.949Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ANT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 493,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.973Z",
+    "modified_on": "2018-05-16T16:48:47.973Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0005355,
+    "timestamp": "2018-05-16T16:48:47.973Z",
+    "source": "etherdelta",
+    "from_currency": "REX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 494,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.980Z",
+    "modified_on": "2018-05-16T16:48:47.980Z",
+    "from_amount": 0.0005355,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.973Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "REX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 495,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.984Z",
+    "modified_on": "2018-05-16T16:48:47.984Z",
+    "from_amount": 1867.41363211951,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.973Z",
+    "source": "etherdelta",
+    "from_currency": "REX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 496,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.988Z",
+    "modified_on": "2018-05-16T16:48:47.988Z",
+    "from_amount": 1.0,
+    "to_amount": 1.55e-05,
+    "timestamp": "2018-05-16T16:48:47.988Z",
+    "source": "etherdelta",
+    "from_currency": "0x2a09",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 497,
+  "fields": {
+    "created_on": "2018-05-16T16:48:47.992Z",
+    "modified_on": "2018-05-16T16:48:47.992Z",
+    "from_amount": 1.55e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.988Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2a09"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 498,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.003Z",
+    "modified_on": "2018-05-16T16:48:48.003Z",
+    "from_amount": 64516.1290322581,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:47.988Z",
+    "source": "etherdelta",
+    "from_currency": "0x2a09",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 499,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.009Z",
+    "modified_on": "2018-05-16T16:48:48.010Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0014,
+    "timestamp": "2018-05-16T16:48:48.010Z",
+    "source": "etherdelta",
+    "from_currency": "AUA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 500,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.015Z",
+    "modified_on": "2018-05-16T16:48:48.015Z",
+    "from_amount": 0.0014,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.010Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "AUA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 501,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.018Z",
+    "modified_on": "2018-05-16T16:48:48.018Z",
+    "from_amount": 714.285714285714,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.010Z",
+    "source": "etherdelta",
+    "from_currency": "AUA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 502,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.023Z",
+    "modified_on": "2018-05-16T16:48:48.023Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001250005,
+    "timestamp": "2018-05-16T16:48:48.023Z",
+    "source": "etherdelta",
+    "from_currency": "0x618e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 503,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.026Z",
+    "modified_on": "2018-05-16T16:48:48.026Z",
+    "from_amount": 0.001250005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.023Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x618e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 504,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.036Z",
+    "modified_on": "2018-05-16T16:48:48.036Z",
+    "from_amount": 799.9968000128,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.023Z",
+    "source": "etherdelta",
+    "from_currency": "0x618e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 505,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.043Z",
+    "modified_on": "2018-05-16T16:48:48.043Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001996,
+    "timestamp": "2018-05-16T16:48:48.043Z",
+    "source": "etherdelta",
+    "from_currency": "0x9b70",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 506,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.048Z",
+    "modified_on": "2018-05-16T16:48:48.048Z",
+    "from_amount": 0.0001996,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.043Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9b70"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 507,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.051Z",
+    "modified_on": "2018-05-16T16:48:48.051Z",
+    "from_amount": 5010.02004008016,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.043Z",
+    "source": "etherdelta",
+    "from_currency": "0x9b70",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 508,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.054Z",
+    "modified_on": "2018-05-16T16:48:48.054Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000982023,
+    "timestamp": "2018-05-16T16:48:48.054Z",
+    "source": "etherdelta",
+    "from_currency": "PRL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 509,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.057Z",
+    "modified_on": "2018-05-16T16:48:48.057Z",
+    "from_amount": 0.000982023,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.054Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PRL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 510,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.060Z",
+    "modified_on": "2018-05-16T16:48:48.060Z",
+    "from_amount": 1018.30608855393,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.054Z",
+    "source": "etherdelta",
+    "from_currency": "PRL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 511,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.073Z",
+    "modified_on": "2018-05-16T16:48:48.073Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000189497,
+    "timestamp": "2018-05-16T16:48:48.073Z",
+    "source": "etherdelta",
+    "from_currency": "EBTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 512,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.078Z",
+    "modified_on": "2018-05-16T16:48:48.078Z",
+    "from_amount": 0.000189497,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.073Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EBTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 513,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.083Z",
+    "modified_on": "2018-05-16T16:48:48.083Z",
+    "from_amount": 5277.12839781105,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.073Z",
+    "source": "etherdelta",
+    "from_currency": "EBTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 514,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.087Z",
+    "modified_on": "2018-05-16T16:48:48.087Z",
+    "from_amount": 1.0,
+    "to_amount": 3.0975e-05,
+    "timestamp": "2018-05-16T16:48:48.087Z",
+    "source": "etherdelta",
+    "from_currency": "EXMR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 515,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.090Z",
+    "modified_on": "2018-05-16T16:48:48.090Z",
+    "from_amount": 3.0975e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.087Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EXMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 516,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.093Z",
+    "modified_on": "2018-05-16T16:48:48.093Z",
+    "from_amount": 32284.1000807103,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.087Z",
+    "source": "etherdelta",
+    "from_currency": "EXMR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 517,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.105Z",
+    "modified_on": "2018-05-16T16:48:48.105Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-06,
+    "timestamp": "2018-05-16T16:48:48.105Z",
+    "source": "etherdelta",
+    "from_currency": "0x2ef1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 518,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.110Z",
+    "modified_on": "2018-05-16T16:48:48.110Z",
+    "from_amount": 5e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.105Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2ef1"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 519,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.114Z",
+    "modified_on": "2018-05-16T16:48:48.115Z",
+    "from_amount": 200000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.105Z",
+    "source": "etherdelta",
+    "from_currency": "0x2ef1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 520,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.118Z",
+    "modified_on": "2018-05-16T16:48:48.118Z",
+    "from_amount": 1.0,
+    "to_amount": 5.00005e-05,
+    "timestamp": "2018-05-16T16:48:48.118Z",
+    "source": "etherdelta",
+    "from_currency": "0x0df9",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 521,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.123Z",
+    "modified_on": "2018-05-16T16:48:48.123Z",
+    "from_amount": 5.00005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.118Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0df9"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 522,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.126Z",
+    "modified_on": "2018-05-16T16:48:48.126Z",
+    "from_amount": 19999.800002,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.118Z",
+    "source": "etherdelta",
+    "from_currency": "0x0df9",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 523,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.134Z",
+    "modified_on": "2018-05-16T16:48:48.135Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003540285,
+    "timestamp": "2018-05-16T16:48:48.134Z",
+    "source": "etherdelta",
+    "from_currency": "0x2c82",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 524,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.142Z",
+    "modified_on": "2018-05-16T16:48:48.142Z",
+    "from_amount": 0.0003540285,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.134Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2c82"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 525,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.146Z",
+    "modified_on": "2018-05-16T16:48:48.146Z",
+    "from_amount": 2824.63135030089,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.134Z",
+    "source": "etherdelta",
+    "from_currency": "0x2c82",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 526,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.151Z",
+    "modified_on": "2018-05-16T16:48:48.151Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0007100065,
+    "timestamp": "2018-05-16T16:48:48.151Z",
+    "source": "etherdelta",
+    "from_currency": "LINK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 527,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.155Z",
+    "modified_on": "2018-05-16T16:48:48.155Z",
+    "from_amount": 0.0007100065,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.151Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LINK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 528,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.158Z",
+    "modified_on": "2018-05-16T16:48:48.158Z",
+    "from_amount": 1408.43781007639,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.151Z",
+    "source": "etherdelta",
+    "from_currency": "LINK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 529,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.165Z",
+    "modified_on": "2018-05-16T16:48:48.165Z",
+    "from_amount": 1.0,
+    "to_amount": 1.8425e-05,
+    "timestamp": "2018-05-16T16:48:48.165Z",
+    "source": "etherdelta",
+    "from_currency": "NTWK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 530,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.174Z",
+    "modified_on": "2018-05-16T16:48:48.174Z",
+    "from_amount": 1.8425e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.165Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "NTWK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 531,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.178Z",
+    "modified_on": "2018-05-16T16:48:48.178Z",
+    "from_amount": 54274.0841248304,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.165Z",
+    "source": "etherdelta",
+    "from_currency": "NTWK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 532,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.183Z",
+    "modified_on": "2018-05-16T16:48:48.183Z",
+    "from_amount": 1.0,
+    "to_amount": 6.25075e-05,
+    "timestamp": "2018-05-16T16:48:48.183Z",
+    "source": "etherdelta",
+    "from_currency": "0x4672",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 533,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.188Z",
+    "modified_on": "2018-05-16T16:48:48.188Z",
+    "from_amount": 6.25075e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.183Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4672"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 534,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.192Z",
+    "modified_on": "2018-05-16T16:48:48.192Z",
+    "from_amount": 15998.0802303724,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.183Z",
+    "source": "etherdelta",
+    "from_currency": "0x4672",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 535,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.198Z",
+    "modified_on": "2018-05-16T16:48:48.199Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000665,
+    "timestamp": "2018-05-16T16:48:48.199Z",
+    "source": "etherdelta",
+    "from_currency": "0xf244",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 536,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.208Z",
+    "modified_on": "2018-05-16T16:48:48.209Z",
+    "from_amount": 0.000665,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.199Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf244"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 537,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.213Z",
+    "modified_on": "2018-05-16T16:48:48.213Z",
+    "from_amount": 1503.75939849624,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.199Z",
+    "source": "etherdelta",
+    "from_currency": "0xf244",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 538,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.217Z",
+    "modified_on": "2018-05-16T16:48:48.218Z",
+    "from_amount": 1.0,
+    "to_amount": 8.1615e-05,
+    "timestamp": "2018-05-16T16:48:48.217Z",
+    "source": "etherdelta",
+    "from_currency": "0xfeda",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 539,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.221Z",
+    "modified_on": "2018-05-16T16:48:48.221Z",
+    "from_amount": 8.1615e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.217Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xfeda"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 540,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.224Z",
+    "modified_on": "2018-05-16T16:48:48.224Z",
+    "from_amount": 12252.6496354837,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.217Z",
+    "source": "etherdelta",
+    "from_currency": "0xfeda",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 541,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.227Z",
+    "modified_on": "2018-05-16T16:48:48.227Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0009555,
+    "timestamp": "2018-05-16T16:48:48.227Z",
+    "source": "etherdelta",
+    "from_currency": "0xaa4a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 542,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.239Z",
+    "modified_on": "2018-05-16T16:48:48.239Z",
+    "from_amount": 0.0009555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.227Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xaa4a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 543,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.243Z",
+    "modified_on": "2018-05-16T16:48:48.243Z",
+    "from_amount": 1046.5724751439,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.227Z",
+    "source": "etherdelta",
+    "from_currency": "0xaa4a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 544,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.247Z",
+    "modified_on": "2018-05-16T16:48:48.247Z",
+    "from_amount": 0.0009555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.227Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xaa4a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 545,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.252Z",
+    "modified_on": "2018-05-16T16:48:48.252Z",
+    "from_amount": 1.0,
+    "to_amount": 1.42285e-05,
+    "timestamp": "2018-05-16T16:48:48.252Z",
+    "source": "etherdelta",
+    "from_currency": "VIU",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 546,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.255Z",
+    "modified_on": "2018-05-16T16:48:48.255Z",
+    "from_amount": 1.42285e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.252Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VIU"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 547,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.258Z",
+    "modified_on": "2018-05-16T16:48:48.258Z",
+    "from_amount": 70281.4773166532,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.252Z",
+    "source": "etherdelta",
+    "from_currency": "VIU",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 548,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.261Z",
+    "modified_on": "2018-05-16T16:48:48.261Z",
+    "from_amount": 1.42285e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.252Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "VIU"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 549,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.273Z",
+    "modified_on": "2018-05-16T16:48:48.273Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002505,
+    "timestamp": "2018-05-16T16:48:48.273Z",
+    "source": "etherdelta",
+    "from_currency": "0x5b13",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 550,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.277Z",
+    "modified_on": "2018-05-16T16:48:48.277Z",
+    "from_amount": 0.002505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.273Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5b13"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 551,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.282Z",
+    "modified_on": "2018-05-16T16:48:48.282Z",
+    "from_amount": 399.201596806387,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.273Z",
+    "source": "etherdelta",
+    "from_currency": "0x5b13",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 552,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.285Z",
+    "modified_on": "2018-05-16T16:48:48.285Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:48.285Z",
+    "source": "etherdelta",
+    "from_currency": "0xa60b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 554,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.290Z",
+    "modified_on": "2018-05-16T16:48:48.290Z",
+    "from_amount": 1.0,
+    "to_amount": 2.40055e-05,
+    "timestamp": "2018-05-16T16:48:48.290Z",
+    "source": "etherdelta",
+    "from_currency": "ARCT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 555,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.293Z",
+    "modified_on": "2018-05-16T16:48:48.293Z",
+    "from_amount": 2.40055e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.290Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ARCT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 556,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.300Z",
+    "modified_on": "2018-05-16T16:48:48.301Z",
+    "from_amount": 41657.1202432776,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.290Z",
+    "source": "etherdelta",
+    "from_currency": "ARCT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 557,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.309Z",
+    "modified_on": "2018-05-16T16:48:48.310Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0010000175,
+    "timestamp": "2018-05-16T16:48:48.310Z",
+    "source": "etherdelta",
+    "from_currency": "0x814f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 558,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.315Z",
+    "modified_on": "2018-05-16T16:48:48.315Z",
+    "from_amount": 0.0010000175,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.310Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x814f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 559,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.321Z",
+    "modified_on": "2018-05-16T16:48:48.321Z",
+    "from_amount": 999.982500306245,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.310Z",
+    "source": "etherdelta",
+    "from_currency": "0x814f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 560,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.328Z",
+    "modified_on": "2018-05-16T16:48:48.328Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:48.328Z",
+    "source": "etherdelta",
+    "from_currency": "0x388e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 562,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.334Z",
+    "modified_on": "2018-05-16T16:48:48.334Z",
+    "from_amount": 1.0,
+    "to_amount": 1.7105e-06,
+    "timestamp": "2018-05-16T16:48:48.334Z",
+    "source": "etherdelta",
+    "from_currency": "TOV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 563,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.338Z",
+    "modified_on": "2018-05-16T16:48:48.338Z",
+    "from_amount": 1.7105e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.334Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "TOV"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 564,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.342Z",
+    "modified_on": "2018-05-16T16:48:48.342Z",
+    "from_amount": 584624.378836597,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.334Z",
+    "source": "etherdelta",
+    "from_currency": "TOV",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 565,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.347Z",
+    "modified_on": "2018-05-16T16:48:48.347Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:48.347Z",
+    "source": "etherdelta",
+    "from_currency": "0x08d3",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 567,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.357Z",
+    "modified_on": "2018-05-16T16:48:48.358Z",
+    "from_amount": 1.0,
+    "to_amount": 7.60005e-05,
+    "timestamp": "2018-05-16T16:48:48.358Z",
+    "source": "etherdelta",
+    "from_currency": "0x5b70",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 568,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.363Z",
+    "modified_on": "2018-05-16T16:48:48.363Z",
+    "from_amount": 7.60005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.358Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5b70"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 569,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.369Z",
+    "modified_on": "2018-05-16T16:48:48.369Z",
+    "from_amount": 13157.8081723147,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.358Z",
+    "source": "etherdelta",
+    "from_currency": "0x5b70",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 570,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.377Z",
+    "modified_on": "2018-05-16T16:48:48.377Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001045,
+    "timestamp": "2018-05-16T16:48:48.377Z",
+    "source": "etherdelta",
+    "from_currency": "0x70c6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 571,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.382Z",
+    "modified_on": "2018-05-16T16:48:48.382Z",
+    "from_amount": 0.001045,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.377Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x70c6"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 572,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.385Z",
+    "modified_on": "2018-05-16T16:48:48.385Z",
+    "from_amount": 956.937799043062,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.377Z",
+    "source": "etherdelta",
+    "from_currency": "0x70c6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 573,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.397Z",
+    "modified_on": "2018-05-16T16:48:48.397Z",
+    "from_amount": 1.0,
+    "to_amount": 3.5001e-05,
+    "timestamp": "2018-05-16T16:48:48.397Z",
+    "source": "etherdelta",
+    "from_currency": "0xa701",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 574,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.408Z",
+    "modified_on": "2018-05-16T16:48:48.408Z",
+    "from_amount": 3.5001e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.397Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa701"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 575,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.415Z",
+    "modified_on": "2018-05-16T16:48:48.415Z",
+    "from_amount": 28570.6122682209,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.397Z",
+    "source": "etherdelta",
+    "from_currency": "0xa701",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 576,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.423Z",
+    "modified_on": "2018-05-16T16:48:48.424Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:48.423Z",
+    "source": "etherdelta",
+    "from_currency": "0x40ca",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 578,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.436Z",
+    "modified_on": "2018-05-16T16:48:48.436Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00080615,
+    "timestamp": "2018-05-16T16:48:48.436Z",
+    "source": "etherdelta",
+    "from_currency": "0x3833",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 579,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.443Z",
+    "modified_on": "2018-05-16T16:48:48.444Z",
+    "from_amount": 0.00080615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.436Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3833"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 580,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.447Z",
+    "modified_on": "2018-05-16T16:48:48.447Z",
+    "from_amount": 1240.46393351113,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.436Z",
+    "source": "etherdelta",
+    "from_currency": "0x3833",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 581,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.451Z",
+    "modified_on": "2018-05-16T16:48:48.453Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000148495,
+    "timestamp": "2018-05-16T16:48:48.452Z",
+    "source": "etherdelta",
+    "from_currency": "0x2167",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 582,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.462Z",
+    "modified_on": "2018-05-16T16:48:48.462Z",
+    "from_amount": 0.000148495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.452Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2167"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 583,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.466Z",
+    "modified_on": "2018-05-16T16:48:48.466Z",
+    "from_amount": 6734.23347587461,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.452Z",
+    "source": "etherdelta",
+    "from_currency": "0x2167",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 584,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.470Z",
+    "modified_on": "2018-05-16T16:48:48.470Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:48.470Z",
+    "source": "etherdelta",
+    "from_currency": "0x3575",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 586,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.477Z",
+    "modified_on": "2018-05-16T16:48:48.477Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0005000005,
+    "timestamp": "2018-05-16T16:48:48.477Z",
+    "source": "etherdelta",
+    "from_currency": "0xc9f0",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 587,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.481Z",
+    "modified_on": "2018-05-16T16:48:48.481Z",
+    "from_amount": 0.0005000005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.477Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xc9f0"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 588,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.485Z",
+    "modified_on": "2018-05-16T16:48:48.486Z",
+    "from_amount": 1999.998000002,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.477Z",
+    "source": "etherdelta",
+    "from_currency": "0xc9f0",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 589,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.494Z",
+    "modified_on": "2018-05-16T16:48:48.495Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001795,
+    "timestamp": "2018-05-16T16:48:48.495Z",
+    "source": "etherdelta",
+    "from_currency": "0x8fe1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 590,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.501Z",
+    "modified_on": "2018-05-16T16:48:48.502Z",
+    "from_amount": 0.001795,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.495Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8fe1"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 591,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.508Z",
+    "modified_on": "2018-05-16T16:48:48.509Z",
+    "from_amount": 557.103064066852,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.495Z",
+    "source": "etherdelta",
+    "from_currency": "0x8fe1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 592,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.512Z",
+    "modified_on": "2018-05-16T16:48:48.512Z",
+    "from_amount": 0.001795,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.495Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8fe1"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 593,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.516Z",
+    "modified_on": "2018-05-16T16:48:48.517Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0019755005,
+    "timestamp": "2018-05-16T16:48:48.516Z",
+    "source": "etherdelta",
+    "from_currency": "0xb98d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 594,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.520Z",
+    "modified_on": "2018-05-16T16:48:48.520Z",
+    "from_amount": 0.0019755005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.516Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xb98d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 595,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.524Z",
+    "modified_on": "2018-05-16T16:48:48.524Z",
+    "from_amount": 506.200833662153,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.516Z",
+    "source": "etherdelta",
+    "from_currency": "0xb98d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 596,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.527Z",
+    "modified_on": "2018-05-16T16:48:48.527Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002661,
+    "timestamp": "2018-05-16T16:48:48.527Z",
+    "source": "etherdelta",
+    "from_currency": "0x464e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 597,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.531Z",
+    "modified_on": "2018-05-16T16:48:48.531Z",
+    "from_amount": 0.0002661,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.527Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x464e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 598,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.539Z",
+    "modified_on": "2018-05-16T16:48:48.539Z",
+    "from_amount": 3757.98571965427,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.527Z",
+    "source": "etherdelta",
+    "from_currency": "0x464e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 599,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.547Z",
+    "modified_on": "2018-05-16T16:48:48.547Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002499995,
+    "timestamp": "2018-05-16T16:48:48.547Z",
+    "source": "etherdelta",
+    "from_currency": "DATA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 600,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.554Z",
+    "modified_on": "2018-05-16T16:48:48.554Z",
+    "from_amount": 0.0002499995,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.547Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DATA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 601,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.559Z",
+    "modified_on": "2018-05-16T16:48:48.559Z",
+    "from_amount": 4000.008000016,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.547Z",
+    "source": "etherdelta",
+    "from_currency": "DATA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 602,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.565Z",
+    "modified_on": "2018-05-16T16:48:48.565Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001995025,
+    "timestamp": "2018-05-16T16:48:48.565Z",
+    "source": "etherdelta",
+    "from_currency": "WAND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 603,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.569Z",
+    "modified_on": "2018-05-16T16:48:48.569Z",
+    "from_amount": 0.0001995025,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.565Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WAND"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 604,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.571Z",
+    "modified_on": "2018-05-16T16:48:48.571Z",
+    "from_amount": 5012.46851543214,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.565Z",
+    "source": "etherdelta",
+    "from_currency": "WAND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 605,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.576Z",
+    "modified_on": "2018-05-16T16:48:48.576Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000622222,
+    "timestamp": "2018-05-16T16:48:48.576Z",
+    "source": "etherdelta",
+    "from_currency": "ART",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 606,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.579Z",
+    "modified_on": "2018-05-16T16:48:48.580Z",
+    "from_amount": 0.000622222,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.576Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ART"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 607,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.583Z",
+    "modified_on": "2018-05-16T16:48:48.583Z",
+    "from_amount": 1607.14343112265,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.576Z",
+    "source": "etherdelta",
+    "from_currency": "ART",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 608,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.597Z",
+    "modified_on": "2018-05-16T16:48:48.597Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000325755,
+    "timestamp": "2018-05-16T16:48:48.597Z",
+    "source": "etherdelta",
+    "from_currency": "SNT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 609,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.604Z",
+    "modified_on": "2018-05-16T16:48:48.604Z",
+    "from_amount": 0.000325755,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.597Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SNT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 610,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.607Z",
+    "modified_on": "2018-05-16T16:48:48.607Z",
+    "from_amount": 3069.79171463216,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.597Z",
+    "source": "etherdelta",
+    "from_currency": "SNT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 611,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.611Z",
+    "modified_on": "2018-05-16T16:48:48.611Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-10,
+    "timestamp": "2018-05-16T16:48:48.611Z",
+    "source": "etherdelta",
+    "from_currency": "0x8f7d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 612,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.615Z",
+    "modified_on": "2018-05-16T16:48:48.615Z",
+    "from_amount": 5e-10,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.611Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8f7d"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 613,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.627Z",
+    "modified_on": "2018-05-16T16:48:48.627Z",
+    "from_amount": 2000000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.611Z",
+    "source": "etherdelta",
+    "from_currency": "0x8f7d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 614,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.634Z",
+    "modified_on": "2018-05-16T16:48:48.634Z",
+    "from_amount": 1.0,
+    "to_amount": 6.05e-05,
+    "timestamp": "2018-05-16T16:48:48.634Z",
+    "source": "etherdelta",
+    "from_currency": "0xcdb7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 615,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.638Z",
+    "modified_on": "2018-05-16T16:48:48.638Z",
+    "from_amount": 6.05e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.634Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xcdb7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 616,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.641Z",
+    "modified_on": "2018-05-16T16:48:48.642Z",
+    "from_amount": 16528.9256198347,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.634Z",
+    "source": "etherdelta",
+    "from_currency": "0xcdb7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 617,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.646Z",
+    "modified_on": "2018-05-16T16:48:48.646Z",
+    "from_amount": 1.0,
+    "to_amount": 0.01,
+    "timestamp": "2018-05-16T16:48:48.646Z",
+    "source": "etherdelta",
+    "from_currency": "TRIA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 618,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.654Z",
+    "modified_on": "2018-05-16T16:48:48.654Z",
+    "from_amount": 0.01,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.646Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "TRIA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 619,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.662Z",
+    "modified_on": "2018-05-16T16:48:48.662Z",
+    "from_amount": 100.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.646Z",
+    "source": "etherdelta",
+    "from_currency": "TRIA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 620,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.668Z",
+    "modified_on": "2018-05-16T16:48:48.668Z",
+    "from_amount": 1.0,
+    "to_amount": 1.6e-08,
+    "timestamp": "2018-05-16T16:48:48.668Z",
+    "source": "etherdelta",
+    "from_currency": "CLASH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 621,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.672Z",
+    "modified_on": "2018-05-16T16:48:48.672Z",
+    "from_amount": 1.6e-08,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.668Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CLASH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 622,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.675Z",
+    "modified_on": "2018-05-16T16:48:48.675Z",
+    "from_amount": 62500000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.668Z",
+    "source": "etherdelta",
+    "from_currency": "CLASH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 623,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.682Z",
+    "modified_on": "2018-05-16T16:48:48.682Z",
+    "from_amount": 1.0,
+    "to_amount": 2e-09,
+    "timestamp": "2018-05-16T16:48:48.682Z",
+    "source": "etherdelta",
+    "from_currency": "SHNZ",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 624,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.690Z",
+    "modified_on": "2018-05-16T16:48:48.690Z",
+    "from_amount": 2e-09,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.682Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SHNZ"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 625,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.697Z",
+    "modified_on": "2018-05-16T16:48:48.697Z",
+    "from_amount": 500000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.682Z",
+    "source": "etherdelta",
+    "from_currency": "SHNZ",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 626,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.702Z",
+    "modified_on": "2018-05-16T16:48:48.702Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001511115,
+    "timestamp": "2018-05-16T16:48:48.702Z",
+    "source": "etherdelta",
+    "from_currency": "HVN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 627,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.706Z",
+    "modified_on": "2018-05-16T16:48:48.706Z",
+    "from_amount": 0.0001511115,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.702Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "HVN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 628,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.709Z",
+    "modified_on": "2018-05-16T16:48:48.709Z",
+    "from_amount": 6617.63002815802,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.702Z",
+    "source": "etherdelta",
+    "from_currency": "HVN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 629,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.712Z",
+    "modified_on": "2018-05-16T16:48:48.712Z",
+    "from_amount": 1.0,
+    "to_amount": 0.008845025,
+    "timestamp": "2018-05-16T16:48:48.712Z",
+    "source": "etherdelta",
+    "from_currency": "PLBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 630,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.718Z",
+    "modified_on": "2018-05-16T16:48:48.718Z",
+    "from_amount": 0.008845025,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.712Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "PLBT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 631,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.730Z",
+    "modified_on": "2018-05-16T16:48:48.730Z",
+    "from_amount": 113.057905432715,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.712Z",
+    "source": "etherdelta",
+    "from_currency": "PLBT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 632,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.734Z",
+    "modified_on": "2018-05-16T16:48:48.734Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00117,
+    "timestamp": "2018-05-16T16:48:48.734Z",
+    "source": "etherdelta",
+    "from_currency": "H2O",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 633,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.743Z",
+    "modified_on": "2018-05-16T16:48:48.743Z",
+    "from_amount": 0.00117,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.734Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "H2O"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 634,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.747Z",
+    "modified_on": "2018-05-16T16:48:48.747Z",
+    "from_amount": 854.700854700855,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.734Z",
+    "source": "etherdelta",
+    "from_currency": "H2O",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 635,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.751Z",
+    "modified_on": "2018-05-16T16:48:48.751Z",
+    "from_amount": 1.0,
+    "to_amount": 4e-06,
+    "timestamp": "2018-05-16T16:48:48.751Z",
+    "source": "etherdelta",
+    "from_currency": "0x47dd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 636,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.755Z",
+    "modified_on": "2018-05-16T16:48:48.755Z",
+    "from_amount": 4e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.751Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x47dd"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 637,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.759Z",
+    "modified_on": "2018-05-16T16:48:48.759Z",
+    "from_amount": 250000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.751Z",
+    "source": "etherdelta",
+    "from_currency": "0x47dd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 638,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.764Z",
+    "modified_on": "2018-05-16T16:48:48.765Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0010416665,
+    "timestamp": "2018-05-16T16:48:48.764Z",
+    "source": "etherdelta",
+    "from_currency": "SND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 639,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.775Z",
+    "modified_on": "2018-05-16T16:48:48.775Z",
+    "from_amount": 0.0010416665,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.764Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SND"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 640,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.780Z",
+    "modified_on": "2018-05-16T16:48:48.780Z",
+    "from_amount": 960.000153600025,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.764Z",
+    "source": "etherdelta",
+    "from_currency": "SND",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 641,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.784Z",
+    "modified_on": "2018-05-16T16:48:48.785Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0039745,
+    "timestamp": "2018-05-16T16:48:48.784Z",
+    "source": "etherdelta",
+    "from_currency": "AION",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 642,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.792Z",
+    "modified_on": "2018-05-16T16:48:48.792Z",
+    "from_amount": 0.0039745,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.784Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "AION"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 643,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.796Z",
+    "modified_on": "2018-05-16T16:48:48.796Z",
+    "from_amount": 251.60397534281,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.784Z",
+    "source": "etherdelta",
+    "from_currency": "AION",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 644,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.801Z",
+    "modified_on": "2018-05-16T16:48:48.801Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001324955,
+    "timestamp": "2018-05-16T16:48:48.801Z",
+    "source": "etherdelta",
+    "from_currency": "POLL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 645,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.806Z",
+    "modified_on": "2018-05-16T16:48:48.806Z",
+    "from_amount": 0.001324955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.801Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "POLL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 646,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.810Z",
+    "modified_on": "2018-05-16T16:48:48.810Z",
+    "from_amount": 754.742613900095,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.801Z",
+    "source": "etherdelta",
+    "from_currency": "POLL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 647,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.814Z",
+    "modified_on": "2018-05-16T16:48:48.814Z",
+    "from_amount": 1.0,
+    "to_amount": 2.31285e-05,
+    "timestamp": "2018-05-16T16:48:48.814Z",
+    "source": "etherdelta",
+    "from_currency": "0x2baa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 648,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.826Z",
+    "modified_on": "2018-05-16T16:48:48.826Z",
+    "from_amount": 2.31285e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.814Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2baa"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 649,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.833Z",
+    "modified_on": "2018-05-16T16:48:48.833Z",
+    "from_amount": 43236.6993103746,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.814Z",
+    "source": "etherdelta",
+    "from_currency": "0x2baa",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 650,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.845Z",
+    "modified_on": "2018-05-16T16:48:48.845Z",
+    "from_amount": 1.0,
+    "to_amount": 5.051e-06,
+    "timestamp": "2018-05-16T16:48:48.845Z",
+    "source": "etherdelta",
+    "from_currency": "0xa8da",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 651,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.853Z",
+    "modified_on": "2018-05-16T16:48:48.853Z",
+    "from_amount": 5.051e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.845Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa8da"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 652,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.864Z",
+    "modified_on": "2018-05-16T16:48:48.864Z",
+    "from_amount": 197980.597901406,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.845Z",
+    "source": "etherdelta",
+    "from_currency": "0xa8da",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 653,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.878Z",
+    "modified_on": "2018-05-16T16:48:48.878Z",
+    "from_amount": 1.0,
+    "to_amount": 2.25e-07,
+    "timestamp": "2018-05-16T16:48:48.878Z",
+    "source": "etherdelta",
+    "from_currency": "0x1acd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 654,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.888Z",
+    "modified_on": "2018-05-16T16:48:48.888Z",
+    "from_amount": 2.25e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.878Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1acd"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 655,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.894Z",
+    "modified_on": "2018-05-16T16:48:48.895Z",
+    "from_amount": 4444444.44444444,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.878Z",
+    "source": "etherdelta",
+    "from_currency": "0x1acd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 656,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.900Z",
+    "modified_on": "2018-05-16T16:48:48.901Z",
+    "from_amount": 2.25e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.878Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1acd"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 657,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.916Z",
+    "modified_on": "2018-05-16T16:48:48.916Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000120005,
+    "timestamp": "2018-05-16T16:48:48.916Z",
+    "source": "etherdelta",
+    "from_currency": "0x3136",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 658,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.923Z",
+    "modified_on": "2018-05-16T16:48:48.924Z",
+    "from_amount": 0.000120005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.916Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3136"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 659,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.931Z",
+    "modified_on": "2018-05-16T16:48:48.931Z",
+    "from_amount": 8332.9861255781,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.916Z",
+    "source": "etherdelta",
+    "from_currency": "0x3136",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 660,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.936Z",
+    "modified_on": "2018-05-16T16:48:48.936Z",
+    "from_amount": 0.000120005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.916Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3136"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 661,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.952Z",
+    "modified_on": "2018-05-16T16:48:48.952Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-06,
+    "timestamp": "2018-05-16T16:48:48.952Z",
+    "source": "etherdelta",
+    "from_currency": "0x2402",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 662,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.959Z",
+    "modified_on": "2018-05-16T16:48:48.959Z",
+    "from_amount": 5e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.952Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2402"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 663,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.964Z",
+    "modified_on": "2018-05-16T16:48:48.964Z",
+    "from_amount": 200000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.952Z",
+    "source": "etherdelta",
+    "from_currency": "0x2402",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 664,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.975Z",
+    "modified_on": "2018-05-16T16:48:48.975Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00225955,
+    "timestamp": "2018-05-16T16:48:48.975Z",
+    "source": "etherdelta",
+    "from_currency": "0x107c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 665,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.982Z",
+    "modified_on": "2018-05-16T16:48:48.982Z",
+    "from_amount": 0.00225955,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.975Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x107c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 666,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.986Z",
+    "modified_on": "2018-05-16T16:48:48.986Z",
+    "from_amount": 442.5659976544,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.975Z",
+    "source": "etherdelta",
+    "from_currency": "0x107c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 667,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.989Z",
+    "modified_on": "2018-05-16T16:48:48.989Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001880459,
+    "timestamp": "2018-05-16T16:48:48.989Z",
+    "source": "etherdelta",
+    "from_currency": "ICN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 668,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.994Z",
+    "modified_on": "2018-05-16T16:48:48.995Z",
+    "from_amount": 0.001880459,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.989Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ICN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 669,
+  "fields": {
+    "created_on": "2018-05-16T16:48:48.997Z",
+    "modified_on": "2018-05-16T16:48:48.998Z",
+    "from_amount": 531.785058860629,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:48.989Z",
+    "source": "etherdelta",
+    "from_currency": "ICN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 670,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.002Z",
+    "modified_on": "2018-05-16T16:48:49.002Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0012555,
+    "timestamp": "2018-05-16T16:48:49.002Z",
+    "source": "etherdelta",
+    "from_currency": "0x69be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 671,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.011Z",
+    "modified_on": "2018-05-16T16:48:49.011Z",
+    "from_amount": 0.0012555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.002Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x69be"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 672,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.016Z",
+    "modified_on": "2018-05-16T16:48:49.016Z",
+    "from_amount": 796.495420151334,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.002Z",
+    "source": "etherdelta",
+    "from_currency": "0x69be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 673,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.024Z",
+    "modified_on": "2018-05-16T16:48:49.024Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00265,
+    "timestamp": "2018-05-16T16:48:49.024Z",
+    "source": "etherdelta",
+    "from_currency": "CO2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 674,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.030Z",
+    "modified_on": "2018-05-16T16:48:49.030Z",
+    "from_amount": 0.00265,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.024Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CO2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 675,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.033Z",
+    "modified_on": "2018-05-16T16:48:49.033Z",
+    "from_amount": 377.358490566038,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.024Z",
+    "source": "etherdelta",
+    "from_currency": "CO2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 676,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.035Z",
+    "modified_on": "2018-05-16T16:48:49.035Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00029965,
+    "timestamp": "2018-05-16T16:48:49.035Z",
+    "source": "etherdelta",
+    "from_currency": "REQ",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 677,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.039Z",
+    "modified_on": "2018-05-16T16:48:49.039Z",
+    "from_amount": 0.00029965,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.035Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "REQ"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 678,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.042Z",
+    "modified_on": "2018-05-16T16:48:49.042Z",
+    "from_amount": 3337.22676455865,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.035Z",
+    "source": "etherdelta",
+    "from_currency": "REQ",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 679,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.044Z",
+    "modified_on": "2018-05-16T16:48:49.045Z",
+    "from_amount": 1.0,
+    "to_amount": 9.69995e-05,
+    "timestamp": "2018-05-16T16:48:49.045Z",
+    "source": "etherdelta",
+    "from_currency": "0xea5f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 680,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.048Z",
+    "modified_on": "2018-05-16T16:48:49.048Z",
+    "from_amount": 9.69995e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.045Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xea5f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 681,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.052Z",
+    "modified_on": "2018-05-16T16:48:49.052Z",
+    "from_amount": 10309.3314913994,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.045Z",
+    "source": "etherdelta",
+    "from_currency": "0xea5f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 682,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.061Z",
+    "modified_on": "2018-05-16T16:48:49.061Z",
+    "from_amount": 1.0,
+    "to_amount": 5.005e-05,
+    "timestamp": "2018-05-16T16:48:49.061Z",
+    "source": "etherdelta",
+    "from_currency": "0xca3e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 683,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.068Z",
+    "modified_on": "2018-05-16T16:48:49.068Z",
+    "from_amount": 5.005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.061Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xca3e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 684,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.074Z",
+    "modified_on": "2018-05-16T16:48:49.075Z",
+    "from_amount": 19980.01998002,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.061Z",
+    "source": "etherdelta",
+    "from_currency": "0xca3e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 685,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.078Z",
+    "modified_on": "2018-05-16T16:48:49.078Z",
+    "from_amount": 5.005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.061Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xca3e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 686,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.081Z",
+    "modified_on": "2018-05-16T16:48:49.082Z",
+    "from_amount": 1.0,
+    "to_amount": 6.80845e-05,
+    "timestamp": "2018-05-16T16:48:49.081Z",
+    "source": "etherdelta",
+    "from_currency": "FUN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 687,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.085Z",
+    "modified_on": "2018-05-16T16:48:49.085Z",
+    "from_amount": 6.80845e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.081Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "FUN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 688,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.087Z",
+    "modified_on": "2018-05-16T16:48:49.087Z",
+    "from_amount": 14687.6308117119,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.081Z",
+    "source": "etherdelta",
+    "from_currency": "FUN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 689,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.091Z",
+    "modified_on": "2018-05-16T16:48:49.091Z",
+    "from_amount": 1.0,
+    "to_amount": 5.55e-05,
+    "timestamp": "2018-05-16T16:48:49.091Z",
+    "source": "etherdelta",
+    "from_currency": "0x552e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 690,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.093Z",
+    "modified_on": "2018-05-16T16:48:49.093Z",
+    "from_amount": 5.55e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.091Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x552e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 691,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.096Z",
+    "modified_on": "2018-05-16T16:48:49.096Z",
+    "from_amount": 18018.018018018,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.091Z",
+    "source": "etherdelta",
+    "from_currency": "0x552e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 692,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.099Z",
+    "modified_on": "2018-05-16T16:48:49.099Z",
+    "from_amount": 1.0,
+    "to_amount": 1.5107e-05,
+    "timestamp": "2018-05-16T16:48:49.099Z",
+    "source": "etherdelta",
+    "from_currency": "0xd092",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 693,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.107Z",
+    "modified_on": "2018-05-16T16:48:49.107Z",
+    "from_amount": 1.5107e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.099Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd092"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 694,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.112Z",
+    "modified_on": "2018-05-16T16:48:49.112Z",
+    "from_amount": 66194.4793804197,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.099Z",
+    "source": "etherdelta",
+    "from_currency": "0xd092",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 695,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.116Z",
+    "modified_on": "2018-05-16T16:48:49.116Z",
+    "from_amount": 1.5107e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.099Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd092"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 696,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.125Z",
+    "modified_on": "2018-05-16T16:48:49.125Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0008925,
+    "timestamp": "2018-05-16T16:48:49.125Z",
+    "source": "etherdelta",
+    "from_currency": "TRST",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 697,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.133Z",
+    "modified_on": "2018-05-16T16:48:49.133Z",
+    "from_amount": 0.0008925,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.125Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "TRST"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 698,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.136Z",
+    "modified_on": "2018-05-16T16:48:49.136Z",
+    "from_amount": 1120.44817927171,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.125Z",
+    "source": "etherdelta",
+    "from_currency": "TRST",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 699,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.140Z",
+    "modified_on": "2018-05-16T16:48:49.140Z",
+    "from_amount": 1.0,
+    "to_amount": 2.15e-05,
+    "timestamp": "2018-05-16T16:48:49.140Z",
+    "source": "etherdelta",
+    "from_currency": "0x900b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 700,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.145Z",
+    "modified_on": "2018-05-16T16:48:49.145Z",
+    "from_amount": 2.15e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.140Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x900b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 701,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.148Z",
+    "modified_on": "2018-05-16T16:48:49.148Z",
+    "from_amount": 46511.6279069767,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.140Z",
+    "source": "etherdelta",
+    "from_currency": "0x900b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 702,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.154Z",
+    "modified_on": "2018-05-16T16:48:49.154Z",
+    "from_amount": 1.0,
+    "to_amount": 1.1e-08,
+    "timestamp": "2018-05-16T16:48:49.154Z",
+    "source": "etherdelta",
+    "from_currency": "1BIT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 703,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.162Z",
+    "modified_on": "2018-05-16T16:48:49.162Z",
+    "from_amount": 1.1e-08,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.154Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "1BIT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 704,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.166Z",
+    "modified_on": "2018-05-16T16:48:49.166Z",
+    "from_amount": 90909090.9090909,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.154Z",
+    "source": "etherdelta",
+    "from_currency": "1BIT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 705,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.176Z",
+    "modified_on": "2018-05-16T16:48:49.176Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.176Z",
+    "source": "etherdelta",
+    "from_currency": "0x2811",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 707,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.186Z",
+    "modified_on": "2018-05-16T16:48:49.186Z",
+    "from_amount": 1.0,
+    "to_amount": 0.4994999915,
+    "timestamp": "2018-05-16T16:48:49.186Z",
+    "source": "etherdelta",
+    "from_currency": "0x40b0",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 708,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.192Z",
+    "modified_on": "2018-05-16T16:48:49.192Z",
+    "from_amount": 0.4994999915,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.186Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x40b0"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 709,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.197Z",
+    "modified_on": "2018-05-16T16:48:49.197Z",
+    "from_amount": 2.0020020360701,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.186Z",
+    "source": "etherdelta",
+    "from_currency": "0x40b0",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 710,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.203Z",
+    "modified_on": "2018-05-16T16:48:49.204Z",
+    "from_amount": 1.0,
+    "to_amount": 2.775e-06,
+    "timestamp": "2018-05-16T16:48:49.203Z",
+    "source": "etherdelta",
+    "from_currency": "EREAL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 711,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.213Z",
+    "modified_on": "2018-05-16T16:48:49.213Z",
+    "from_amount": 2.775e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.203Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "EREAL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 712,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.218Z",
+    "modified_on": "2018-05-16T16:48:49.218Z",
+    "from_amount": 360360.36036036,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.203Z",
+    "source": "etherdelta",
+    "from_currency": "EREAL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 713,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.228Z",
+    "modified_on": "2018-05-16T16:48:49.228Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0068100035,
+    "timestamp": "2018-05-16T16:48:49.228Z",
+    "source": "etherdelta",
+    "from_currency": "RLC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 714,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.234Z",
+    "modified_on": "2018-05-16T16:48:49.234Z",
+    "from_amount": 0.0068100035,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.228Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "RLC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 715,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.237Z",
+    "modified_on": "2018-05-16T16:48:49.237Z",
+    "from_amount": 146.842802650542,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.228Z",
+    "source": "etherdelta",
+    "from_currency": "RLC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 716,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.243Z",
+    "modified_on": "2018-05-16T16:48:49.243Z",
+    "from_amount": 1.0,
+    "to_amount": 0.010575502,
+    "timestamp": "2018-05-16T16:48:49.243Z",
+    "source": "etherdelta",
+    "from_currency": "0x1c79",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 717,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.248Z",
+    "modified_on": "2018-05-16T16:48:49.248Z",
+    "from_amount": 0.010575502,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.243Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1c79"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 718,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.256Z",
+    "modified_on": "2018-05-16T16:48:49.256Z",
+    "from_amount": 94.5581590358547,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.243Z",
+    "source": "etherdelta",
+    "from_currency": "0x1c79",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 719,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.265Z",
+    "modified_on": "2018-05-16T16:48:49.265Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000313,
+    "timestamp": "2018-05-16T16:48:49.265Z",
+    "source": "etherdelta",
+    "from_currency": "0xd2d6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 720,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.273Z",
+    "modified_on": "2018-05-16T16:48:49.273Z",
+    "from_amount": 0.000313,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.265Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xd2d6"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 721,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.279Z",
+    "modified_on": "2018-05-16T16:48:49.279Z",
+    "from_amount": 3194.88817891374,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.265Z",
+    "source": "etherdelta",
+    "from_currency": "0xd2d6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 722,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.284Z",
+    "modified_on": "2018-05-16T16:48:49.284Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.284Z",
+    "source": "etherdelta",
+    "from_currency": "0xbdd0",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 724,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.300Z",
+    "modified_on": "2018-05-16T16:48:49.300Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000244,
+    "timestamp": "2018-05-16T16:48:49.300Z",
+    "source": "etherdelta",
+    "from_currency": "0x5c74",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 725,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.314Z",
+    "modified_on": "2018-05-16T16:48:49.314Z",
+    "from_amount": 0.000244,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.300Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5c74"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 726,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.319Z",
+    "modified_on": "2018-05-16T16:48:49.319Z",
+    "from_amount": 4098.3606557377,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.300Z",
+    "source": "etherdelta",
+    "from_currency": "0x5c74",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 727,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.322Z",
+    "modified_on": "2018-05-16T16:48:49.322Z",
+    "from_amount": 0.000244,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.300Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5c74"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 728,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.329Z",
+    "modified_on": "2018-05-16T16:48:49.329Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0277556005,
+    "timestamp": "2018-05-16T16:48:49.329Z",
+    "source": "etherdelta",
+    "from_currency": "0xbf21",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 729,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.338Z",
+    "modified_on": "2018-05-16T16:48:49.339Z",
+    "from_amount": 0.0277556005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.329Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xbf21"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 730,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.348Z",
+    "modified_on": "2018-05-16T16:48:49.348Z",
+    "from_amount": 36.0287647172325,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.329Z",
+    "source": "etherdelta",
+    "from_currency": "0xbf21",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 731,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.355Z",
+    "modified_on": "2018-05-16T16:48:49.355Z",
+    "from_amount": 1.0,
+    "to_amount": 5.1e-08,
+    "timestamp": "2018-05-16T16:48:49.355Z",
+    "source": "etherdelta",
+    "from_currency": "0xb200",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 732,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.365Z",
+    "modified_on": "2018-05-16T16:48:49.365Z",
+    "from_amount": 5.1e-08,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.355Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xb200"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 733,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.370Z",
+    "modified_on": "2018-05-16T16:48:49.370Z",
+    "from_amount": 19607843.1372549,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.355Z",
+    "source": "etherdelta",
+    "from_currency": "0xb200",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 734,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.374Z",
+    "modified_on": "2018-05-16T16:48:49.375Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00175,
+    "timestamp": "2018-05-16T16:48:49.375Z",
+    "source": "etherdelta",
+    "from_currency": "LOC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 735,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.381Z",
+    "modified_on": "2018-05-16T16:48:49.381Z",
+    "from_amount": 0.00175,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.375Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LOC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 736,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.391Z",
+    "modified_on": "2018-05-16T16:48:49.391Z",
+    "from_amount": 571.428571428571,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.375Z",
+    "source": "etherdelta",
+    "from_currency": "LOC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 737,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.399Z",
+    "modified_on": "2018-05-16T16:48:49.399Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.399Z",
+    "source": "etherdelta",
+    "from_currency": "0x8c2d",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 739,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.413Z",
+    "modified_on": "2018-05-16T16:48:49.413Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000200005,
+    "timestamp": "2018-05-16T16:48:49.413Z",
+    "source": "etherdelta",
+    "from_currency": "0x23b7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 740,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.421Z",
+    "modified_on": "2018-05-16T16:48:49.421Z",
+    "from_amount": 0.000200005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.413Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x23b7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 741,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.426Z",
+    "modified_on": "2018-05-16T16:48:49.426Z",
+    "from_amount": 4999.87500312492,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.413Z",
+    "source": "etherdelta",
+    "from_currency": "0x23b7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 742,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.433Z",
+    "modified_on": "2018-05-16T16:48:49.433Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000385555,
+    "timestamp": "2018-05-16T16:48:49.433Z",
+    "source": "etherdelta",
+    "from_currency": "0x2f9b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 743,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.443Z",
+    "modified_on": "2018-05-16T16:48:49.443Z",
+    "from_amount": 0.000385555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.433Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2f9b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 744,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.450Z",
+    "modified_on": "2018-05-16T16:48:49.450Z",
+    "from_amount": 2593.66367963066,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.433Z",
+    "source": "etherdelta",
+    "from_currency": "0x2f9b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 745,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.455Z",
+    "modified_on": "2018-05-16T16:48:49.455Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000125,
+    "timestamp": "2018-05-16T16:48:49.455Z",
+    "source": "etherdelta",
+    "from_currency": "0x9d22",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 746,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.462Z",
+    "modified_on": "2018-05-16T16:48:49.462Z",
+    "from_amount": 0.000125,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.455Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9d22"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 747,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.466Z",
+    "modified_on": "2018-05-16T16:48:49.466Z",
+    "from_amount": 8000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.455Z",
+    "source": "etherdelta",
+    "from_currency": "0x9d22",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 748,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.477Z",
+    "modified_on": "2018-05-16T16:48:49.477Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.477Z",
+    "source": "etherdelta",
+    "from_currency": "0x4248",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 750,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.484Z",
+    "modified_on": "2018-05-16T16:48:49.484Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001150015,
+    "timestamp": "2018-05-16T16:48:49.484Z",
+    "source": "etherdelta",
+    "from_currency": "0x4df4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 751,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.491Z",
+    "modified_on": "2018-05-16T16:48:49.492Z",
+    "from_amount": 0.0001150015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.484Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4df4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 752,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.495Z",
+    "modified_on": "2018-05-16T16:48:49.495Z",
+    "from_amount": 8695.53875384234,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.484Z",
+    "source": "etherdelta",
+    "from_currency": "0x4df4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 753,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.499Z",
+    "modified_on": "2018-05-16T16:48:49.499Z",
+    "from_amount": 0.0001150015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.484Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4df4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 754,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.503Z",
+    "modified_on": "2018-05-16T16:48:49.503Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003225,
+    "timestamp": "2018-05-16T16:48:49.503Z",
+    "source": "etherdelta",
+    "from_currency": "0x8eb2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 755,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.508Z",
+    "modified_on": "2018-05-16T16:48:49.508Z",
+    "from_amount": 0.0003225,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.503Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8eb2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 756,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.511Z",
+    "modified_on": "2018-05-16T16:48:49.511Z",
+    "from_amount": 3100.77519379845,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.503Z",
+    "source": "etherdelta",
+    "from_currency": "0x8eb2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 757,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.514Z",
+    "modified_on": "2018-05-16T16:48:49.514Z",
+    "from_amount": 1.0,
+    "to_amount": 6.14e-07,
+    "timestamp": "2018-05-16T16:48:49.514Z",
+    "source": "etherdelta",
+    "from_currency": "LIFE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 758,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.517Z",
+    "modified_on": "2018-05-16T16:48:49.517Z",
+    "from_amount": 6.14e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.514Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LIFE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 759,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.527Z",
+    "modified_on": "2018-05-16T16:48:49.527Z",
+    "from_amount": 1628664.49511401,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.514Z",
+    "source": "etherdelta",
+    "from_currency": "LIFE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 760,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.533Z",
+    "modified_on": "2018-05-16T16:48:49.533Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000354951,
+    "timestamp": "2018-05-16T16:48:49.533Z",
+    "source": "etherdelta",
+    "from_currency": "SCT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 761,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.540Z",
+    "modified_on": "2018-05-16T16:48:49.540Z",
+    "from_amount": 0.000354951,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.533Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SCT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 762,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.545Z",
+    "modified_on": "2018-05-16T16:48:49.545Z",
+    "from_amount": 2817.29027386879,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.533Z",
+    "source": "etherdelta",
+    "from_currency": "SCT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 763,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.549Z",
+    "modified_on": "2018-05-16T16:48:49.549Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.549Z",
+    "source": "etherdelta",
+    "from_currency": "CTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 765,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.554Z",
+    "modified_on": "2018-05-16T16:48:49.554Z",
+    "from_amount": 1.0,
+    "to_amount": 6.0255e-06,
+    "timestamp": "2018-05-16T16:48:49.554Z",
+    "source": "etherdelta",
+    "from_currency": "0xda6c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 766,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.558Z",
+    "modified_on": "2018-05-16T16:48:49.558Z",
+    "from_amount": 6.0255e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.554Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xda6c"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 767,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.560Z",
+    "modified_on": "2018-05-16T16:48:49.560Z",
+    "from_amount": 165961.331009875,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.554Z",
+    "source": "etherdelta",
+    "from_currency": "0xda6c",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 768,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.564Z",
+    "modified_on": "2018-05-16T16:48:49.564Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002005,
+    "timestamp": "2018-05-16T16:48:49.564Z",
+    "source": "etherdelta",
+    "from_currency": "0x5dbe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 769,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.567Z",
+    "modified_on": "2018-05-16T16:48:49.567Z",
+    "from_amount": 0.0002005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.564Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5dbe"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 770,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.575Z",
+    "modified_on": "2018-05-16T16:48:49.575Z",
+    "from_amount": 4987.53117206982,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.564Z",
+    "source": "etherdelta",
+    "from_currency": "0x5dbe",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 771,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.581Z",
+    "modified_on": "2018-05-16T16:48:49.581Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:49.581Z",
+    "source": "etherdelta",
+    "from_currency": "0x5de3",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 773,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.590Z",
+    "modified_on": "2018-05-16T16:48:49.590Z",
+    "from_amount": 1.0,
+    "to_amount": 3.75e-06,
+    "timestamp": "2018-05-16T16:48:49.590Z",
+    "source": "etherdelta",
+    "from_currency": "0x357a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 774,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.597Z",
+    "modified_on": "2018-05-16T16:48:49.597Z",
+    "from_amount": 3.75e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.590Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x357a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 775,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.602Z",
+    "modified_on": "2018-05-16T16:48:49.602Z",
+    "from_amount": 266666.666666667,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.590Z",
+    "source": "etherdelta",
+    "from_currency": "0x357a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 776,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.605Z",
+    "modified_on": "2018-05-16T16:48:49.605Z",
+    "from_amount": 3.75e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.590Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x357a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 777,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.609Z",
+    "modified_on": "2018-05-16T16:48:49.609Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000207105,
+    "timestamp": "2018-05-16T16:48:49.609Z",
+    "source": "etherdelta",
+    "from_currency": "0x922a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 778,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.612Z",
+    "modified_on": "2018-05-16T16:48:49.612Z",
+    "from_amount": 0.000207105,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.609Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x922a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 779,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.615Z",
+    "modified_on": "2018-05-16T16:48:49.615Z",
+    "from_amount": 4828.46865116728,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.609Z",
+    "source": "etherdelta",
+    "from_currency": "0x922a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 780,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.620Z",
+    "modified_on": "2018-05-16T16:48:49.621Z",
+    "from_amount": 1.0,
+    "to_amount": 25.0000050045,
+    "timestamp": "2018-05-16T16:48:49.620Z",
+    "source": "etherdelta",
+    "from_currency": "0x5ba4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 781,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.631Z",
+    "modified_on": "2018-05-16T16:48:49.631Z",
+    "from_amount": 25.0000050045,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.620Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5ba4"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 782,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.635Z",
+    "modified_on": "2018-05-16T16:48:49.635Z",
+    "from_amount": 0.0399999919928016,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.620Z",
+    "source": "etherdelta",
+    "from_currency": "0x5ba4",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 783,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.644Z",
+    "modified_on": "2018-05-16T16:48:49.644Z",
+    "from_amount": 1.0,
+    "to_amount": 1.60055e-05,
+    "timestamp": "2018-05-16T16:48:49.644Z",
+    "source": "etherdelta",
+    "from_currency": "0x4de2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 784,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.649Z",
+    "modified_on": "2018-05-16T16:48:49.649Z",
+    "from_amount": 1.60055e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.644Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4de2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 785,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.653Z",
+    "modified_on": "2018-05-16T16:48:49.653Z",
+    "from_amount": 62478.5230077161,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.644Z",
+    "source": "etherdelta",
+    "from_currency": "0x4de2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 786,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.658Z",
+    "modified_on": "2018-05-16T16:48:49.658Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0010172835,
+    "timestamp": "2018-05-16T16:48:49.658Z",
+    "source": "etherdelta",
+    "from_currency": "IXT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 787,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.664Z",
+    "modified_on": "2018-05-16T16:48:49.664Z",
+    "from_amount": 0.0010172835,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.658Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "IXT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 788,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.668Z",
+    "modified_on": "2018-05-16T16:48:49.668Z",
+    "from_amount": 983.010144173183,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.658Z",
+    "source": "etherdelta",
+    "from_currency": "IXT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 789,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.679Z",
+    "modified_on": "2018-05-16T16:48:49.679Z",
+    "from_amount": 1.0,
+    "to_amount": 4.0205e-05,
+    "timestamp": "2018-05-16T16:48:49.679Z",
+    "source": "etherdelta",
+    "from_currency": "0x997e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 790,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.684Z",
+    "modified_on": "2018-05-16T16:48:49.684Z",
+    "from_amount": 4.0205e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.679Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x997e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 791,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.691Z",
+    "modified_on": "2018-05-16T16:48:49.692Z",
+    "from_amount": 24872.5282925009,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.679Z",
+    "source": "etherdelta",
+    "from_currency": "0x997e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 792,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.697Z",
+    "modified_on": "2018-05-16T16:48:49.697Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004465025,
+    "timestamp": "2018-05-16T16:48:49.697Z",
+    "source": "etherdelta",
+    "from_currency": "0x9a00",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 793,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.701Z",
+    "modified_on": "2018-05-16T16:48:49.701Z",
+    "from_amount": 0.0004465025,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.697Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9a00"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 794,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.704Z",
+    "modified_on": "2018-05-16T16:48:49.704Z",
+    "from_amount": 2239.62911741816,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.697Z",
+    "source": "etherdelta",
+    "from_currency": "0x9a00",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 795,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.709Z",
+    "modified_on": "2018-05-16T16:48:49.709Z",
+    "from_amount": 1.0,
+    "to_amount": 1.3244e-05,
+    "timestamp": "2018-05-16T16:48:49.709Z",
+    "source": "etherdelta",
+    "from_currency": "JS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 796,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.713Z",
+    "modified_on": "2018-05-16T16:48:49.713Z",
+    "from_amount": 1.3244e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.709Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "JS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 797,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.716Z",
+    "modified_on": "2018-05-16T16:48:49.717Z",
+    "from_amount": 75505.8894593778,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.709Z",
+    "source": "etherdelta",
+    "from_currency": "JS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 798,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.731Z",
+    "modified_on": "2018-05-16T16:48:49.731Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-10,
+    "timestamp": "2018-05-16T16:48:49.731Z",
+    "source": "etherdelta",
+    "from_currency": "0x1a23",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 799,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.741Z",
+    "modified_on": "2018-05-16T16:48:49.741Z",
+    "from_amount": 5e-10,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.731Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x1a23"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 800,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.748Z",
+    "modified_on": "2018-05-16T16:48:49.748Z",
+    "from_amount": 2000000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.731Z",
+    "source": "etherdelta",
+    "from_currency": "0x1a23",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 801,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.754Z",
+    "modified_on": "2018-05-16T16:48:49.754Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000320555,
+    "timestamp": "2018-05-16T16:48:49.754Z",
+    "source": "etherdelta",
+    "from_currency": "DBET",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 802,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.761Z",
+    "modified_on": "2018-05-16T16:48:49.761Z",
+    "from_amount": 0.000320555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.754Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DBET"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 803,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.766Z",
+    "modified_on": "2018-05-16T16:48:49.767Z",
+    "from_amount": 3119.5894620268,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.754Z",
+    "source": "etherdelta",
+    "from_currency": "DBET",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 804,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.777Z",
+    "modified_on": "2018-05-16T16:48:49.777Z",
+    "from_amount": 1.0,
+    "to_amount": 4.4505e-06,
+    "timestamp": "2018-05-16T16:48:49.777Z",
+    "source": "etherdelta",
+    "from_currency": "BENJA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 805,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.782Z",
+    "modified_on": "2018-05-16T16:48:49.782Z",
+    "from_amount": 4.4505e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.777Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BENJA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 806,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.790Z",
+    "modified_on": "2018-05-16T16:48:49.791Z",
+    "from_amount": 224693.854623076,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.777Z",
+    "source": "etherdelta",
+    "from_currency": "BENJA",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 807,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.796Z",
+    "modified_on": "2018-05-16T16:48:49.796Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001538555,
+    "timestamp": "2018-05-16T16:48:49.796Z",
+    "source": "etherdelta",
+    "from_currency": "0x3f24",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 808,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.800Z",
+    "modified_on": "2018-05-16T16:48:49.800Z",
+    "from_amount": 0.0001538555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.796Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3f24"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 809,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.804Z",
+    "modified_on": "2018-05-16T16:48:49.804Z",
+    "from_amount": 6499.6051489872,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.796Z",
+    "source": "etherdelta",
+    "from_currency": "0x3f24",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 810,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.809Z",
+    "modified_on": "2018-05-16T16:48:49.809Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0069155005,
+    "timestamp": "2018-05-16T16:48:49.809Z",
+    "source": "etherdelta",
+    "from_currency": "0x4d30",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 811,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.813Z",
+    "modified_on": "2018-05-16T16:48:49.813Z",
+    "from_amount": 0.0069155005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.809Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4d30"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 812,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.816Z",
+    "modified_on": "2018-05-16T16:48:49.816Z",
+    "from_amount": 144.602693615596,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.809Z",
+    "source": "etherdelta",
+    "from_currency": "0x4d30",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 813,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.822Z",
+    "modified_on": "2018-05-16T16:48:49.823Z",
+    "from_amount": 1.0,
+    "to_amount": 3.3505e-06,
+    "timestamp": "2018-05-16T16:48:49.823Z",
+    "source": "etherdelta",
+    "from_currency": "0xe8fc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 814,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.830Z",
+    "modified_on": "2018-05-16T16:48:49.830Z",
+    "from_amount": 3.3505e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.823Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe8fc"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 815,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.833Z",
+    "modified_on": "2018-05-16T16:48:49.834Z",
+    "from_amount": 298462.915982689,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.823Z",
+    "source": "etherdelta",
+    "from_currency": "0xe8fc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 816,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.841Z",
+    "modified_on": "2018-05-16T16:48:49.842Z",
+    "from_amount": 3.3505e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.823Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe8fc"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 817,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.850Z",
+    "modified_on": "2018-05-16T16:48:49.850Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002055015,
+    "timestamp": "2018-05-16T16:48:49.850Z",
+    "source": "etherdelta",
+    "from_currency": "0x70a7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 818,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.855Z",
+    "modified_on": "2018-05-16T16:48:49.855Z",
+    "from_amount": 0.0002055015,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.850Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x70a7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 819,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.858Z",
+    "modified_on": "2018-05-16T16:48:49.858Z",
+    "from_amount": 4866.14452935867,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.850Z",
+    "source": "etherdelta",
+    "from_currency": "0x70a7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 820,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.863Z",
+    "modified_on": "2018-05-16T16:48:49.863Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0005305,
+    "timestamp": "2018-05-16T16:48:49.863Z",
+    "source": "etherdelta",
+    "from_currency": "0xbc86",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 821,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.866Z",
+    "modified_on": "2018-05-16T16:48:49.866Z",
+    "from_amount": 0.0005305,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.863Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xbc86"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 822,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.880Z",
+    "modified_on": "2018-05-16T16:48:49.880Z",
+    "from_amount": 1885.01413760603,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.863Z",
+    "source": "etherdelta",
+    "from_currency": "0xbc86",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 823,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.886Z",
+    "modified_on": "2018-05-16T16:48:49.886Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003944445,
+    "timestamp": "2018-05-16T16:48:49.886Z",
+    "source": "etherdelta",
+    "from_currency": "0x5bc7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 824,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.891Z",
+    "modified_on": "2018-05-16T16:48:49.891Z",
+    "from_amount": 0.0003944445,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.886Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5bc7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 825,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.894Z",
+    "modified_on": "2018-05-16T16:48:49.894Z",
+    "from_amount": 2535.21091053367,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.886Z",
+    "source": "etherdelta",
+    "from_currency": "0x5bc7",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 826,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.896Z",
+    "modified_on": "2018-05-16T16:48:49.896Z",
+    "from_amount": 0.0003944445,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.886Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5bc7"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 827,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.900Z",
+    "modified_on": "2018-05-16T16:48:49.900Z",
+    "from_amount": 1.0,
+    "to_amount": 1.725e-06,
+    "timestamp": "2018-05-16T16:48:49.900Z",
+    "source": "etherdelta",
+    "from_currency": "CLASSY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 828,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.917Z",
+    "modified_on": "2018-05-16T16:48:49.917Z",
+    "from_amount": 1.725e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.900Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CLASSY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 829,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.923Z",
+    "modified_on": "2018-05-16T16:48:49.923Z",
+    "from_amount": 579710.144927536,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.900Z",
+    "source": "etherdelta",
+    "from_currency": "CLASSY",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 830,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.928Z",
+    "modified_on": "2018-05-16T16:48:49.929Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000340615,
+    "timestamp": "2018-05-16T16:48:49.928Z",
+    "source": "etherdelta",
+    "from_currency": "0x80bc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 831,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.933Z",
+    "modified_on": "2018-05-16T16:48:49.933Z",
+    "from_amount": 0.000340615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.928Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x80bc"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 832,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.938Z",
+    "modified_on": "2018-05-16T16:48:49.938Z",
+    "from_amount": 2935.86600707544,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.928Z",
+    "source": "etherdelta",
+    "from_currency": "0x80bc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 833,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.947Z",
+    "modified_on": "2018-05-16T16:48:49.947Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0005000005,
+    "timestamp": "2018-05-16T16:48:49.947Z",
+    "source": "etherdelta",
+    "from_currency": "0x64be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 834,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.955Z",
+    "modified_on": "2018-05-16T16:48:49.956Z",
+    "from_amount": 0.0005000005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.947Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x64be"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 835,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.962Z",
+    "modified_on": "2018-05-16T16:48:49.962Z",
+    "from_amount": 1999.998000002,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.947Z",
+    "source": "etherdelta",
+    "from_currency": "0x64be",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 836,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.968Z",
+    "modified_on": "2018-05-16T16:48:49.968Z",
+    "from_amount": 1.0,
+    "to_amount": 5.8105e-06,
+    "timestamp": "2018-05-16T16:48:49.968Z",
+    "source": "etherdelta",
+    "from_currency": "STCN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 837,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.972Z",
+    "modified_on": "2018-05-16T16:48:49.972Z",
+    "from_amount": 5.8105e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.968Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "STCN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 838,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.975Z",
+    "modified_on": "2018-05-16T16:48:49.975Z",
+    "from_amount": 172102.228723862,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.968Z",
+    "source": "etherdelta",
+    "from_currency": "STCN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 839,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.980Z",
+    "modified_on": "2018-05-16T16:48:49.980Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001862,
+    "timestamp": "2018-05-16T16:48:49.980Z",
+    "source": "etherdelta",
+    "from_currency": "0xa5f8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 840,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.984Z",
+    "modified_on": "2018-05-16T16:48:49.984Z",
+    "from_amount": 0.0001862,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.980Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa5f8"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 841,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.993Z",
+    "modified_on": "2018-05-16T16:48:49.993Z",
+    "from_amount": 5370.56928034372,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.980Z",
+    "source": "etherdelta",
+    "from_currency": "0xa5f8",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 842,
+  "fields": {
+    "created_on": "2018-05-16T16:48:49.998Z",
+    "modified_on": "2018-05-16T16:48:49.999Z",
+    "from_amount": 0.0001862,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:49.980Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa5f8"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 843,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.006Z",
+    "modified_on": "2018-05-16T16:48:50.006Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0003475,
+    "timestamp": "2018-05-16T16:48:50.006Z",
+    "source": "etherdelta",
+    "from_currency": "0xaa7a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 844,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.013Z",
+    "modified_on": "2018-05-16T16:48:50.013Z",
+    "from_amount": 0.0003475,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.006Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xaa7a"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 845,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.017Z",
+    "modified_on": "2018-05-16T16:48:50.017Z",
+    "from_amount": 2877.69784172662,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.006Z",
+    "source": "etherdelta",
+    "from_currency": "0xaa7a",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 846,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.022Z",
+    "modified_on": "2018-05-16T16:48:50.022Z",
+    "from_amount": 1.0,
+    "to_amount": 8.45e-08,
+    "timestamp": "2018-05-16T16:48:50.022Z",
+    "source": "etherdelta",
+    "from_currency": "BITC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 847,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.027Z",
+    "modified_on": "2018-05-16T16:48:50.027Z",
+    "from_amount": 8.45e-08,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.022Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BITC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 848,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.031Z",
+    "modified_on": "2018-05-16T16:48:50.031Z",
+    "from_amount": 11834319.5266272,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.022Z",
+    "source": "etherdelta",
+    "from_currency": "BITC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 849,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.036Z",
+    "modified_on": "2018-05-16T16:48:50.036Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:50.036Z",
+    "source": "etherdelta",
+    "from_currency": "0x623b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 851,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.048Z",
+    "modified_on": "2018-05-16T16:48:50.048Z",
+    "from_amount": 1.0,
+    "to_amount": 1.3e-08,
+    "timestamp": "2018-05-16T16:48:50.048Z",
+    "source": "etherdelta",
+    "from_currency": "GREED",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 852,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.052Z",
+    "modified_on": "2018-05-16T16:48:50.052Z",
+    "from_amount": 1.3e-08,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.048Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "GREED"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 853,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.060Z",
+    "modified_on": "2018-05-16T16:48:50.060Z",
+    "from_amount": 76923076.9230769,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.048Z",
+    "source": "etherdelta",
+    "from_currency": "GREED",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 854,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.066Z",
+    "modified_on": "2018-05-16T16:48:50.067Z",
+    "from_amount": 1.0,
+    "to_amount": 2.885e-07,
+    "timestamp": "2018-05-16T16:48:50.066Z",
+    "source": "etherdelta",
+    "from_currency": "0xac2b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 855,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.071Z",
+    "modified_on": "2018-05-16T16:48:50.071Z",
+    "from_amount": 2.885e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.066Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xac2b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 856,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.075Z",
+    "modified_on": "2018-05-16T16:48:50.075Z",
+    "from_amount": 3466204.50606586,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.066Z",
+    "source": "etherdelta",
+    "from_currency": "0xac2b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 857,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.079Z",
+    "modified_on": "2018-05-16T16:48:50.079Z",
+    "from_amount": 1.0,
+    "to_amount": 1.30745e-05,
+    "timestamp": "2018-05-16T16:48:50.079Z",
+    "source": "etherdelta",
+    "from_currency": "ZDR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 858,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.083Z",
+    "modified_on": "2018-05-16T16:48:50.083Z",
+    "from_amount": 1.30745e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.079Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ZDR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 859,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.091Z",
+    "modified_on": "2018-05-16T16:48:50.091Z",
+    "from_amount": 76484.760411488,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.079Z",
+    "source": "etherdelta",
+    "from_currency": "ZDR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 860,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.098Z",
+    "modified_on": "2018-05-16T16:48:50.099Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002075495,
+    "timestamp": "2018-05-16T16:48:50.099Z",
+    "source": "etherdelta",
+    "from_currency": "0xe5da",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 861,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.103Z",
+    "modified_on": "2018-05-16T16:48:50.104Z",
+    "from_amount": 0.0002075495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.099Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe5da"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 862,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.106Z",
+    "modified_on": "2018-05-16T16:48:50.106Z",
+    "from_amount": 4818.12772374783,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.099Z",
+    "source": "etherdelta",
+    "from_currency": "0xe5da",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 863,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.110Z",
+    "modified_on": "2018-05-16T16:48:50.110Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00015499,
+    "timestamp": "2018-05-16T16:48:50.110Z",
+    "source": "etherdelta",
+    "from_currency": "FUEL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 864,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.113Z",
+    "modified_on": "2018-05-16T16:48:50.113Z",
+    "from_amount": 0.00015499,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.110Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "FUEL"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 865,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.116Z",
+    "modified_on": "2018-05-16T16:48:50.116Z",
+    "from_amount": 6452.02916317182,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.110Z",
+    "source": "etherdelta",
+    "from_currency": "FUEL",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 866,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.121Z",
+    "modified_on": "2018-05-16T16:48:50.121Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-10,
+    "timestamp": "2018-05-16T16:48:50.121Z",
+    "source": "etherdelta",
+    "from_currency": "0x2bf9",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 867,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.134Z",
+    "modified_on": "2018-05-16T16:48:50.134Z",
+    "from_amount": 5e-10,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.121Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2bf9"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 868,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.137Z",
+    "modified_on": "2018-05-16T16:48:50.137Z",
+    "from_amount": 2000000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.121Z",
+    "source": "etherdelta",
+    "from_currency": "0x2bf9",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 869,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.142Z",
+    "modified_on": "2018-05-16T16:48:50.143Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00225001,
+    "timestamp": "2018-05-16T16:48:50.143Z",
+    "source": "etherdelta",
+    "from_currency": "RHOC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 870,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.148Z",
+    "modified_on": "2018-05-16T16:48:50.148Z",
+    "from_amount": 0.00225001,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.143Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "RHOC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 871,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.156Z",
+    "modified_on": "2018-05-16T16:48:50.156Z",
+    "from_amount": 444.442469144582,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.143Z",
+    "source": "etherdelta",
+    "from_currency": "RHOC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 872,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.166Z",
+    "modified_on": "2018-05-16T16:48:50.166Z",
+    "from_amount": 1.0,
+    "to_amount": 3.70925e-05,
+    "timestamp": "2018-05-16T16:48:50.166Z",
+    "source": "etherdelta",
+    "from_currency": "DEEP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 873,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.174Z",
+    "modified_on": "2018-05-16T16:48:50.174Z",
+    "from_amount": 3.70925e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.166Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DEEP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 874,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.180Z",
+    "modified_on": "2018-05-16T16:48:50.180Z",
+    "from_amount": 26959.6279571342,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.166Z",
+    "source": "etherdelta",
+    "from_currency": "DEEP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 875,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.184Z",
+    "modified_on": "2018-05-16T16:48:50.185Z",
+    "from_amount": 1.0,
+    "to_amount": 1.595e-05,
+    "timestamp": "2018-05-16T16:48:50.184Z",
+    "source": "etherdelta",
+    "from_currency": "0x4cc1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 876,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.188Z",
+    "modified_on": "2018-05-16T16:48:50.189Z",
+    "from_amount": 1.595e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.184Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4cc1"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 877,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.193Z",
+    "modified_on": "2018-05-16T16:48:50.193Z",
+    "from_amount": 62695.9247648903,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.184Z",
+    "source": "etherdelta",
+    "from_currency": "0x4cc1",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 878,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.197Z",
+    "modified_on": "2018-05-16T16:48:50.197Z",
+    "from_amount": 1.0,
+    "to_amount": 2.00045e-05,
+    "timestamp": "2018-05-16T16:48:50.197Z",
+    "source": "etherdelta",
+    "from_currency": "0xbf54",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 879,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.201Z",
+    "modified_on": "2018-05-16T16:48:50.201Z",
+    "from_amount": 2.00045e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.197Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xbf54"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 880,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.211Z",
+    "modified_on": "2018-05-16T16:48:50.211Z",
+    "from_amount": 49988.7525306806,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.197Z",
+    "source": "etherdelta",
+    "from_currency": "0xbf54",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 881,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.217Z",
+    "modified_on": "2018-05-16T16:48:50.218Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00036,
+    "timestamp": "2018-05-16T16:48:50.218Z",
+    "source": "etherdelta",
+    "from_currency": "0x28b5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 882,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.226Z",
+    "modified_on": "2018-05-16T16:48:50.226Z",
+    "from_amount": 0.00036,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.218Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x28b5"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 883,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.231Z",
+    "modified_on": "2018-05-16T16:48:50.231Z",
+    "from_amount": 2777.77777777778,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.218Z",
+    "source": "etherdelta",
+    "from_currency": "0x28b5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 884,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.234Z",
+    "modified_on": "2018-05-16T16:48:50.234Z",
+    "from_amount": 0.00036,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.218Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x28b5"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 885,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.239Z",
+    "modified_on": "2018-05-16T16:48:50.239Z",
+    "from_amount": 1.0,
+    "to_amount": 8e-05,
+    "timestamp": "2018-05-16T16:48:50.239Z",
+    "source": "etherdelta",
+    "from_currency": "WILD",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 886,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.244Z",
+    "modified_on": "2018-05-16T16:48:50.244Z",
+    "from_amount": 8e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.239Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "WILD"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 887,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.247Z",
+    "modified_on": "2018-05-16T16:48:50.247Z",
+    "from_amount": 12500.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.239Z",
+    "source": "etherdelta",
+    "from_currency": "WILD",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 888,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.251Z",
+    "modified_on": "2018-05-16T16:48:50.251Z",
+    "from_amount": 1.0,
+    "to_amount": 9.085e-07,
+    "timestamp": "2018-05-16T16:48:50.251Z",
+    "source": "etherdelta",
+    "from_currency": "0xf7dc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 889,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.261Z",
+    "modified_on": "2018-05-16T16:48:50.261Z",
+    "from_amount": 9.085e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.251Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf7dc"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 890,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.265Z",
+    "modified_on": "2018-05-16T16:48:50.266Z",
+    "from_amount": 1100715.46505228,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.251Z",
+    "source": "etherdelta",
+    "from_currency": "0xf7dc",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 891,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.274Z",
+    "modified_on": "2018-05-16T16:48:50.275Z",
+    "from_amount": 1.0,
+    "to_amount": 4.01595e-05,
+    "timestamp": "2018-05-16T16:48:50.275Z",
+    "source": "etherdelta",
+    "from_currency": "GRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 892,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.280Z",
+    "modified_on": "2018-05-16T16:48:50.280Z",
+    "from_amount": 4.01595e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.275Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "GRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 893,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.284Z",
+    "modified_on": "2018-05-16T16:48:50.284Z",
+    "from_amount": 24900.7084251547,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.275Z",
+    "source": "etherdelta",
+    "from_currency": "GRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 894,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.288Z",
+    "modified_on": "2018-05-16T16:48:50.289Z",
+    "from_amount": 1.0,
+    "to_amount": 5e-10,
+    "timestamp": "2018-05-16T16:48:50.289Z",
+    "source": "etherdelta",
+    "from_currency": "0xfa6f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 895,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.294Z",
+    "modified_on": "2018-05-16T16:48:50.294Z",
+    "from_amount": 5e-10,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.289Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xfa6f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 896,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.297Z",
+    "modified_on": "2018-05-16T16:48:50.297Z",
+    "from_amount": 2000000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.289Z",
+    "source": "etherdelta",
+    "from_currency": "0xfa6f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 897,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.301Z",
+    "modified_on": "2018-05-16T16:48:50.301Z",
+    "from_amount": 1.0,
+    "to_amount": 3.64205e-05,
+    "timestamp": "2018-05-16T16:48:50.301Z",
+    "source": "etherdelta",
+    "from_currency": "0x4092",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 898,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.311Z",
+    "modified_on": "2018-05-16T16:48:50.311Z",
+    "from_amount": 3.64205e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.301Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4092"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 899,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.315Z",
+    "modified_on": "2018-05-16T16:48:50.315Z",
+    "from_amount": 27457.0640161448,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.301Z",
+    "source": "etherdelta",
+    "from_currency": "0x4092",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 900,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.321Z",
+    "modified_on": "2018-05-16T16:48:50.322Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000622501,
+    "timestamp": "2018-05-16T16:48:50.322Z",
+    "source": "etherdelta",
+    "from_currency": "DDF",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 901,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.329Z",
+    "modified_on": "2018-05-16T16:48:50.329Z",
+    "from_amount": 0.000622501,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.322Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "DDF"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 902,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.333Z",
+    "modified_on": "2018-05-16T16:48:50.333Z",
+    "from_amount": 1606.42312221185,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.322Z",
+    "source": "etherdelta",
+    "from_currency": "DDF",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 903,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.337Z",
+    "modified_on": "2018-05-16T16:48:50.337Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:50.337Z",
+    "source": "etherdelta",
+    "from_currency": "0x9371",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 905,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.344Z",
+    "modified_on": "2018-05-16T16:48:50.344Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0004625,
+    "timestamp": "2018-05-16T16:48:50.344Z",
+    "source": "etherdelta",
+    "from_currency": "QBE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 906,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.348Z",
+    "modified_on": "2018-05-16T16:48:50.348Z",
+    "from_amount": 0.0004625,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.344Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "QBE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 907,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.351Z",
+    "modified_on": "2018-05-16T16:48:50.351Z",
+    "from_amount": 2162.16216216216,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.344Z",
+    "source": "etherdelta",
+    "from_currency": "QBE",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 908,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.359Z",
+    "modified_on": "2018-05-16T16:48:50.359Z",
+    "from_amount": 0.0004625,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.344Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "QBE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 909,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.365Z",
+    "modified_on": "2018-05-16T16:48:50.366Z",
+    "from_amount": 1.0,
+    "to_amount": 7.9256e-05,
+    "timestamp": "2018-05-16T16:48:50.366Z",
+    "source": "etherdelta",
+    "from_currency": "0x5942",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 910,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.370Z",
+    "modified_on": "2018-05-16T16:48:50.371Z",
+    "from_amount": 7.9256e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.366Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5942"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 911,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.379Z",
+    "modified_on": "2018-05-16T16:48:50.379Z",
+    "from_amount": 12617.3412738468,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.366Z",
+    "source": "etherdelta",
+    "from_currency": "0x5942",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 912,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.384Z",
+    "modified_on": "2018-05-16T16:48:50.384Z",
+    "from_amount": 1.0,
+    "to_amount": 3.005e-05,
+    "timestamp": "2018-05-16T16:48:50.384Z",
+    "source": "etherdelta",
+    "from_currency": "ASTR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 913,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.388Z",
+    "modified_on": "2018-05-16T16:48:50.388Z",
+    "from_amount": 3.005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.384Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ASTR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 914,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.393Z",
+    "modified_on": "2018-05-16T16:48:50.393Z",
+    "from_amount": 33277.8702163062,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.384Z",
+    "source": "etherdelta",
+    "from_currency": "ASTR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 915,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.397Z",
+    "modified_on": "2018-05-16T16:48:50.397Z",
+    "from_amount": 3.005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.384Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ASTR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 916,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.403Z",
+    "modified_on": "2018-05-16T16:48:50.404Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0006245,
+    "timestamp": "2018-05-16T16:48:50.404Z",
+    "source": "etherdelta",
+    "from_currency": "0x9e96",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 917,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.415Z",
+    "modified_on": "2018-05-16T16:48:50.415Z",
+    "from_amount": 0.0006245,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.404Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x9e96"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 918,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.419Z",
+    "modified_on": "2018-05-16T16:48:50.419Z",
+    "from_amount": 1601.28102481986,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.404Z",
+    "source": "etherdelta",
+    "from_currency": "0x9e96",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 919,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.428Z",
+    "modified_on": "2018-05-16T16:48:50.428Z",
+    "from_amount": 1.0,
+    "to_amount": 0.1262000595,
+    "timestamp": "2018-05-16T16:48:50.428Z",
+    "source": "etherdelta",
+    "from_currency": "ORME",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 920,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.433Z",
+    "modified_on": "2018-05-16T16:48:50.433Z",
+    "from_amount": 0.1262000595,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.428Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ORME"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 921,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.437Z",
+    "modified_on": "2018-05-16T16:48:50.437Z",
+    "from_amount": 7.92392653348947,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.428Z",
+    "source": "etherdelta",
+    "from_currency": "ORME",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 922,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.442Z",
+    "modified_on": "2018-05-16T16:48:50.442Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0005,
+    "timestamp": "2018-05-16T16:48:50.442Z",
+    "source": "etherdelta",
+    "from_currency": "0x041f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 923,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.446Z",
+    "modified_on": "2018-05-16T16:48:50.446Z",
+    "from_amount": 0.0005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.442Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x041f"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 924,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.450Z",
+    "modified_on": "2018-05-16T16:48:50.450Z",
+    "from_amount": 2000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.442Z",
+    "source": "etherdelta",
+    "from_currency": "0x041f",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 925,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.459Z",
+    "modified_on": "2018-05-16T16:48:50.459Z",
+    "from_amount": 1.0,
+    "to_amount": 4.325e-06,
+    "timestamp": "2018-05-16T16:48:50.459Z",
+    "source": "etherdelta",
+    "from_currency": "LGR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 926,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.464Z",
+    "modified_on": "2018-05-16T16:48:50.464Z",
+    "from_amount": 4.325e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.459Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LGR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 927,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.468Z",
+    "modified_on": "2018-05-16T16:48:50.468Z",
+    "from_amount": 231213.87283237,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.459Z",
+    "source": "etherdelta",
+    "from_currency": "LGR",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 928,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.482Z",
+    "modified_on": "2018-05-16T16:48:50.482Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001102,
+    "timestamp": "2018-05-16T16:48:50.482Z",
+    "source": "etherdelta",
+    "from_currency": "0x0d66",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 929,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.486Z",
+    "modified_on": "2018-05-16T16:48:50.486Z",
+    "from_amount": 0.001102,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.482Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0d66"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 930,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.489Z",
+    "modified_on": "2018-05-16T16:48:50.489Z",
+    "from_amount": 907.441016333938,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.482Z",
+    "source": "etherdelta",
+    "from_currency": "0x0d66",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 931,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.493Z",
+    "modified_on": "2018-05-16T16:48:50.494Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001,
+    "timestamp": "2018-05-16T16:48:50.494Z",
+    "source": "etherdelta",
+    "from_currency": "0x6bef",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 932,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.497Z",
+    "modified_on": "2018-05-16T16:48:50.497Z",
+    "from_amount": 0.001,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.494Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x6bef"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 933,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.500Z",
+    "modified_on": "2018-05-16T16:48:50.500Z",
+    "from_amount": 1000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.494Z",
+    "source": "etherdelta",
+    "from_currency": "0x6bef",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 934,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.511Z",
+    "modified_on": "2018-05-16T16:48:50.512Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001213502,
+    "timestamp": "2018-05-16T16:48:50.512Z",
+    "source": "etherdelta",
+    "from_currency": "STX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 935,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.517Z",
+    "modified_on": "2018-05-16T16:48:50.517Z",
+    "from_amount": 0.001213502,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.512Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "STX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 936,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.520Z",
+    "modified_on": "2018-05-16T16:48:50.520Z",
+    "from_amount": 824.061270603592,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.512Z",
+    "source": "etherdelta",
+    "from_currency": "STX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 937,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.524Z",
+    "modified_on": "2018-05-16T16:48:50.524Z",
+    "from_amount": 1.0,
+    "to_amount": 6.7005e-06,
+    "timestamp": "2018-05-16T16:48:50.524Z",
+    "source": "etherdelta",
+    "from_currency": "0x3618",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 938,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.527Z",
+    "modified_on": "2018-05-16T16:48:50.527Z",
+    "from_amount": 6.7005e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.524Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3618"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 939,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.530Z",
+    "modified_on": "2018-05-16T16:48:50.530Z",
+    "from_amount": 149242.593836281,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.524Z",
+    "source": "etherdelta",
+    "from_currency": "0x3618",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 940,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.532Z",
+    "modified_on": "2018-05-16T16:48:50.532Z",
+    "from_amount": 6.7005e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.524Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3618"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 941,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.537Z",
+    "modified_on": "2018-05-16T16:48:50.537Z",
+    "from_amount": 1.0,
+    "to_amount": 2.67e-07,
+    "timestamp": "2018-05-16T16:48:50.537Z",
+    "source": "etherdelta",
+    "from_currency": "0x95ab",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 942,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.546Z",
+    "modified_on": "2018-05-16T16:48:50.546Z",
+    "from_amount": 2.67e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.537Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x95ab"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 943,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.550Z",
+    "modified_on": "2018-05-16T16:48:50.550Z",
+    "from_amount": 3745318.35205992,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.537Z",
+    "source": "etherdelta",
+    "from_currency": "0x95ab",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 944,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.557Z",
+    "modified_on": "2018-05-16T16:48:50.558Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002518005,
+    "timestamp": "2018-05-16T16:48:50.558Z",
+    "source": "etherdelta",
+    "from_currency": "0x998b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 945,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.563Z",
+    "modified_on": "2018-05-16T16:48:50.563Z",
+    "from_amount": 0.0002518005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.558Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x998b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 946,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.567Z",
+    "modified_on": "2018-05-16T16:48:50.567Z",
+    "from_amount": 3971.39799166404,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.558Z",
+    "source": "etherdelta",
+    "from_currency": "0x998b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 947,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.571Z",
+    "modified_on": "2018-05-16T16:48:50.571Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001473505,
+    "timestamp": "2018-05-16T16:48:50.571Z",
+    "source": "etherdelta",
+    "from_currency": "0x408e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 948,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.576Z",
+    "modified_on": "2018-05-16T16:48:50.576Z",
+    "from_amount": 0.0001473505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.571Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x408e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 949,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.579Z",
+    "modified_on": "2018-05-16T16:48:50.580Z",
+    "from_amount": 6786.53957740218,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.571Z",
+    "source": "etherdelta",
+    "from_currency": "0x408e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 950,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.584Z",
+    "modified_on": "2018-05-16T16:48:50.584Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00055,
+    "timestamp": "2018-05-16T16:48:50.584Z",
+    "source": "etherdelta",
+    "from_currency": "0x4306",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 951,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.595Z",
+    "modified_on": "2018-05-16T16:48:50.596Z",
+    "from_amount": 0.00055,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.584Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4306"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 952,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.600Z",
+    "modified_on": "2018-05-16T16:48:50.600Z",
+    "from_amount": 1818.18181818182,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.584Z",
+    "source": "etherdelta",
+    "from_currency": "0x4306",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 953,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.610Z",
+    "modified_on": "2018-05-16T16:48:50.610Z",
+    "from_amount": 1.0,
+    "to_amount": 4.68e-07,
+    "timestamp": "2018-05-16T16:48:50.610Z",
+    "source": "etherdelta",
+    "from_currency": "0x3eb2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 954,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.615Z",
+    "modified_on": "2018-05-16T16:48:50.615Z",
+    "from_amount": 4.68e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.610Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3eb2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 955,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.618Z",
+    "modified_on": "2018-05-16T16:48:50.618Z",
+    "from_amount": 2136752.13675214,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.610Z",
+    "source": "etherdelta",
+    "from_currency": "0x3eb2",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 956,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.620Z",
+    "modified_on": "2018-05-16T16:48:50.620Z",
+    "from_amount": 4.68e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.610Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x3eb2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 957,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.627Z",
+    "modified_on": "2018-05-16T16:48:50.627Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:50.627Z",
+    "source": "etherdelta",
+    "from_currency": "0x52cd",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 959,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.632Z",
+    "modified_on": "2018-05-16T16:48:50.632Z",
+    "from_amount": 1.0,
+    "to_amount": 3.6e-05,
+    "timestamp": "2018-05-16T16:48:50.632Z",
+    "source": "etherdelta",
+    "from_currency": "0x5529",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 960,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.637Z",
+    "modified_on": "2018-05-16T16:48:50.638Z",
+    "from_amount": 3.6e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.632Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x5529"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 961,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.649Z",
+    "modified_on": "2018-05-16T16:48:50.649Z",
+    "from_amount": 27777.7777777778,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.632Z",
+    "source": "etherdelta",
+    "from_currency": "0x5529",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 962,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.653Z",
+    "modified_on": "2018-05-16T16:48:50.653Z",
+    "from_amount": 1.0,
+    "to_amount": 1.5e-09,
+    "timestamp": "2018-05-16T16:48:50.653Z",
+    "source": "etherdelta",
+    "from_currency": "0x0235",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 963,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.663Z",
+    "modified_on": "2018-05-16T16:48:50.663Z",
+    "from_amount": 1.5e-09,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.653Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0235"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 964,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.667Z",
+    "modified_on": "2018-05-16T16:48:50.667Z",
+    "from_amount": 666666666.666667,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.653Z",
+    "source": "etherdelta",
+    "from_currency": "0x0235",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 965,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.670Z",
+    "modified_on": "2018-05-16T16:48:50.671Z",
+    "from_amount": 1.5e-09,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.653Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x0235"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 966,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.674Z",
+    "modified_on": "2018-05-16T16:48:50.675Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0001576505,
+    "timestamp": "2018-05-16T16:48:50.674Z",
+    "source": "etherdelta",
+    "from_currency": "0x17e6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 967,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.679Z",
+    "modified_on": "2018-05-16T16:48:50.679Z",
+    "from_amount": 0.0001576505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.674Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x17e6"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 968,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.682Z",
+    "modified_on": "2018-05-16T16:48:50.682Z",
+    "from_amount": 6343.14512164567,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.674Z",
+    "source": "etherdelta",
+    "from_currency": "0x17e6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 969,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.685Z",
+    "modified_on": "2018-05-16T16:48:50.685Z",
+    "from_amount": 1.0,
+    "to_amount": 6.3e-05,
+    "timestamp": "2018-05-16T16:48:50.685Z",
+    "source": "etherdelta",
+    "from_currency": "BCO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 970,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.695Z",
+    "modified_on": "2018-05-16T16:48:50.695Z",
+    "from_amount": 6.3e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.685Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "BCO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 971,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.698Z",
+    "modified_on": "2018-05-16T16:48:50.699Z",
+    "from_amount": 15873.0158730159,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.685Z",
+    "source": "etherdelta",
+    "from_currency": "BCO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 972,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.704Z",
+    "modified_on": "2018-05-16T16:48:50.705Z",
+    "from_amount": 1.0,
+    "to_amount": 8.4785e-06,
+    "timestamp": "2018-05-16T16:48:50.704Z",
+    "source": "etherdelta",
+    "from_currency": "COSS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 973,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.714Z",
+    "modified_on": "2018-05-16T16:48:50.714Z",
+    "from_amount": 8.4785e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.704Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "COSS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 974,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.717Z",
+    "modified_on": "2018-05-16T16:48:50.717Z",
+    "from_amount": 117945.391283836,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.704Z",
+    "source": "etherdelta",
+    "from_currency": "COSS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 975,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.721Z",
+    "modified_on": "2018-05-16T16:48:50.721Z",
+    "from_amount": 1.0,
+    "to_amount": 4.10015e-05,
+    "timestamp": "2018-05-16T16:48:50.721Z",
+    "source": "etherdelta",
+    "from_currency": "0x92e5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 976,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.726Z",
+    "modified_on": "2018-05-16T16:48:50.726Z",
+    "from_amount": 4.10015e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.721Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x92e5"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 977,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.731Z",
+    "modified_on": "2018-05-16T16:48:50.731Z",
+    "from_amount": 24389.3516090875,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.721Z",
+    "source": "etherdelta",
+    "from_currency": "0x92e5",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 978,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.735Z",
+    "modified_on": "2018-05-16T16:48:50.735Z",
+    "from_amount": 1.0,
+    "to_amount": 6.955e-06,
+    "timestamp": "2018-05-16T16:48:50.735Z",
+    "source": "etherdelta",
+    "from_currency": "ETHB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 979,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.745Z",
+    "modified_on": "2018-05-16T16:48:50.745Z",
+    "from_amount": 6.955e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.735Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "ETHB"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 980,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.750Z",
+    "modified_on": "2018-05-16T16:48:50.750Z",
+    "from_amount": 143781.452192667,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.735Z",
+    "source": "etherdelta",
+    "from_currency": "ETHB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 981,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.758Z",
+    "modified_on": "2018-05-16T16:48:50.759Z",
+    "from_amount": 1.0,
+    "to_amount": 9.1545e-06,
+    "timestamp": "2018-05-16T16:48:50.759Z",
+    "source": "etherdelta",
+    "from_currency": "NEWB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 982,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.764Z",
+    "modified_on": "2018-05-16T16:48:50.765Z",
+    "from_amount": 9.1545e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.759Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "NEWB"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 983,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.768Z",
+    "modified_on": "2018-05-16T16:48:50.768Z",
+    "from_amount": 109235.894915069,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.759Z",
+    "source": "etherdelta",
+    "from_currency": "NEWB",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 984,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.771Z",
+    "modified_on": "2018-05-16T16:48:50.771Z",
+    "from_amount": 1.0,
+    "to_amount": 8.3e-05,
+    "timestamp": "2018-05-16T16:48:50.771Z",
+    "source": "etherdelta",
+    "from_currency": "FDX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 985,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.776Z",
+    "modified_on": "2018-05-16T16:48:50.776Z",
+    "from_amount": 8.3e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.771Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "FDX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 986,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.779Z",
+    "modified_on": "2018-05-16T16:48:50.779Z",
+    "from_amount": 12048.1927710843,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.771Z",
+    "source": "etherdelta",
+    "from_currency": "FDX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 987,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.782Z",
+    "modified_on": "2018-05-16T16:48:50.783Z",
+    "from_amount": 1.0,
+    "to_amount": 8.151e-05,
+    "timestamp": "2018-05-16T16:48:50.783Z",
+    "source": "etherdelta",
+    "from_currency": "0x4a52",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 988,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.788Z",
+    "modified_on": "2018-05-16T16:48:50.788Z",
+    "from_amount": 8.151e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.783Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x4a52"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 989,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.795Z",
+    "modified_on": "2018-05-16T16:48:50.795Z",
+    "from_amount": 12268.4333210649,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.783Z",
+    "source": "etherdelta",
+    "from_currency": "0x4a52",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 990,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.800Z",
+    "modified_on": "2018-05-16T16:48:50.800Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00127135,
+    "timestamp": "2018-05-16T16:48:50.800Z",
+    "source": "etherdelta",
+    "from_currency": "0x8993",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 991,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.806Z",
+    "modified_on": "2018-05-16T16:48:50.806Z",
+    "from_amount": 0.00127135,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.800Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x8993"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 992,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.811Z",
+    "modified_on": "2018-05-16T16:48:50.812Z",
+    "from_amount": 786.565461910568,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.800Z",
+    "source": "etherdelta",
+    "from_currency": "0x8993",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 993,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.816Z",
+    "modified_on": "2018-05-16T16:48:50.817Z",
+    "from_amount": 1.0,
+    "to_amount": 7.26e-05,
+    "timestamp": "2018-05-16T16:48:50.816Z",
+    "source": "etherdelta",
+    "from_currency": "LNC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 994,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.821Z",
+    "modified_on": "2018-05-16T16:48:50.821Z",
+    "from_amount": 7.26e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.816Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LNC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 995,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.825Z",
+    "modified_on": "2018-05-16T16:48:50.825Z",
+    "from_amount": 13774.1046831956,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.816Z",
+    "source": "etherdelta",
+    "from_currency": "LNC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 996,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.829Z",
+    "modified_on": "2018-05-16T16:48:50.829Z",
+    "from_amount": 1.0,
+    "to_amount": 1.8101e-05,
+    "timestamp": "2018-05-16T16:48:50.829Z",
+    "source": "etherdelta",
+    "from_currency": "0x63e6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 997,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.833Z",
+    "modified_on": "2018-05-16T16:48:50.833Z",
+    "from_amount": 1.8101e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.829Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x63e6"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 998,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.836Z",
+    "modified_on": "2018-05-16T16:48:50.836Z",
+    "from_amount": 55245.5665432849,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.829Z",
+    "source": "etherdelta",
+    "from_currency": "0x63e6",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 999,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.847Z",
+    "modified_on": "2018-05-16T16:48:50.847Z",
+    "from_amount": 1.0,
+    "to_amount": 2.00005e-05,
+    "timestamp": "2018-05-16T16:48:50.847Z",
+    "source": "etherdelta",
+    "from_currency": "0xe760",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1000,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.851Z",
+    "modified_on": "2018-05-16T16:48:50.851Z",
+    "from_amount": 2.00005e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.847Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe760"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1001,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.859Z",
+    "modified_on": "2018-05-16T16:48:50.859Z",
+    "from_amount": 49998.7500312492,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.847Z",
+    "source": "etherdelta",
+    "from_currency": "0xe760",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1002,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.863Z",
+    "modified_on": "2018-05-16T16:48:50.864Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:50.864Z",
+    "source": "etherdelta",
+    "from_currency": "JWT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1004,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.871Z",
+    "modified_on": "2018-05-16T16:48:50.871Z",
+    "from_amount": 1.0,
+    "to_amount": 3.00555e-05,
+    "timestamp": "2018-05-16T16:48:50.871Z",
+    "source": "etherdelta",
+    "from_currency": "0x2335",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1005,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.876Z",
+    "modified_on": "2018-05-16T16:48:50.876Z",
+    "from_amount": 3.00555e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.871Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x2335"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1006,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.879Z",
+    "modified_on": "2018-05-16T16:48:50.879Z",
+    "from_amount": 33271.7805393356,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.871Z",
+    "source": "etherdelta",
+    "from_currency": "0x2335",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1007,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.883Z",
+    "modified_on": "2018-05-16T16:48:50.883Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000765001,
+    "timestamp": "2018-05-16T16:48:50.883Z",
+    "source": "etherdelta",
+    "from_currency": "LLT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1008,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.896Z",
+    "modified_on": "2018-05-16T16:48:50.896Z",
+    "from_amount": 0.000765001,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.883Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "LLT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1009,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.903Z",
+    "modified_on": "2018-05-16T16:48:50.903Z",
+    "from_amount": 1307.18783374139,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.883Z",
+    "source": "etherdelta",
+    "from_currency": "LLT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1010,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.914Z",
+    "modified_on": "2018-05-16T16:48:50.915Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:50.914Z",
+    "source": "etherdelta",
+    "from_currency": "0xc761",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1012,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.922Z",
+    "modified_on": "2018-05-16T16:48:50.922Z",
+    "from_amount": 1.0,
+    "to_amount": 2.185e-07,
+    "timestamp": "2018-05-16T16:48:50.922Z",
+    "source": "etherdelta",
+    "from_currency": "0xf7ae",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1013,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.927Z",
+    "modified_on": "2018-05-16T16:48:50.927Z",
+    "from_amount": 2.185e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.922Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xf7ae"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1014,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.931Z",
+    "modified_on": "2018-05-16T16:48:50.931Z",
+    "from_amount": 4576659.0389016,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.922Z",
+    "source": "etherdelta",
+    "from_currency": "0xf7ae",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1015,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.938Z",
+    "modified_on": "2018-05-16T16:48:50.938Z",
+    "from_amount": 1.0,
+    "to_amount": 2.5e-09,
+    "timestamp": "2018-05-16T16:48:50.938Z",
+    "source": "etherdelta",
+    "from_currency": "0x12fb",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1016,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.948Z",
+    "modified_on": "2018-05-16T16:48:50.948Z",
+    "from_amount": 2.5e-09,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.938Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x12fb"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1017,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.952Z",
+    "modified_on": "2018-05-16T16:48:50.952Z",
+    "from_amount": 400000000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.938Z",
+    "source": "etherdelta",
+    "from_currency": "0x12fb",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1018,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.962Z",
+    "modified_on": "2018-05-16T16:48:50.962Z",
+    "from_amount": 1.0,
+    "to_amount": 9.135e-05,
+    "timestamp": "2018-05-16T16:48:50.962Z",
+    "source": "etherdelta",
+    "from_currency": "KSS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1019,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.967Z",
+    "modified_on": "2018-05-16T16:48:50.967Z",
+    "from_amount": 9.135e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.962Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "KSS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1020,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.972Z",
+    "modified_on": "2018-05-16T16:48:50.972Z",
+    "from_amount": 10946.9074986316,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.962Z",
+    "source": "etherdelta",
+    "from_currency": "KSS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1021,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.977Z",
+    "modified_on": "2018-05-16T16:48:50.977Z",
+    "from_amount": 1.0,
+    "to_amount": 1.9035e-06,
+    "timestamp": "2018-05-16T16:48:50.977Z",
+    "source": "etherdelta",
+    "from_currency": "CAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1022,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.982Z",
+    "modified_on": "2018-05-16T16:48:50.982Z",
+    "from_amount": 1.9035e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.977Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CAS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1023,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.985Z",
+    "modified_on": "2018-05-16T16:48:50.985Z",
+    "from_amount": 525348.04307854,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.977Z",
+    "source": "etherdelta",
+    "from_currency": "CAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1024,
+  "fields": {
+    "created_on": "2018-05-16T16:48:50.993Z",
+    "modified_on": "2018-05-16T16:48:50.993Z",
+    "from_amount": 1.9035e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:50.977Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CAS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1025,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.000Z",
+    "modified_on": "2018-05-16T16:48:51.001Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000143,
+    "timestamp": "2018-05-16T16:48:51.001Z",
+    "source": "etherdelta",
+    "from_currency": "0xa4ea",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1026,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.009Z",
+    "modified_on": "2018-05-16T16:48:51.009Z",
+    "from_amount": 0.000143,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.001Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xa4ea"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1027,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.014Z",
+    "modified_on": "2018-05-16T16:48:51.014Z",
+    "from_amount": 6993.00699300699,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.001Z",
+    "source": "etherdelta",
+    "from_currency": "0xa4ea",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1028,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.020Z",
+    "modified_on": "2018-05-16T16:48:51.020Z",
+    "from_amount": 1.0,
+    "to_amount": 2.45505e-05,
+    "timestamp": "2018-05-16T16:48:51.020Z",
+    "source": "etherdelta",
+    "from_currency": "0x949b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1029,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.025Z",
+    "modified_on": "2018-05-16T16:48:51.025Z",
+    "from_amount": 2.45505e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.020Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x949b"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1030,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.029Z",
+    "modified_on": "2018-05-16T16:48:51.029Z",
+    "from_amount": 40732.3679762123,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.020Z",
+    "source": "etherdelta",
+    "from_currency": "0x949b",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1031,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.033Z",
+    "modified_on": "2018-05-16T16:48:51.033Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:51.033Z",
+    "source": "etherdelta",
+    "from_currency": "UGT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1033,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.048Z",
+    "modified_on": "2018-05-16T16:48:51.048Z",
+    "from_amount": 1.0,
+    "to_amount": 2.025e-05,
+    "timestamp": "2018-05-16T16:48:51.048Z",
+    "source": "etherdelta",
+    "from_currency": "0xe531",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1034,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.053Z",
+    "modified_on": "2018-05-16T16:48:51.053Z",
+    "from_amount": 2.025e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.048Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0xe531"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1035,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.056Z",
+    "modified_on": "2018-05-16T16:48:51.056Z",
+    "from_amount": 49382.7160493827,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.048Z",
+    "source": "etherdelta",
+    "from_currency": "0xe531",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1036,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.060Z",
+    "modified_on": "2018-05-16T16:48:51.061Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0007500005,
+    "timestamp": "2018-05-16T16:48:51.060Z",
+    "source": "etherdelta",
+    "from_currency": "0x7c32",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1037,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.065Z",
+    "modified_on": "2018-05-16T16:48:51.065Z",
+    "from_amount": 0.0007500005,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.060Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x7c32"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1038,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.069Z",
+    "modified_on": "2018-05-16T16:48:51.069Z",
+    "from_amount": 1333.33244444504,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.060Z",
+    "source": "etherdelta",
+    "from_currency": "0x7c32",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1039,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.078Z",
+    "modified_on": "2018-05-16T16:48:51.079Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002556545,
+    "timestamp": "2018-05-16T16:48:51.079Z",
+    "source": "etherdelta",
+    "from_currency": "MEDI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1040,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.084Z",
+    "modified_on": "2018-05-16T16:48:51.084Z",
+    "from_amount": 0.0002556545,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.079Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "MEDI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1041,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.090Z",
+    "modified_on": "2018-05-16T16:48:51.090Z",
+    "from_amount": 3911.52903625792,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.079Z",
+    "source": "etherdelta",
+    "from_currency": "MEDI",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1042,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.097Z",
+    "modified_on": "2018-05-16T16:48:51.097Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000387,
+    "timestamp": "2018-05-16T16:48:51.097Z",
+    "source": "etherdelta",
+    "from_currency": "CRED",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1043,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.102Z",
+    "modified_on": "2018-05-16T16:48:51.102Z",
+    "from_amount": 0.000387,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.097Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "CRED"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1044,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.105Z",
+    "modified_on": "2018-05-16T16:48:51.105Z",
+    "from_amount": 2583.97932816537,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.097Z",
+    "source": "etherdelta",
+    "from_currency": "CRED",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1045,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.110Z",
+    "modified_on": "2018-05-16T16:48:51.110Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0,
+    "timestamp": "2018-05-16T16:48:51.110Z",
+    "source": "etherdelta",
+    "from_currency": "0x0598",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1047,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.116Z",
+    "modified_on": "2018-05-16T16:48:51.116Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00272495,
+    "timestamp": "2018-05-16T16:48:51.116Z",
+    "source": "etherdelta",
+    "from_currency": "SAN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1048,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.124Z",
+    "modified_on": "2018-05-16T16:48:51.124Z",
+    "from_amount": 0.00272495,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.116Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "SAN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1049,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.134Z",
+    "modified_on": "2018-05-16T16:48:51.134Z",
+    "from_amount": 366.979210627718,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.116Z",
+    "source": "etherdelta",
+    "from_currency": "SAN",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1050,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.143Z",
+    "modified_on": "2018-05-16T16:48:51.144Z",
+    "from_amount": 1.0,
+    "to_amount": 1.4225e-06,
+    "timestamp": "2018-05-16T16:48:51.144Z",
+    "source": "etherdelta",
+    "from_currency": "IBTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1051,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.150Z",
+    "modified_on": "2018-05-16T16:48:51.150Z",
+    "from_amount": 1.4225e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.144Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "IBTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1052,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.154Z",
+    "modified_on": "2018-05-16T16:48:51.155Z",
+    "from_amount": 702987.69771529,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.144Z",
+    "source": "etherdelta",
+    "from_currency": "IBTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1053,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.159Z",
+    "modified_on": "2018-05-16T16:48:51.159Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00100125,
+    "timestamp": "2018-05-16T16:48:51.159Z",
+    "source": "etherdelta",
+    "from_currency": "0x369e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1054,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.164Z",
+    "modified_on": "2018-05-16T16:48:51.164Z",
+    "from_amount": 0.00100125,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.159Z",
+    "source": "etherdelta",
+    "from_currency": "ETH",
+    "to_currency": "0x369e"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1055,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.168Z",
+    "modified_on": "2018-05-16T16:48:51.168Z",
+    "from_amount": 998.751560549313,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.159Z",
+    "source": "etherdelta",
+    "from_currency": "0x369e",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1056,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.494Z",
+    "modified_on": "2018-05-16T16:48:51.494Z",
+    "from_amount": 1.0,
+    "to_amount": 1.245e-06,
+    "timestamp": "2018-05-16T16:48:51.494Z",
+    "source": "poloniex",
+    "from_currency": "BCN",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1057,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.498Z",
+    "modified_on": "2018-05-16T16:48:51.498Z",
+    "from_amount": 1.245e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.494Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BCN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1058,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.500Z",
+    "modified_on": "2018-05-16T16:48:51.500Z",
+    "from_amount": 803212.851405623,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.494Z",
+    "source": "poloniex",
+    "from_currency": "BCN",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1059,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.503Z",
+    "modified_on": "2018-05-16T16:48:51.503Z",
+    "from_amount": 1.0,
+    "to_amount": 7.28e-06,
+    "timestamp": "2018-05-16T16:48:51.503Z",
+    "source": "poloniex",
+    "from_currency": "BELA",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1060,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.507Z",
+    "modified_on": "2018-05-16T16:48:51.507Z",
+    "from_amount": 7.28e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.503Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BELA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1061,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.509Z",
+    "modified_on": "2018-05-16T16:48:51.509Z",
+    "from_amount": 137362.637362637,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.503Z",
+    "source": "poloniex",
+    "from_currency": "BELA",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1062,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.511Z",
+    "modified_on": "2018-05-16T16:48:51.511Z",
+    "from_amount": 7.28e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.503Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BELA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1063,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.523Z",
+    "modified_on": "2018-05-16T16:48:51.523Z",
+    "from_amount": 1.0,
+    "to_amount": 3.1465e-05,
+    "timestamp": "2018-05-16T16:48:51.523Z",
+    "source": "poloniex",
+    "from_currency": "BLK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1064,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.530Z",
+    "modified_on": "2018-05-16T16:48:51.530Z",
+    "from_amount": 3.1465e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.523Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BLK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1065,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.533Z",
+    "modified_on": "2018-05-16T16:48:51.533Z",
+    "from_amount": 31781.344350866,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.523Z",
+    "source": "poloniex",
+    "from_currency": "BLK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1066,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.536Z",
+    "modified_on": "2018-05-16T16:48:51.537Z",
+    "from_amount": 1.0,
+    "to_amount": 0.010901925,
+    "timestamp": "2018-05-16T16:48:51.537Z",
+    "source": "poloniex",
+    "from_currency": "BTCD",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1067,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.542Z",
+    "modified_on": "2018-05-16T16:48:51.542Z",
+    "from_amount": 0.010901925,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.537Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BTCD"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1068,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.545Z",
+    "modified_on": "2018-05-16T16:48:51.545Z",
+    "from_amount": 91.7269197871018,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.537Z",
+    "source": "poloniex",
+    "from_currency": "BTCD",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1069,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.549Z",
+    "modified_on": "2018-05-16T16:48:51.549Z",
+    "from_amount": 1.0,
+    "to_amount": 6.345e-05,
+    "timestamp": "2018-05-16T16:48:51.549Z",
+    "source": "poloniex",
+    "from_currency": "Bitmark",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1070,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.553Z",
+    "modified_on": "2018-05-16T16:48:51.553Z",
+    "from_amount": 6.345e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.549Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "Bitmark"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1071,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.557Z",
+    "modified_on": "2018-05-16T16:48:51.557Z",
+    "from_amount": 15760.4412923562,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.549Z",
+    "source": "poloniex",
+    "from_currency": "Bitmark",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1072,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.560Z",
+    "modified_on": "2018-05-16T16:48:51.560Z",
+    "from_amount": 1.0,
+    "to_amount": 2.941e-05,
+    "timestamp": "2018-05-16T16:48:51.560Z",
+    "source": "poloniex",
+    "from_currency": "BTS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1073,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.564Z",
+    "modified_on": "2018-05-16T16:48:51.565Z",
+    "from_amount": 2.941e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.560Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BTS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1074,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.569Z",
+    "modified_on": "2018-05-16T16:48:51.569Z",
+    "from_amount": 34002.0401224074,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.560Z",
+    "source": "poloniex",
+    "from_currency": "BTS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1075,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.571Z",
+    "modified_on": "2018-05-16T16:48:51.571Z",
+    "from_amount": 2.941e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.560Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BTS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1076,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.575Z",
+    "modified_on": "2018-05-16T16:48:51.575Z",
+    "from_amount": 1.0,
+    "to_amount": 3.125e-06,
+    "timestamp": "2018-05-16T16:48:51.575Z",
+    "source": "poloniex",
+    "from_currency": "BURST",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1077,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.580Z",
+    "modified_on": "2018-05-16T16:48:51.580Z",
+    "from_amount": 3.125e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.575Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BURST"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1078,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.583Z",
+    "modified_on": "2018-05-16T16:48:51.583Z",
+    "from_amount": 320000.0,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.575Z",
+    "source": "poloniex",
+    "from_currency": "BURST",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1079,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.585Z",
+    "modified_on": "2018-05-16T16:48:51.585Z",
+    "from_amount": 3.125e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.575Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BURST"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1080,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.593Z",
+    "modified_on": "2018-05-16T16:48:51.593Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000457345,
+    "timestamp": "2018-05-16T16:48:51.593Z",
+    "source": "poloniex",
+    "from_currency": "CLAM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1081,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.600Z",
+    "modified_on": "2018-05-16T16:48:51.600Z",
+    "from_amount": 0.000457345,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.593Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "CLAM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1082,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.604Z",
+    "modified_on": "2018-05-16T16:48:51.604Z",
+    "from_amount": 2186.53314237611,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.593Z",
+    "source": "poloniex",
+    "from_currency": "CLAM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1083,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.607Z",
+    "modified_on": "2018-05-16T16:48:51.607Z",
+    "from_amount": 0.000457345,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.593Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "CLAM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1084,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.612Z",
+    "modified_on": "2018-05-16T16:48:51.612Z",
+    "from_amount": 1.0,
+    "to_amount": 0.04951555,
+    "timestamp": "2018-05-16T16:48:51.612Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1085,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.615Z",
+    "modified_on": "2018-05-16T16:48:51.615Z",
+    "from_amount": 0.04951555,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.612Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "DASH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1086,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.617Z",
+    "modified_on": "2018-05-16T16:48:51.617Z",
+    "from_amount": 20.1956759038322,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.612Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1087,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.620Z",
+    "modified_on": "2018-05-16T16:48:51.620Z",
+    "from_amount": 1.0,
+    "to_amount": 4.685e-06,
+    "timestamp": "2018-05-16T16:48:51.620Z",
+    "source": "poloniex",
+    "from_currency": "DGB",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1088,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.626Z",
+    "modified_on": "2018-05-16T16:48:51.626Z",
+    "from_amount": 4.685e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.620Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "DGB"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1089,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.631Z",
+    "modified_on": "2018-05-16T16:48:51.632Z",
+    "from_amount": 213447.171824973,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.620Z",
+    "source": "poloniex",
+    "from_currency": "DGB",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1090,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.636Z",
+    "modified_on": "2018-05-16T16:48:51.636Z",
+    "from_amount": 1.0,
+    "to_amount": 5.25e-07,
+    "timestamp": "2018-05-16T16:48:51.636Z",
+    "source": "poloniex",
+    "from_currency": "DOGE",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1091,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.642Z",
+    "modified_on": "2018-05-16T16:48:51.642Z",
+    "from_amount": 5.25e-07,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.636Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "DOGE"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1092,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.645Z",
+    "modified_on": "2018-05-16T16:48:51.645Z",
+    "from_amount": 1904761.9047619,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.636Z",
+    "source": "poloniex",
+    "from_currency": "DOGE",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1093,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.648Z",
+    "modified_on": "2018-05-16T16:48:51.648Z",
+    "from_amount": 1.0,
+    "to_amount": 2.7655e-05,
+    "timestamp": "2018-05-16T16:48:51.648Z",
+    "source": "poloniex",
+    "from_currency": "EMC2",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1094,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.652Z",
+    "modified_on": "2018-05-16T16:48:51.652Z",
+    "from_amount": 2.7655e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.648Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "EMC2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1095,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.657Z",
+    "modified_on": "2018-05-16T16:48:51.658Z",
+    "from_amount": 36159.8264328331,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.648Z",
+    "source": "poloniex",
+    "from_currency": "EMC2",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1096,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.664Z",
+    "modified_on": "2018-05-16T16:48:51.664Z",
+    "from_amount": 2.7655e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.648Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "EMC2"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1097,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.669Z",
+    "modified_on": "2018-05-16T16:48:51.670Z",
+    "from_amount": 1.0,
+    "to_amount": 1.96e-06,
+    "timestamp": "2018-05-16T16:48:51.670Z",
+    "source": "poloniex",
+    "from_currency": "FLDC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1098,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.674Z",
+    "modified_on": "2018-05-16T16:48:51.674Z",
+    "from_amount": 1.96e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.670Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "FLDC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1099,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.676Z",
+    "modified_on": "2018-05-16T16:48:51.676Z",
+    "from_amount": 510204.081632653,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.670Z",
+    "source": "poloniex",
+    "from_currency": "FLDC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1100,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.680Z",
+    "modified_on": "2018-05-16T16:48:51.681Z",
+    "from_amount": 1.0,
+    "to_amount": 1.204e-05,
+    "timestamp": "2018-05-16T16:48:51.681Z",
+    "source": "poloniex",
+    "from_currency": "FLO",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1101,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.685Z",
+    "modified_on": "2018-05-16T16:48:51.685Z",
+    "from_amount": 1.204e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.681Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "FLO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1102,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.690Z",
+    "modified_on": "2018-05-16T16:48:51.690Z",
+    "from_amount": 83056.4784053156,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.681Z",
+    "source": "poloniex",
+    "from_currency": "FLO",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1103,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.698Z",
+    "modified_on": "2018-05-16T16:48:51.698Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000164055,
+    "timestamp": "2018-05-16T16:48:51.698Z",
+    "source": "poloniex",
+    "from_currency": "GAME",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1104,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.703Z",
+    "modified_on": "2018-05-16T16:48:51.703Z",
+    "from_amount": 0.000164055,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.698Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "GAME"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1105,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.706Z",
+    "modified_on": "2018-05-16T16:48:51.706Z",
+    "from_amount": 6095.51674743226,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.698Z",
+    "source": "poloniex",
+    "from_currency": "GAME",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1106,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.709Z",
+    "modified_on": "2018-05-16T16:48:51.709Z",
+    "from_amount": 1.0,
+    "to_amount": 5.335e-06,
+    "timestamp": "2018-05-16T16:48:51.709Z",
+    "source": "poloniex",
+    "from_currency": "GRC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1107,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.714Z",
+    "modified_on": "2018-05-16T16:48:51.714Z",
+    "from_amount": 5.335e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.709Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "GRC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1108,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.718Z",
+    "modified_on": "2018-05-16T16:48:51.718Z",
+    "from_amount": 187441.424554827,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.709Z",
+    "source": "poloniex",
+    "from_currency": "GRC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1109,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.725Z",
+    "modified_on": "2018-05-16T16:48:51.726Z",
+    "from_amount": 1.0,
+    "to_amount": 1.5685e-05,
+    "timestamp": "2018-05-16T16:48:51.726Z",
+    "source": "poloniex",
+    "from_currency": "HUC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1110,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.734Z",
+    "modified_on": "2018-05-16T16:48:51.734Z",
+    "from_amount": 1.5685e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.726Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "HUC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1111,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.739Z",
+    "modified_on": "2018-05-16T16:48:51.739Z",
+    "from_amount": 63755.1801083838,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.726Z",
+    "source": "poloniex",
+    "from_currency": "HUC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1112,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.749Z",
+    "modified_on": "2018-05-16T16:48:51.749Z",
+    "from_amount": 1.0,
+    "to_amount": 0.01661746,
+    "timestamp": "2018-05-16T16:48:51.749Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1113,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.754Z",
+    "modified_on": "2018-05-16T16:48:51.754Z",
+    "from_amount": 0.01661746,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.749Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "LTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1114,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.757Z",
+    "modified_on": "2018-05-16T16:48:51.757Z",
+    "from_amount": 60.177668548623,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.749Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1115,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.762Z",
+    "modified_on": "2018-05-16T16:48:51.763Z",
+    "from_amount": 1.0,
+    "to_amount": 4.1645e-05,
+    "timestamp": "2018-05-16T16:48:51.763Z",
+    "source": "poloniex",
+    "from_currency": "MAID",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1116,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.768Z",
+    "modified_on": "2018-05-16T16:48:51.768Z",
+    "from_amount": 4.1645e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.763Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "MAID"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1117,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.775Z",
+    "modified_on": "2018-05-16T16:48:51.775Z",
+    "from_amount": 24012.4864929763,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.763Z",
+    "source": "poloniex",
+    "from_currency": "MAID",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1118,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.785Z",
+    "modified_on": "2018-05-16T16:48:51.785Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00400042,
+    "timestamp": "2018-05-16T16:48:51.785Z",
+    "source": "poloniex",
+    "from_currency": "OMNI",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1119,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.794Z",
+    "modified_on": "2018-05-16T16:48:51.794Z",
+    "from_amount": 0.00400042,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.785Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "OMNI"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1120,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.799Z",
+    "modified_on": "2018-05-16T16:48:51.799Z",
+    "from_amount": 249.973752755961,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.785Z",
+    "source": "poloniex",
+    "from_currency": "OMNI",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1121,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.804Z",
+    "modified_on": "2018-05-16T16:48:51.804Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000137225,
+    "timestamp": "2018-05-16T16:48:51.804Z",
+    "source": "poloniex",
+    "from_currency": "NAV",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1122,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.809Z",
+    "modified_on": "2018-05-16T16:48:51.809Z",
+    "from_amount": 0.000137225,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.804Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NAV"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1123,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.813Z",
+    "modified_on": "2018-05-16T16:48:51.813Z",
+    "from_amount": 7287.30187648023,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.804Z",
+    "source": "poloniex",
+    "from_currency": "NAV",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1124,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.819Z",
+    "modified_on": "2018-05-16T16:48:51.819Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00032474,
+    "timestamp": "2018-05-16T16:48:51.819Z",
+    "source": "poloniex",
+    "from_currency": "NEOS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1125,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.830Z",
+    "modified_on": "2018-05-16T16:48:51.830Z",
+    "from_amount": 0.00032474,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.819Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NEOS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1126,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.836Z",
+    "modified_on": "2018-05-16T16:48:51.836Z",
+    "from_amount": 3079.38658619203,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.819Z",
+    "source": "poloniex",
+    "from_currency": "NEOS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1127,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.845Z",
+    "modified_on": "2018-05-16T16:48:51.846Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0002417,
+    "timestamp": "2018-05-16T16:48:51.846Z",
+    "source": "poloniex",
+    "from_currency": "NMC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1128,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.853Z",
+    "modified_on": "2018-05-16T16:48:51.853Z",
+    "from_amount": 0.0002417,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.846Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NMC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1129,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.857Z",
+    "modified_on": "2018-05-16T16:48:51.857Z",
+    "from_amount": 4137.36036408771,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.846Z",
+    "source": "poloniex",
+    "from_currency": "NMC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1130,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.861Z",
+    "modified_on": "2018-05-16T16:48:51.861Z",
+    "from_amount": 0.0002417,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.846Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NMC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1131,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.869Z",
+    "modified_on": "2018-05-16T16:48:51.870Z",
+    "from_amount": 1.0,
+    "to_amount": 1.965e-05,
+    "timestamp": "2018-05-16T16:48:51.869Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1132,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.881Z",
+    "modified_on": "2018-05-16T16:48:51.881Z",
+    "from_amount": 1.965e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.869Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NXT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1133,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.886Z",
+    "modified_on": "2018-05-16T16:48:51.886Z",
+    "from_amount": 50890.5852417303,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.869Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1134,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.896Z",
+    "modified_on": "2018-05-16T16:48:51.896Z",
+    "from_amount": 1.0,
+    "to_amount": 2.68e-06,
+    "timestamp": "2018-05-16T16:48:51.896Z",
+    "source": "poloniex",
+    "from_currency": "PINK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1135,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.902Z",
+    "modified_on": "2018-05-16T16:48:51.902Z",
+    "from_amount": 2.68e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.896Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "PINK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1136,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.906Z",
+    "modified_on": "2018-05-16T16:48:51.907Z",
+    "from_amount": 373134.328358209,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.896Z",
+    "source": "poloniex",
+    "from_currency": "PINK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1137,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.912Z",
+    "modified_on": "2018-05-16T16:48:51.912Z",
+    "from_amount": 1.0,
+    "to_amount": 1.245e-05,
+    "timestamp": "2018-05-16T16:48:51.912Z",
+    "source": "poloniex",
+    "from_currency": "POT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1138,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.917Z",
+    "modified_on": "2018-05-16T16:48:51.917Z",
+    "from_amount": 1.245e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.912Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "POT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1139,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.920Z",
+    "modified_on": "2018-05-16T16:48:51.920Z",
+    "from_amount": 80321.2851405622,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.912Z",
+    "source": "poloniex",
+    "from_currency": "POT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1140,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.932Z",
+    "modified_on": "2018-05-16T16:48:51.932Z",
+    "from_amount": 1.245e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.912Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "POT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1141,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.937Z",
+    "modified_on": "2018-05-16T16:48:51.938Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00032565,
+    "timestamp": "2018-05-16T16:48:51.938Z",
+    "source": "poloniex",
+    "from_currency": "PPC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1142,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.946Z",
+    "modified_on": "2018-05-16T16:48:51.946Z",
+    "from_amount": 0.00032565,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.938Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "PPC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1143,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.951Z",
+    "modified_on": "2018-05-16T16:48:51.951Z",
+    "from_amount": 3070.78151389529,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.938Z",
+    "source": "poloniex",
+    "from_currency": "PPC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1144,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.956Z",
+    "modified_on": "2018-05-16T16:48:51.956Z",
+    "from_amount": 1.0,
+    "to_amount": 1.0185e-05,
+    "timestamp": "2018-05-16T16:48:51.956Z",
+    "source": "poloniex",
+    "from_currency": "RIC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1145,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.961Z",
+    "modified_on": "2018-05-16T16:48:51.961Z",
+    "from_amount": 1.0185e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.956Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "RIC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1146,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.965Z",
+    "modified_on": "2018-05-16T16:48:51.965Z",
+    "from_amount": 98183.6033382425,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.956Z",
+    "source": "poloniex",
+    "from_currency": "RIC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1147,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.971Z",
+    "modified_on": "2018-05-16T16:48:51.971Z",
+    "from_amount": 1.0,
+    "to_amount": 3.9365e-05,
+    "timestamp": "2018-05-16T16:48:51.971Z",
+    "source": "poloniex",
+    "from_currency": "XLM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1148,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.982Z",
+    "modified_on": "2018-05-16T16:48:51.982Z",
+    "from_amount": 3.9365e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.971Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XLM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1149,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.985Z",
+    "modified_on": "2018-05-16T16:48:51.986Z",
+    "from_amount": 25403.2770227359,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.971Z",
+    "source": "poloniex",
+    "from_currency": "XLM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1150,
+  "fields": {
+    "created_on": "2018-05-16T16:48:51.994Z",
+    "modified_on": "2018-05-16T16:48:51.994Z",
+    "from_amount": 1.0,
+    "to_amount": 4.362e-05,
+    "timestamp": "2018-05-16T16:48:51.994Z",
+    "source": "poloniex",
+    "from_currency": "SYS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1151,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.000Z",
+    "modified_on": "2018-05-16T16:48:52.000Z",
+    "from_amount": 4.362e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.994Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "SYS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1152,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.003Z",
+    "modified_on": "2018-05-16T16:48:52.003Z",
+    "from_amount": 22925.2636405319,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:51.994Z",
+    "source": "poloniex",
+    "from_currency": "SYS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1153,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.007Z",
+    "modified_on": "2018-05-16T16:48:52.007Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00024058,
+    "timestamp": "2018-05-16T16:48:52.007Z",
+    "source": "poloniex",
+    "from_currency": "VIA",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1154,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.012Z",
+    "modified_on": "2018-05-16T16:48:52.012Z",
+    "from_amount": 0.00024058,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.007Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "VIA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1155,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.015Z",
+    "modified_on": "2018-05-16T16:48:52.015Z",
+    "from_amount": 4156.62149804639,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.007Z",
+    "source": "poloniex",
+    "from_currency": "VIA",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1156,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.018Z",
+    "modified_on": "2018-05-16T16:48:52.018Z",
+    "from_amount": 0.00024058,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.007Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "VIA"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1157,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.027Z",
+    "modified_on": "2018-05-16T16:48:52.028Z",
+    "from_amount": 1.0,
+    "to_amount": 3.058e-05,
+    "timestamp": "2018-05-16T16:48:52.027Z",
+    "source": "poloniex",
+    "from_currency": "XVC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1158,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.032Z",
+    "modified_on": "2018-05-16T16:48:52.033Z",
+    "from_amount": 3.058e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.027Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XVC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1159,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.037Z",
+    "modified_on": "2018-05-16T16:48:52.037Z",
+    "from_amount": 32701.1118378025,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.027Z",
+    "source": "poloniex",
+    "from_currency": "XVC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1160,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.047Z",
+    "modified_on": "2018-05-16T16:48:52.047Z",
+    "from_amount": 1.0,
+    "to_amount": 6.638e-05,
+    "timestamp": "2018-05-16T16:48:52.047Z",
+    "source": "poloniex",
+    "from_currency": "VRC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1161,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.053Z",
+    "modified_on": "2018-05-16T16:48:52.053Z",
+    "from_amount": 6.638e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.047Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "VRC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1162,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.056Z",
+    "modified_on": "2018-05-16T16:48:52.056Z",
+    "from_amount": 15064.7785477553,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.047Z",
+    "source": "poloniex",
+    "from_currency": "VRC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1163,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.061Z",
+    "modified_on": "2018-05-16T16:48:52.061Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00026689,
+    "timestamp": "2018-05-16T16:48:52.061Z",
+    "source": "poloniex",
+    "from_currency": "VTC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1164,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.065Z",
+    "modified_on": "2018-05-16T16:48:52.065Z",
+    "from_amount": 0.00026689,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.061Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "VTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1165,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.069Z",
+    "modified_on": "2018-05-16T16:48:52.069Z",
+    "from_amount": 3746.86200307243,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.061Z",
+    "source": "poloniex",
+    "from_currency": "VTC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1166,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.080Z",
+    "modified_on": "2018-05-16T16:48:52.080Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00623197,
+    "timestamp": "2018-05-16T16:48:52.080Z",
+    "source": "poloniex",
+    "from_currency": "XBC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1167,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.086Z",
+    "modified_on": "2018-05-16T16:48:52.086Z",
+    "from_amount": 0.00623197,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.080Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XBC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1168,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.089Z",
+    "modified_on": "2018-05-16T16:48:52.090Z",
+    "from_amount": 160.462903383681,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.080Z",
+    "source": "poloniex",
+    "from_currency": "XBC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1169,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.094Z",
+    "modified_on": "2018-05-16T16:48:52.094Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00181753,
+    "timestamp": "2018-05-16T16:48:52.094Z",
+    "source": "poloniex",
+    "from_currency": "XCP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1170,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.098Z",
+    "modified_on": "2018-05-16T16:48:52.098Z",
+    "from_amount": 0.00181753,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.094Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XCP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1171,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.101Z",
+    "modified_on": "2018-05-16T16:48:52.101Z",
+    "from_amount": 550.197245712588,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.094Z",
+    "source": "poloniex",
+    "from_currency": "XCP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1172,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.103Z",
+    "modified_on": "2018-05-16T16:48:52.103Z",
+    "from_amount": 0.00181753,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.094Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XCP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1173,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.118Z",
+    "modified_on": "2018-05-16T16:48:52.118Z",
+    "from_amount": 1.0,
+    "to_amount": 3.85e-05,
+    "timestamp": "2018-05-16T16:48:52.118Z",
+    "source": "poloniex",
+    "from_currency": "XEM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1174,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.125Z",
+    "modified_on": "2018-05-16T16:48:52.125Z",
+    "from_amount": 3.85e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.118Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XEM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1175,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.130Z",
+    "modified_on": "2018-05-16T16:48:52.130Z",
+    "from_amount": 25974.025974026,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.118Z",
+    "source": "poloniex",
+    "from_currency": "XEM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1176,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.135Z",
+    "modified_on": "2018-05-16T16:48:52.135Z",
+    "from_amount": 1.0,
+    "to_amount": 0.02377331,
+    "timestamp": "2018-05-16T16:48:52.135Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1177,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.146Z",
+    "modified_on": "2018-05-16T16:48:52.146Z",
+    "from_amount": 0.02377331,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.135Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1178,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.151Z",
+    "modified_on": "2018-05-16T16:48:52.151Z",
+    "from_amount": 42.0639784699733,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.135Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1179,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.157Z",
+    "modified_on": "2018-05-16T16:48:52.157Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00027103,
+    "timestamp": "2018-05-16T16:48:52.157Z",
+    "source": "poloniex",
+    "from_currency": "XPM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1180,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.162Z",
+    "modified_on": "2018-05-16T16:48:52.162Z",
+    "from_amount": 0.00027103,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.157Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XPM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1181,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.165Z",
+    "modified_on": "2018-05-16T16:48:52.165Z",
+    "from_amount": 3689.62845441464,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.157Z",
+    "source": "poloniex",
+    "from_currency": "XPM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1182,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.169Z",
+    "modified_on": "2018-05-16T16:48:52.169Z",
+    "from_amount": 1.0,
+    "to_amount": 8.2175e-05,
+    "timestamp": "2018-05-16T16:48:52.169Z",
+    "source": "poloniex",
+    "from_currency": "XRP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1183,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.180Z",
+    "modified_on": "2018-05-16T16:48:52.181Z",
+    "from_amount": 8.2175e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.169Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "XRP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1184,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.186Z",
+    "modified_on": "2018-05-16T16:48:52.186Z",
+    "from_amount": 12169.1512017037,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.169Z",
+    "source": "poloniex",
+    "from_currency": "XRP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1185,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.191Z",
+    "modified_on": "2018-05-16T16:48:52.191Z",
+    "from_amount": 1.0,
+    "to_amount": 8230.25164679,
+    "timestamp": "2018-05-16T16:48:52.191Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1186,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.196Z",
+    "modified_on": "2018-05-16T16:48:52.196Z",
+    "from_amount": 8230.25164679,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.191Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1187,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.198Z",
+    "modified_on": "2018-05-16T16:48:52.199Z",
+    "from_amount": 0.00012150296769966,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.191Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1188,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.202Z",
+    "modified_on": "2018-05-16T16:48:52.202Z",
+    "from_amount": 1.0,
+    "to_amount": 406.714052585,
+    "timestamp": "2018-05-16T16:48:52.202Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1189,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.211Z",
+    "modified_on": "2018-05-16T16:48:52.211Z",
+    "from_amount": 406.714052585,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.202Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "DASH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1190,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.217Z",
+    "modified_on": "2018-05-16T16:48:52.217Z",
+    "from_amount": 0.0024587298954737,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.202Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1191,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.221Z",
+    "modified_on": "2018-05-16T16:48:52.222Z",
+    "from_amount": 406.714052585,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.202Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "DASH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1192,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.227Z",
+    "modified_on": "2018-05-16T16:48:52.227Z",
+    "from_amount": 1.0,
+    "to_amount": 136.87873812,
+    "timestamp": "2018-05-16T16:48:52.227Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1193,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.231Z",
+    "modified_on": "2018-05-16T16:48:52.231Z",
+    "from_amount": 136.87873812,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.227Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "LTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1194,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.234Z",
+    "modified_on": "2018-05-16T16:48:52.234Z",
+    "from_amount": 0.00730573654999151,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.227Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1195,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.237Z",
+    "modified_on": "2018-05-16T16:48:52.238Z",
+    "from_amount": 1.0,
+    "to_amount": 0.16235,
+    "timestamp": "2018-05-16T16:48:52.238Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1196,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.249Z",
+    "modified_on": "2018-05-16T16:48:52.249Z",
+    "from_amount": 0.16235,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.238Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "NXT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1197,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.253Z",
+    "modified_on": "2018-05-16T16:48:52.253Z",
+    "from_amount": 6.15953187557746,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.238Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1198,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.259Z",
+    "modified_on": "2018-05-16T16:48:52.259Z",
+    "from_amount": 1.0,
+    "to_amount": 0.32388037,
+    "timestamp": "2018-05-16T16:48:52.259Z",
+    "source": "poloniex",
+    "from_currency": "XLM",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1199,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.264Z",
+    "modified_on": "2018-05-16T16:48:52.264Z",
+    "from_amount": 0.32388037,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.259Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "XLM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1200,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.267Z",
+    "modified_on": "2018-05-16T16:48:52.267Z",
+    "from_amount": 3.08755976782415,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.259Z",
+    "source": "poloniex",
+    "from_currency": "XLM",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1201,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.272Z",
+    "modified_on": "2018-05-16T16:48:52.273Z",
+    "from_amount": 1.0,
+    "to_amount": 195.40848044,
+    "timestamp": "2018-05-16T16:48:52.273Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1202,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.283Z",
+    "modified_on": "2018-05-16T16:48:52.283Z",
+    "from_amount": 195.40848044,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.273Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1203,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.286Z",
+    "modified_on": "2018-05-16T16:48:52.286Z",
+    "from_amount": 0.00511748516619292,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.273Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1204,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.292Z",
+    "modified_on": "2018-05-16T16:48:52.292Z",
+    "from_amount": 1.0,
+    "to_amount": 0.67649523,
+    "timestamp": "2018-05-16T16:48:52.292Z",
+    "source": "poloniex",
+    "from_currency": "XRP",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1205,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.296Z",
+    "modified_on": "2018-05-16T16:48:52.296Z",
+    "from_amount": 0.67649523,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.292Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "XRP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1206,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.298Z",
+    "modified_on": "2018-05-16T16:48:52.298Z",
+    "from_amount": 1.47820702298226,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.292Z",
+    "source": "poloniex",
+    "from_currency": "XRP",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1207,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.302Z",
+    "modified_on": "2018-05-16T16:48:52.302Z",
+    "from_amount": 1.0,
+    "to_amount": 5.261e-05,
+    "timestamp": "2018-05-16T16:48:52.302Z",
+    "source": "poloniex",
+    "from_currency": "BCN",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1208,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.310Z",
+    "modified_on": "2018-05-16T16:48:52.311Z",
+    "from_amount": 5.261e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.302Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "BCN"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1209,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.317Z",
+    "modified_on": "2018-05-16T16:48:52.317Z",
+    "from_amount": 19007.79319521,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.302Z",
+    "source": "poloniex",
+    "from_currency": "BCN",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1210,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.322Z",
+    "modified_on": "2018-05-16T16:48:52.323Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00133767,
+    "timestamp": "2018-05-16T16:48:52.322Z",
+    "source": "poloniex",
+    "from_currency": "BLK",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1211,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.327Z",
+    "modified_on": "2018-05-16T16:48:52.327Z",
+    "from_amount": 0.00133767,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.322Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "BLK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1212,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.330Z",
+    "modified_on": "2018-05-16T16:48:52.330Z",
+    "from_amount": 747.568533345294,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.322Z",
+    "source": "poloniex",
+    "from_currency": "BLK",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1213,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.334Z",
+    "modified_on": "2018-05-16T16:48:52.334Z",
+    "from_amount": 1.0,
+    "to_amount": 0.4557334,
+    "timestamp": "2018-05-16T16:48:52.334Z",
+    "source": "poloniex",
+    "from_currency": "BTCD",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1214,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.339Z",
+    "modified_on": "2018-05-16T16:48:52.339Z",
+    "from_amount": 0.4557334,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.334Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "BTCD"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1215,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.349Z",
+    "modified_on": "2018-05-16T16:48:52.349Z",
+    "from_amount": 2.19426533144158,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.334Z",
+    "source": "poloniex",
+    "from_currency": "BTCD",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1216,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.354Z",
+    "modified_on": "2018-05-16T16:48:52.354Z",
+    "from_amount": 1.0,
+    "to_amount": 2.075450675,
+    "timestamp": "2018-05-16T16:48:52.354Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1217,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.360Z",
+    "modified_on": "2018-05-16T16:48:52.360Z",
+    "from_amount": 2.075450675,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.354Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "DASH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1218,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.363Z",
+    "modified_on": "2018-05-16T16:48:52.363Z",
+    "from_amount": 0.481823062357288,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.354Z",
+    "source": "poloniex",
+    "from_currency": "DASH",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1219,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.367Z",
+    "modified_on": "2018-05-16T16:48:52.367Z",
+    "from_amount": 1.0,
+    "to_amount": 0.69929178,
+    "timestamp": "2018-05-16T16:48:52.367Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1220,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.371Z",
+    "modified_on": "2018-05-16T16:48:52.371Z",
+    "from_amount": 0.69929178,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.367Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "LTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1221,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.378Z",
+    "modified_on": "2018-05-16T16:48:52.379Z",
+    "from_amount": 1.43001823931064,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.367Z",
+    "source": "poloniex",
+    "from_currency": "LTC",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1222,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.387Z",
+    "modified_on": "2018-05-16T16:48:52.387Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001770125,
+    "timestamp": "2018-05-16T16:48:52.387Z",
+    "source": "poloniex",
+    "from_currency": "MAID",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1223,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.392Z",
+    "modified_on": "2018-05-16T16:48:52.392Z",
+    "from_amount": 0.001770125,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.387Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "MAID"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1224,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.395Z",
+    "modified_on": "2018-05-16T16:48:52.395Z",
+    "from_amount": 564.931855094979,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.387Z",
+    "source": "poloniex",
+    "from_currency": "MAID",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1225,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.399Z",
+    "modified_on": "2018-05-16T16:48:52.399Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00082959,
+    "timestamp": "2018-05-16T16:48:52.399Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1226,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.402Z",
+    "modified_on": "2018-05-16T16:48:52.402Z",
+    "from_amount": 0.00082959,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.399Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "NXT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1227,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.410Z",
+    "modified_on": "2018-05-16T16:48:52.411Z",
+    "from_amount": 1205.41472293543,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.399Z",
+    "source": "poloniex",
+    "from_currency": "NXT",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1228,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.418Z",
+    "modified_on": "2018-05-16T16:48:52.418Z",
+    "from_amount": 0.00082959,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.399Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "NXT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1229,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.425Z",
+    "modified_on": "2018-05-16T16:48:52.425Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0840658,
+    "timestamp": "2018-05-16T16:48:52.425Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1230,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.429Z",
+    "modified_on": "2018-05-16T16:48:52.429Z",
+    "from_amount": 0.0840658,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.425Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1231,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.432Z",
+    "modified_on": "2018-05-16T16:48:52.432Z",
+    "from_amount": 11.895443807113,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.425Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1232,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.436Z",
+    "modified_on": "2018-05-16T16:48:52.436Z",
+    "from_amount": 1.0,
+    "to_amount": 692.1043355,
+    "timestamp": "2018-05-16T16:48:52.436Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1233,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.446Z",
+    "modified_on": "2018-05-16T16:48:52.446Z",
+    "from_amount": 692.1043355,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.436Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1234,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.451Z",
+    "modified_on": "2018-05-16T16:48:52.451Z",
+    "from_amount": 0.0014448688567708,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.436Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1235,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.457Z",
+    "modified_on": "2018-05-16T16:48:52.457Z",
+    "from_amount": 1.0,
+    "to_amount": 2.265e-06,
+    "timestamp": "2018-05-16T16:48:52.457Z",
+    "source": "poloniex",
+    "from_currency": "SC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1236,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.461Z",
+    "modified_on": "2018-05-16T16:48:52.462Z",
+    "from_amount": 2.265e-06,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.457Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "SC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1237,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.464Z",
+    "modified_on": "2018-05-16T16:48:52.464Z",
+    "from_amount": 441501.103752759,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.457Z",
+    "source": "poloniex",
+    "from_currency": "SC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1238,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.467Z",
+    "modified_on": "2018-05-16T16:48:52.468Z",
+    "from_amount": 1.0,
+    "to_amount": 4.015e-05,
+    "timestamp": "2018-05-16T16:48:52.468Z",
+    "source": "poloniex",
+    "from_currency": "BCY",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1239,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.471Z",
+    "modified_on": "2018-05-16T16:48:52.471Z",
+    "from_amount": 4.015e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.468Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BCY"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1240,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.482Z",
+    "modified_on": "2018-05-16T16:48:52.482Z",
+    "from_amount": 24906.600249066,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.468Z",
+    "source": "poloniex",
+    "from_currency": "BCY",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1241,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.487Z",
+    "modified_on": "2018-05-16T16:48:52.488Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000218135,
+    "timestamp": "2018-05-16T16:48:52.488Z",
+    "source": "poloniex",
+    "from_currency": "EXP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1242,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.492Z",
+    "modified_on": "2018-05-16T16:48:52.493Z",
+    "from_amount": 0.000218135,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.488Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "EXP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1243,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.495Z",
+    "modified_on": "2018-05-16T16:48:52.496Z",
+    "from_amount": 4584.31705136727,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.488Z",
+    "source": "poloniex",
+    "from_currency": "EXP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1244,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.498Z",
+    "modified_on": "2018-05-16T16:48:52.498Z",
+    "from_amount": 0.000218135,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.488Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "EXP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1245,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.502Z",
+    "modified_on": "2018-05-16T16:48:52.502Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002561735,
+    "timestamp": "2018-05-16T16:48:52.502Z",
+    "source": "poloniex",
+    "from_currency": "FCT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1246,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.513Z",
+    "modified_on": "2018-05-16T16:48:52.513Z",
+    "from_amount": 0.002561735,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.502Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "FCT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1247,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.518Z",
+    "modified_on": "2018-05-16T16:48:52.518Z",
+    "from_amount": 390.360439311638,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.502Z",
+    "source": "poloniex",
+    "from_currency": "FCT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1248,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.524Z",
+    "modified_on": "2018-05-16T16:48:52.524Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000525975,
+    "timestamp": "2018-05-16T16:48:52.524Z",
+    "source": "poloniex",
+    "from_currency": "RADS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1249,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.528Z",
+    "modified_on": "2018-05-16T16:48:52.528Z",
+    "from_amount": 0.000525975,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.524Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "RADS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1250,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.531Z",
+    "modified_on": "2018-05-16T16:48:52.531Z",
+    "from_amount": 1901.231047103,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.524Z",
+    "source": "poloniex",
+    "from_currency": "RADS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1251,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.534Z",
+    "modified_on": "2018-05-16T16:48:52.534Z",
+    "from_amount": 1.0,
+    "to_amount": 2.8425e-05,
+    "timestamp": "2018-05-16T16:48:52.534Z",
+    "source": "poloniex",
+    "from_currency": "AMP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1252,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.537Z",
+    "modified_on": "2018-05-16T16:48:52.537Z",
+    "from_amount": 2.8425e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.534Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "AMP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1253,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.547Z",
+    "modified_on": "2018-05-16T16:48:52.547Z",
+    "from_amount": 35180.2990325418,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.534Z",
+    "source": "poloniex",
+    "from_currency": "AMP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1254,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.553Z",
+    "modified_on": "2018-05-16T16:48:52.553Z",
+    "from_amount": 1.0,
+    "to_amount": 0.01161113,
+    "timestamp": "2018-05-16T16:48:52.553Z",
+    "source": "poloniex",
+    "from_currency": "DCR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1255,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.558Z",
+    "modified_on": "2018-05-16T16:48:52.558Z",
+    "from_amount": 0.01161113,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.553Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "DCR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1256,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.562Z",
+    "modified_on": "2018-05-16T16:48:52.562Z",
+    "from_amount": 86.124261807421,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.553Z",
+    "source": "poloniex",
+    "from_currency": "DCR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1257,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.567Z",
+    "modified_on": "2018-05-16T16:48:52.568Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0012104,
+    "timestamp": "2018-05-16T16:48:52.568Z",
+    "source": "poloniex",
+    "from_currency": "LSK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1258,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.576Z",
+    "modified_on": "2018-05-16T16:48:52.576Z",
+    "from_amount": 0.0012104,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.568Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "LSK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1259,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.585Z",
+    "modified_on": "2018-05-16T16:48:52.585Z",
+    "from_amount": 826.173165895572,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.568Z",
+    "source": "poloniex",
+    "from_currency": "LSK",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1260,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.590Z",
+    "modified_on": "2018-05-16T16:48:52.590Z",
+    "from_amount": 1.0,
+    "to_amount": 0.01443798,
+    "timestamp": "2018-05-16T16:48:52.590Z",
+    "source": "poloniex",
+    "from_currency": "LSK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1261,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.595Z",
+    "modified_on": "2018-05-16T16:48:52.595Z",
+    "from_amount": 0.01443798,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.590Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "LSK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1262,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.599Z",
+    "modified_on": "2018-05-16T16:48:52.600Z",
+    "from_amount": 69.2617665352078,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.590Z",
+    "source": "poloniex",
+    "from_currency": "LSK",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1263,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.604Z",
+    "modified_on": "2018-05-16T16:48:52.604Z",
+    "from_amount": 0.01443798,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.590Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "LSK"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1264,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.619Z",
+    "modified_on": "2018-05-16T16:48:52.620Z",
+    "from_amount": 1.0,
+    "to_amount": 2.7585e-05,
+    "timestamp": "2018-05-16T16:48:52.620Z",
+    "source": "poloniex",
+    "from_currency": "LBC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1265,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.626Z",
+    "modified_on": "2018-05-16T16:48:52.627Z",
+    "from_amount": 2.7585e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.620Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "LBC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1266,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.631Z",
+    "modified_on": "2018-05-16T16:48:52.631Z",
+    "from_amount": 36251.5860068878,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.620Z",
+    "source": "poloniex",
+    "from_currency": "LBC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1267,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.634Z",
+    "modified_on": "2018-05-16T16:48:52.634Z",
+    "from_amount": 2.7585e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.620Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "LBC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1268,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.638Z",
+    "modified_on": "2018-05-16T16:48:52.638Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000301335,
+    "timestamp": "2018-05-16T16:48:52.638Z",
+    "source": "poloniex",
+    "from_currency": "STEEM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1269,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.650Z",
+    "modified_on": "2018-05-16T16:48:52.650Z",
+    "from_amount": 0.000301335,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.638Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "STEEM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1270,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.654Z",
+    "modified_on": "2018-05-16T16:48:52.654Z",
+    "from_amount": 3318.56571589759,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.638Z",
+    "source": "poloniex",
+    "from_currency": "STEEM",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1271,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.658Z",
+    "modified_on": "2018-05-16T16:48:52.659Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00359008,
+    "timestamp": "2018-05-16T16:48:52.658Z",
+    "source": "poloniex",
+    "from_currency": "STEEM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1272,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.663Z",
+    "modified_on": "2018-05-16T16:48:52.663Z",
+    "from_amount": 0.00359008,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.658Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "STEEM"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1273,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.666Z",
+    "modified_on": "2018-05-16T16:48:52.666Z",
+    "from_amount": 278.545324895267,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.658Z",
+    "source": "poloniex",
+    "from_currency": "STEEM",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1274,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.669Z",
+    "modified_on": "2018-05-16T16:48:52.670Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00030851,
+    "timestamp": "2018-05-16T16:48:52.670Z",
+    "source": "poloniex",
+    "from_currency": "SBD",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1275,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.681Z",
+    "modified_on": "2018-05-16T16:48:52.681Z",
+    "from_amount": 0.00030851,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.670Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "SBD"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1276,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.685Z",
+    "modified_on": "2018-05-16T16:48:52.685Z",
+    "from_amount": 3241.38601666072,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.670Z",
+    "source": "poloniex",
+    "from_currency": "SBD",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1277,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.691Z",
+    "modified_on": "2018-05-16T16:48:52.691Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002104535,
+    "timestamp": "2018-05-16T16:48:52.691Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1278,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.695Z",
+    "modified_on": "2018-05-16T16:48:52.695Z",
+    "from_amount": 0.002104535,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.691Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "ETC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1279,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.698Z",
+    "modified_on": "2018-05-16T16:48:52.698Z",
+    "from_amount": 475.164347468681,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.691Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1280,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.701Z",
+    "modified_on": "2018-05-16T16:48:52.701Z",
+    "from_amount": 1.0,
+    "to_amount": 0.02506674,
+    "timestamp": "2018-05-16T16:48:52.701Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1281,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.705Z",
+    "modified_on": "2018-05-16T16:48:52.705Z",
+    "from_amount": 0.02506674,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.701Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "ETC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1282,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.717Z",
+    "modified_on": "2018-05-16T16:48:52.717Z",
+    "from_amount": 39.8935003115682,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.701Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1283,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.720Z",
+    "modified_on": "2018-05-16T16:48:52.720Z",
+    "from_amount": 0.02506674,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.701Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "ETC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1284,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.726Z",
+    "modified_on": "2018-05-16T16:48:52.727Z",
+    "from_amount": 1.0,
+    "to_amount": 17.348308515,
+    "timestamp": "2018-05-16T16:48:52.727Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1285,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.732Z",
+    "modified_on": "2018-05-16T16:48:52.732Z",
+    "from_amount": 17.348308515,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.727Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "ETC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1286,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.736Z",
+    "modified_on": "2018-05-16T16:48:52.736Z",
+    "from_amount": 0.0576425072874028,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.727Z",
+    "source": "poloniex",
+    "from_currency": "ETC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1287,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.744Z",
+    "modified_on": "2018-05-16T16:48:52.744Z",
+    "from_amount": 1.0,
+    "to_amount": 0.005972505,
+    "timestamp": "2018-05-16T16:48:52.744Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1288,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.753Z",
+    "modified_on": "2018-05-16T16:48:52.753Z",
+    "from_amount": 0.005972505,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.744Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "REP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1289,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.757Z",
+    "modified_on": "2018-05-16T16:48:52.757Z",
+    "from_amount": 167.433932663095,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.744Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1290,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.762Z",
+    "modified_on": "2018-05-16T16:48:52.762Z",
+    "from_amount": 1.0,
+    "to_amount": 49.42950883,
+    "timestamp": "2018-05-16T16:48:52.762Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1291,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.766Z",
+    "modified_on": "2018-05-16T16:48:52.766Z",
+    "from_amount": 49.42950883,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.762Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "REP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1292,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.769Z",
+    "modified_on": "2018-05-16T16:48:52.769Z",
+    "from_amount": 0.0202308301998153,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.762Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1293,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.774Z",
+    "modified_on": "2018-05-16T16:48:52.775Z",
+    "from_amount": 1.0,
+    "to_amount": 0.07143868,
+    "timestamp": "2018-05-16T16:48:52.774Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1294,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.784Z",
+    "modified_on": "2018-05-16T16:48:52.784Z",
+    "from_amount": 0.07143868,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.774Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "REP"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1295,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.788Z",
+    "modified_on": "2018-05-16T16:48:52.788Z",
+    "from_amount": 13.9980190003511,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.774Z",
+    "source": "poloniex",
+    "from_currency": "REP",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1296,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.793Z",
+    "modified_on": "2018-05-16T16:48:52.793Z",
+    "from_amount": 1.0,
+    "to_amount": 3.531e-05,
+    "timestamp": "2018-05-16T16:48:52.793Z",
+    "source": "poloniex",
+    "from_currency": "ARDR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1297,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.797Z",
+    "modified_on": "2018-05-16T16:48:52.797Z",
+    "from_amount": 3.531e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.793Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "ARDR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1298,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.800Z",
+    "modified_on": "2018-05-16T16:48:52.800Z",
+    "from_amount": 28320.5890682526,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.793Z",
+    "source": "poloniex",
+    "from_currency": "ARDR",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1299,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.803Z",
+    "modified_on": "2018-05-16T16:48:52.803Z",
+    "from_amount": 1.0,
+    "to_amount": 0.0432225,
+    "timestamp": "2018-05-16T16:48:52.803Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1300,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.817Z",
+    "modified_on": "2018-05-16T16:48:52.817Z",
+    "from_amount": 0.0432225,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.803Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "ZEC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1301,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.822Z",
+    "modified_on": "2018-05-16T16:48:52.822Z",
+    "from_amount": 23.1360980970559,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.803Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1302,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.827Z",
+    "modified_on": "2018-05-16T16:48:52.828Z",
+    "from_amount": 1.0,
+    "to_amount": 0.515503395,
+    "timestamp": "2018-05-16T16:48:52.827Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1303,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.832Z",
+    "modified_on": "2018-05-16T16:48:52.832Z",
+    "from_amount": 0.515503395,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.827Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "ZEC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1304,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.835Z",
+    "modified_on": "2018-05-16T16:48:52.835Z",
+    "from_amount": 1.93985143395612,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.827Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1305,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.842Z",
+    "modified_on": "2018-05-16T16:48:52.844Z",
+    "from_amount": 1.0,
+    "to_amount": 354.20334904,
+    "timestamp": "2018-05-16T16:48:52.843Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1306,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.854Z",
+    "modified_on": "2018-05-16T16:48:52.854Z",
+    "from_amount": 354.20334904,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.843Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "ZEC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1307,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.859Z",
+    "modified_on": "2018-05-16T16:48:52.859Z",
+    "from_amount": 0.0028232369984934,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.843Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1308,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.864Z",
+    "modified_on": "2018-05-16T16:48:52.864Z",
+    "from_amount": 1.0,
+    "to_amount": 1.82510585,
+    "timestamp": "2018-05-16T16:48:52.864Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1309,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.868Z",
+    "modified_on": "2018-05-16T16:48:52.868Z",
+    "from_amount": 1.82510585,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.864Z",
+    "source": "poloniex",
+    "from_currency": "XMR",
+    "to_currency": "ZEC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1310,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.871Z",
+    "modified_on": "2018-05-16T16:48:52.871Z",
+    "from_amount": 0.547913426500715,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.864Z",
+    "source": "poloniex",
+    "from_currency": "ZEC",
+    "to_currency": "XMR"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1311,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.885Z",
+    "modified_on": "2018-05-16T16:48:52.885Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00074484,
+    "timestamp": "2018-05-16T16:48:52.885Z",
+    "source": "poloniex",
+    "from_currency": "STRAT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1312,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.891Z",
+    "modified_on": "2018-05-16T16:48:52.891Z",
+    "from_amount": 0.00074484,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.885Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "STRAT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1313,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.896Z",
+    "modified_on": "2018-05-16T16:48:52.896Z",
+    "from_amount": 1342.57021642232,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.885Z",
+    "source": "poloniex",
+    "from_currency": "STRAT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1314,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.900Z",
+    "modified_on": "2018-05-16T16:48:52.900Z",
+    "from_amount": 1.0,
+    "to_amount": 1.738e-05,
+    "timestamp": "2018-05-16T16:48:52.900Z",
+    "source": "poloniex",
+    "from_currency": "NXC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1315,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.904Z",
+    "modified_on": "2018-05-16T16:48:52.904Z",
+    "from_amount": 1.738e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.900Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "NXC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1316,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.913Z",
+    "modified_on": "2018-05-16T16:48:52.914Z",
+    "from_amount": 57537.3993095512,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.900Z",
+    "source": "poloniex",
+    "from_currency": "NXC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1317,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.920Z",
+    "modified_on": "2018-05-16T16:48:52.920Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00010092,
+    "timestamp": "2018-05-16T16:48:52.920Z",
+    "source": "poloniex",
+    "from_currency": "PASC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1318,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.925Z",
+    "modified_on": "2018-05-16T16:48:52.925Z",
+    "from_amount": 0.00010092,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.920Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "PASC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1319,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.928Z",
+    "modified_on": "2018-05-16T16:48:52.928Z",
+    "from_amount": 9908.83868410622,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.920Z",
+    "source": "poloniex",
+    "from_currency": "PASC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1320,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.934Z",
+    "modified_on": "2018-05-16T16:48:52.934Z",
+    "from_amount": 1.0,
+    "to_amount": 6.562e-05,
+    "timestamp": "2018-05-16T16:48:52.934Z",
+    "source": "poloniex",
+    "from_currency": "GNT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1321,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.939Z",
+    "modified_on": "2018-05-16T16:48:52.940Z",
+    "from_amount": 6.562e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.934Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "GNT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1322,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.951Z",
+    "modified_on": "2018-05-16T16:48:52.951Z",
+    "from_amount": 15239.2563242914,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.934Z",
+    "source": "poloniex",
+    "from_currency": "GNT",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1323,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.957Z",
+    "modified_on": "2018-05-16T16:48:52.957Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00078587,
+    "timestamp": "2018-05-16T16:48:52.957Z",
+    "source": "poloniex",
+    "from_currency": "GNT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1324,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.962Z",
+    "modified_on": "2018-05-16T16:48:52.962Z",
+    "from_amount": 0.00078587,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.957Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "GNT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1325,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.966Z",
+    "modified_on": "2018-05-16T16:48:52.966Z",
+    "from_amount": 1272.47509130009,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.957Z",
+    "source": "poloniex",
+    "from_currency": "GNT",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1326,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.971Z",
+    "modified_on": "2018-05-16T16:48:52.971Z",
+    "from_amount": 1.0,
+    "to_amount": 0.01104747,
+    "timestamp": "2018-05-16T16:48:52.971Z",
+    "source": "poloniex",
+    "from_currency": "GNO",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1327,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.983Z",
+    "modified_on": "2018-05-16T16:48:52.983Z",
+    "from_amount": 0.01104747,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.971Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "GNO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1328,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.987Z",
+    "modified_on": "2018-05-16T16:48:52.987Z",
+    "from_amount": 90.5184625982238,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.971Z",
+    "source": "poloniex",
+    "from_currency": "GNO",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1329,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.992Z",
+    "modified_on": "2018-05-16T16:48:52.992Z",
+    "from_amount": 1.0,
+    "to_amount": 0.13180501,
+    "timestamp": "2018-05-16T16:48:52.992Z",
+    "source": "poloniex",
+    "from_currency": "GNO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1330,
+  "fields": {
+    "created_on": "2018-05-16T16:48:52.996Z",
+    "modified_on": "2018-05-16T16:48:52.996Z",
+    "from_amount": 0.13180501,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.992Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "GNO"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1331,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.000Z",
+    "modified_on": "2018-05-16T16:48:53.000Z",
+    "from_amount": 7.58696501749061,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:52.992Z",
+    "source": "poloniex",
+    "from_currency": "GNO",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1332,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.004Z",
+    "modified_on": "2018-05-16T16:48:53.004Z",
+    "from_amount": 1.0,
+    "to_amount": 0.15281249,
+    "timestamp": "2018-05-16T16:48:53.004Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1333,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.016Z",
+    "modified_on": "2018-05-16T16:48:53.016Z",
+    "from_amount": 0.15281249,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.004Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "BCH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1334,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.020Z",
+    "modified_on": "2018-05-16T16:48:53.020Z",
+    "from_amount": 6.54396770839871,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.004Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1335,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.026Z",
+    "modified_on": "2018-05-16T16:48:53.026Z",
+    "from_amount": 1.0,
+    "to_amount": 1.826067625,
+    "timestamp": "2018-05-16T16:48:53.026Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1336,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.030Z",
+    "modified_on": "2018-05-16T16:48:53.030Z",
+    "from_amount": 1.826067625,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.026Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "BCH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1337,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.033Z",
+    "modified_on": "2018-05-16T16:48:53.033Z",
+    "from_amount": 0.547624844945159,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.026Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1338,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.035Z",
+    "modified_on": "2018-05-16T16:48:53.035Z",
+    "from_amount": 1.826067625,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.026Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "BCH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1339,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.042Z",
+    "modified_on": "2018-05-16T16:48:53.042Z",
+    "from_amount": 1.0,
+    "to_amount": 1254.37523367,
+    "timestamp": "2018-05-16T16:48:53.042Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1340,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.051Z",
+    "modified_on": "2018-05-16T16:48:53.051Z",
+    "from_amount": 1254.37523367,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.042Z",
+    "source": "poloniex",
+    "from_currency": "USDT",
+    "to_currency": "BCH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1341,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.054Z",
+    "modified_on": "2018-05-16T16:48:53.054Z",
+    "from_amount": 0.00079720961731223,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.042Z",
+    "source": "poloniex",
+    "from_currency": "BCH",
+    "to_currency": "USDT"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1342,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.060Z",
+    "modified_on": "2018-05-16T16:48:53.060Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000163085,
+    "timestamp": "2018-05-16T16:48:53.060Z",
+    "source": "poloniex",
+    "from_currency": "ZRX",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1343,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.064Z",
+    "modified_on": "2018-05-16T16:48:53.064Z",
+    "from_amount": 0.000163085,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.060Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "ZRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1344,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.067Z",
+    "modified_on": "2018-05-16T16:48:53.067Z",
+    "from_amount": 6131.77177545452,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.060Z",
+    "source": "poloniex",
+    "from_currency": "ZRX",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1345,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.080Z",
+    "modified_on": "2018-05-16T16:48:53.080Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00193796,
+    "timestamp": "2018-05-16T16:48:53.080Z",
+    "source": "poloniex",
+    "from_currency": "ZRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1346,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.086Z",
+    "modified_on": "2018-05-16T16:48:53.086Z",
+    "from_amount": 0.00193796,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.080Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "ZRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1347,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.090Z",
+    "modified_on": "2018-05-16T16:48:53.091Z",
+    "from_amount": 516.006522322442,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.080Z",
+    "source": "poloniex",
+    "from_currency": "ZRX",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1348,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.095Z",
+    "modified_on": "2018-05-16T16:48:53.095Z",
+    "from_amount": 0.00193796,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.080Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "ZRX"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1349,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.100Z",
+    "modified_on": "2018-05-16T16:48:53.100Z",
+    "from_amount": 1.0,
+    "to_amount": 4.1675e-05,
+    "timestamp": "2018-05-16T16:48:53.100Z",
+    "source": "poloniex",
+    "from_currency": "CVC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1350,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.104Z",
+    "modified_on": "2018-05-16T16:48:53.104Z",
+    "from_amount": 4.1675e-05,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.100Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "CVC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1351,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.110Z",
+    "modified_on": "2018-05-16T16:48:53.111Z",
+    "from_amount": 23995.200959808,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.100Z",
+    "source": "poloniex",
+    "from_currency": "CVC",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1352,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.119Z",
+    "modified_on": "2018-05-16T16:48:53.120Z",
+    "from_amount": 1.0,
+    "to_amount": 0.00049334,
+    "timestamp": "2018-05-16T16:48:53.120Z",
+    "source": "poloniex",
+    "from_currency": "CVC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1353,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.125Z",
+    "modified_on": "2018-05-16T16:48:53.125Z",
+    "from_amount": 0.00049334,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.120Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "CVC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1354,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.128Z",
+    "modified_on": "2018-05-16T16:48:53.128Z",
+    "from_amount": 2026.99963514007,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.120Z",
+    "source": "poloniex",
+    "from_currency": "CVC",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1355,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.133Z",
+    "modified_on": "2018-05-16T16:48:53.133Z",
+    "from_amount": 1.0,
+    "to_amount": 0.001556855,
+    "timestamp": "2018-05-16T16:48:53.133Z",
+    "source": "poloniex",
+    "from_currency": "OMG",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1356,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.137Z",
+    "modified_on": "2018-05-16T16:48:53.137Z",
+    "from_amount": 0.001556855,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.133Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "OMG"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1357,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.149Z",
+    "modified_on": "2018-05-16T16:48:53.149Z",
+    "from_amount": 642.320575776164,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.133Z",
+    "source": "poloniex",
+    "from_currency": "OMG",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1358,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.154Z",
+    "modified_on": "2018-05-16T16:48:53.154Z",
+    "from_amount": 1.0,
+    "to_amount": 0.018570615,
+    "timestamp": "2018-05-16T16:48:53.154Z",
+    "source": "poloniex",
+    "from_currency": "OMG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1359,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.159Z",
+    "modified_on": "2018-05-16T16:48:53.159Z",
+    "from_amount": 0.018570615,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.154Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "OMG"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1360,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.162Z",
+    "modified_on": "2018-05-16T16:48:53.162Z",
+    "from_amount": 53.8485128252349,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.154Z",
+    "source": "poloniex",
+    "from_currency": "OMG",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1361,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.166Z",
+    "modified_on": "2018-05-16T16:48:53.166Z",
+    "from_amount": 1.0,
+    "to_amount": 0.002822725,
+    "timestamp": "2018-05-16T16:48:53.166Z",
+    "source": "poloniex",
+    "from_currency": "GAS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1362,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.170Z",
+    "modified_on": "2018-05-16T16:48:53.170Z",
+    "from_amount": 0.002822725,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.166Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "GAS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1363,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.177Z",
+    "modified_on": "2018-05-16T16:48:53.178Z",
+    "from_amount": 354.26759602866,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.166Z",
+    "source": "poloniex",
+    "from_currency": "GAS",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1364,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.186Z",
+    "modified_on": "2018-05-16T16:48:53.186Z",
+    "from_amount": 1.0,
+    "to_amount": 0.03376674,
+    "timestamp": "2018-05-16T16:48:53.186Z",
+    "source": "poloniex",
+    "from_currency": "GAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1365,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.192Z",
+    "modified_on": "2018-05-16T16:48:53.192Z",
+    "from_amount": 0.03376674,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.186Z",
+    "source": "poloniex",
+    "from_currency": "ETH",
+    "to_currency": "GAS"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1366,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.195Z",
+    "modified_on": "2018-05-16T16:48:53.195Z",
+    "from_amount": 29.6149406190826,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.186Z",
+    "source": "poloniex",
+    "from_currency": "GAS",
+    "to_currency": "ETH"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1367,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.199Z",
+    "modified_on": "2018-05-16T16:48:53.199Z",
+    "from_amount": 1.0,
+    "to_amount": 0.000106645,
+    "timestamp": "2018-05-16T16:48:53.199Z",
+    "source": "poloniex",
+    "from_currency": "STORJ",
+    "to_currency": "BTC"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1368,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.202Z",
+    "modified_on": "2018-05-16T16:48:53.202Z",
+    "from_amount": 0.000106645,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.199Z",
+    "source": "poloniex",
+    "from_currency": "BTC",
+    "to_currency": "STORJ"
+  }
+},
+{
+  "model": "economy.conversionrate",
+  "pk": 1369,
+  "fields": {
+    "created_on": "2018-05-16T16:48:53.205Z",
+    "modified_on": "2018-05-16T16:48:53.205Z",
+    "from_amount": 9376.90468376389,
+    "to_amount": 1.0,
+    "timestamp": "2018-05-16T16:48:53.199Z",
+    "source": "poloniex",
+    "from_currency": "STORJ",
+    "to_currency": "BTC"
+  }
+}]

--- a/app/economy/models.py
+++ b/app/economy/models.py
@@ -70,16 +70,18 @@ class ConversionRate(SuperModel):
 @receiver(post_save, sender=ConversionRate, dispatch_uid="ReverseConversionRate")
 def reverse_conversion_rate(sender, instance, **kwargs):
     """Handle the reverse conversion rate signal during post-save."""
-    # 1 / # 0.000979
-    from_amount = float(instance.to_amount) / float(instance.from_amount)
-    to_amount = 1
+    # If this is a fixture, don't create reverse CR.
+    if not kwargs.get('raw', False):
+        # 1 / # 0.000979
+        from_amount = float(instance.to_amount) / float(instance.from_amount)
+        to_amount = 1
 
-    # reverse transaction
-    ConversionRate.objects.get_or_create(
-        from_amount=from_amount,
-        to_amount=to_amount,
-        timestamp=instance.timestamp,
-        source=instance.source,
-        from_currency=instance.to_currency,
-        to_currency=instance.from_currency
-    )
+        # reverse transaction
+        ConversionRate.objects.get_or_create(
+            from_amount=from_amount,
+            to_amount=to_amount,
+            timestamp=instance.timestamp,
+            source=instance.source,
+            from_currency=instance.to_currency,
+            to_currency=instance.from_currency
+        )

--- a/bin/docker-command.bash
+++ b/bin/docker-command.bash
@@ -7,6 +7,7 @@ WEB_INTERFACE=${WEB_INTERFACE:-'0.0.0.0'}
 WEB_PORT=${WEB_PORT:-'8000'}
 # General / Overrides
 FORCE_PROVISION=${FORCE_PROVISION:-'off'}
+FORCE_GET_PRICES=${FORCE_GET_PRICES:-'off'}
 
 cd app
 # Check whether or not the .env file exists. If not, create it.
@@ -28,9 +29,12 @@ if [ ! -f /provisioned ] || [ "$FORCE_PROVISION" = "on" ]; then
     python manage.py collectstatic --noinput -i other &
     python manage.py migrate
     python manage.py loaddata initial
-    python manage.py get_prices
     date >> /provisioned
     echo "Provisioning completed!"
+fi
+
+if [ "$FORCE_GET_PRICES" = "on" ]; then
+    python manage.py get_prices
 fi
 
 python manage.py "$WEB_WORKER" "$WEB_INTERFACE":"$WEB_PORT" --extra-file /code/app/app/.env --nopin

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -13,6 +13,13 @@ All of the environment variables used by this application conform to the [`djang
 | DEBUG | Whether or not to run the environment in Debug mode. | `bool` | True |
 | SECRET_KEY | The secret key to use for your Django environment. | `str` | TODO |
 
+## Project / Entry Specific
+
+| Variable | Description | Type | Default |
+| --- | --- | --- | --- |
+| FORCE_PROVISION | Whether or not to force provisioning even if the container has been previously provisioned | `bool` | False |
+| FORCE_GET_PRICES | Whether or not to force pulling fresh conversion rate data from etherdelta and poloniex | `bool` | False |
+
 ## Amazon Web Services
 
 | Variable | Description | Type | Default |


### PR DESCRIPTION
##### Description

The goal of this PR is to introduce `ConversionRate` initial fixture data for local development.  Additionally, this PR disabled `get_prices` from running during provisioning, but allows users to pass `FORCE_GET_PRICES` via env var to force loading fresh conversionrates on container restart.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
docker, backend

##### Testing
Tested locally

