### PR TITLE
Modify issueURL placeholder text to reflect GH issues

### DIFF
--- a/app/dashboard/templates/fulfill_bounty.html
+++ b/app/dashboard/templates/fulfill_bounty.html
@@ -45,7 +45,7 @@
                 <form id="submitBounty">
                   <div class="w-100">
                     <label class="form__label" for="issueURL">{% trans "Issue URL" %}</label>
-                    <input required name='issueURL' id="issueURL" class="form__input" type="url" placeholder="https://github.com/user/repo/pull/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
+                    <input required name='issueURL' id="issueURL" class="form__input" type="url" placeholder="https://github.com/user/repo/issues/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
                   </div>
                   {% include 'shared/github_username.html' %}
                   {% include 'shared/notification_email.html' %}

--- a/app/dashboard/templates/increase_bounty.html
+++ b/app/dashboard/templates/increase_bounty.html
@@ -52,7 +52,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 {% include 'shared/network_status.html' %}
                 <div class="w-100">
                   <label class="form__label" for=issueURL>Issue URL</label>
-                  <input name='issueURL' id="issueURL" class="w-100 form__input" type="url" placeholder="https://github.com/user/repo/pull/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" disabled/>
+                  <input name='issueURL' id="issueURL" class="w-100 form__input" type="url" placeholder="https://github.com/user/repo/issues/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" disabled/>
                 </div>
                 <div class="w-100 mt-2">
                   <label class="form__label" for="amount">Amount</label>

--- a/app/dashboard/templates/kill_bounty.html
+++ b/app/dashboard/templates/kill_bounty.html
@@ -45,7 +45,7 @@
                 <form id="submitBounty">
                   <div class="w-100">
                     <label class="form__label" for="issueURL">{% trans "Issue URL" %}</label>
-                    <input name='issueURL' id="issueURL" class="form__input" type="url" required placeholder="https://github.com/user/repo/pull/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
+                    <input name='issueURL' id="issueURL" class="form__input" type="url" required placeholder="https://github.com/user/repo/issues/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
                   </div>
                   <div class="w-100 mt-2 terms_container">
                     <div class="form__checkbox">

--- a/app/dashboard/templates/process_bounty.html
+++ b/app/dashboard/templates/process_bounty.html
@@ -45,7 +45,7 @@
                 {% include 'shared/network_status.html' %}
                 <div class="w-100">
                   <label for=issueURL>{% trans "Issue URL:" %}</label>
-                  <input name='issueURL' id="issueURL" class="w-100 gc-round-text-input" type="text" placeholder="https://github.com/user/repo/pull/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
+                  <input name='issueURL' id="issueURL" class="w-100 gc-round-text-input" type="text" placeholder="https://github.com/user/repo/issues/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
                 </div>
                 <div class="w-100 mt-2">
                   <label for=bountyFulfillment>{% trans "Bounty Submission:" %}</label>

--- a/app/dashboard/templates/submit_bounty.html
+++ b/app/dashboard/templates/submit_bounty.html
@@ -48,7 +48,7 @@
                                 {% include 'shared/network_status.html' %}
                                 <div class="w-100">
                                     <label class="form__label" for=issueURL>{% trans "Issue URL" %}</label>
-                                    <input required name='issueURL' id="issueURL" class="w-100 form__input" type="url" placeholder="https://github.com/user/repo/pull/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
+                                    <input required name='issueURL' id="issueURL" class="w-100 form__input" type="url" placeholder="https://github.com/user/repo/issues/n" value="{% if bounty %}{{bounty.github_url}}{%endif%}" />
                                 </div>
                                 <div class="w-100 mt-2 amount_container">
                                     <label class="form__label" for="amount">{% trans "Amount" %}</label>

--- a/app/dashboard/templates/yge/send2.html
+++ b/app/dashboard/templates/yge/send2.html
@@ -58,7 +58,7 @@
     <div id='advanced' style="display:none;">
       <div>
         {% trans "Related Github Issue URL" %} ({% trans "optional" %}):
-        <input type="text" placeholder="https://github.com/user/repo/pull/n" id="issueURL" value="" style="width: 400px; margin-left: auto; margin-right: auto;">
+        <input type="text" placeholder="https://github.com/user/repo/pull|issues/n" id="issueURL" value="" style="width: 400px; margin-left: auto; margin-right: auto;">
       </div>
       <div>
         {% trans "To Email address" %} ({% trans "optional" %}):


### PR DESCRIPTION
##### Description

The goal of this PR is to modify the `issueURL` placeholder text to be more representative of the appropriate URL to be used when opening a `Bounty` or `Tip`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
ux, funding forms

##### Testing
Viewed locally

##### Refers/Fixes
Fixes: #1194
