### PR TITLE
GDPR: show updated policy via modal

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -1166,7 +1166,12 @@ input.is-invalid {
   width: 25em;
 }
 
-.ui-widget-shadow {
+.blocker {
+  background-color: rgba(93,90,149, 0.8) !important;
+}
+
+.ui-widget-shadow,
+.modal {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1) !important;
 }
 
@@ -1670,4 +1675,21 @@ input.is-invalid {
   #sidebar_container {
     display: none;
   }
+}
+
+/* TODO : Remove after GDPR */
+.notify_policy_update {
+  font-family: "Muli", sans-serif;
+}
+
+.notify_policy_update h2 {
+  letter-spacing: 0;
+}
+
+.modal.notify_policy_update {
+  max-width: 34rem;
+}
+
+.notify_policy_update .button {
+  padding: 0.25rem 1.25rem;
 }

--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -1166,10 +1166,6 @@ input.is-invalid {
   width: 25em;
 }
 
-.blocker {
-  background-color: rgba(93,90,149, 0.8) !important;
-}
-
 .ui-widget-shadow,
 .modal {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1) !important;

--- a/app/assets/v2/css/buttons.css
+++ b/app/assets/v2/css/buttons.css
@@ -38,11 +38,6 @@
   --hover: #ffdc7f;
 }
 
-.close:hover,
-.close:focus {
-  box-shadow: inset -3.5em 0 0 0 var(--hover), inset 3.5em 0 0 0 var(--hover);
-}
-
 .raise {
   --color: #000;
   --hover: #000;

--- a/app/assets/v2/js/base.js
+++ b/app/assets/v2/js/base.js
@@ -174,3 +174,42 @@ $(document).ready(function() {
 $(window).scroll(function() {
   var scrollPos = $(document).scrollTop();
 });
+
+/* TODO : Remove after GDPR */
+if ($('#is-authenticated').val() === 'True' && !localStorage['notify_policy_update']) {
+  localStorage['notify_policy_update'] = true;
+
+  var content = $.parseHTML(
+    '<div><div class="row">' +
+      '<div class="col-12 closebtn">' +
+        '<a rel="modal:close" href="javascript:void" class="close" aria-label="Close dialog">' +
+          '<span aria-hidden="true">&times;</span>' +
+        '</a>' +
+      '</div>' +
+      '<div class="col-12 pt-2 pb-2 text-center">' +
+        '<h2 class="font-title">' + gettext('We Care About Your Privacy') + '</h2>' +
+      '</div>' +
+      '<div class="col-12 pt-2 pb-2 font-body">' +
+        '<p>' + gettext('As a Web 3.0 company, we think carefully about user data and privacy ' +
+          'and how the internet is evolving. We hope Web 3.0 will bring more control ' +
+          'of data to users. With this ethos in mind, we are always careful about how ' +
+          'we use your information.') + '</p>' +
+        '<p>' + gettext('We recently reviewed our Privacy Policy to comply with requirements of ' +
+          'General Data Protection Regulation (GDPR), improving our Terms of Use, ' +
+          'Privacy Policy and Cookie Policy. These changes will go into effect on May 25, ' +
+          '2018, and your continued use of the Gitcoin after May 25, 2018 will be ' +
+          'subject to our updated Terms of Use and Privacy Policy.') +
+        '</p>' +
+      '</div>' +
+      '<div class="col-12 font-caption"><a href="/legal/policy" target="_blank">' +
+        gettext('Read Our Updated Terms') +
+      '</a></div>' +
+      '<div class="col-12 mt-4 mb-2 text-right font-caption">' +
+        '<a rel="modal:close" href="javascript:void" aria-label="Close dialog" class="button button--primary">Ok</a>' +
+      '</div>' +
+    '</div></div>');
+
+  var modal = $(content).appendTo('body').modal({
+    modalClass: 'modal notify_policy_update'
+  });
+}

--- a/app/dashboard/templates/shared/nav_auth.html
+++ b/app/dashboard/templates/shared/nav_auth.html
@@ -15,6 +15,7 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static %}
+<input id="is-authenticated" type="hidden" value={{user.is_authenticated}}>
 {% if user.is_authenticated %}
   <div class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"


### PR DESCRIPTION
##### Description

- displays modal via localStorage check + github login
- removed weird yellow hover on cross icon on modal
- update the background color on opened modal

@vs77bb @owocki @PixelantDesign 
On clicking **View Our Updated Terms** -> it takes you to `https://gitcoin.co/legal/policy `. 
I'm guessing this isn't, could get the right url ? 

@PixelantDesign could you give me the rgb color code of the blue background ? This is what I got , when I used a color picker -> It's weird :P 

<img width="1440" alt="screen shot 2018-05-24 at 4 13 02 pm" src="https://user-images.githubusercontent.com/5358146/40481292-98be5172-5f6e-11e8-88e1-a129338a9d6c.png">

Or I can default it to the black background ^_^ 

<img width="1440" alt="screen shot 2018-05-24 at 4 13 18 pm" src="https://user-images.githubusercontent.com/5358146/40481293-9905186e-5f6e-11e8-9eef-32eab29464b9.png">








##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css
- js

##### Fixes
 - #1239
