### PR TITLE
css: fixed font name

### DIFF
--- a/app/assets/v2/_variables.scss
+++ b/app/assets/v2/_variables.scss
@@ -194,7 +194,7 @@ $transition-collapse: height 0.35s ease !default;
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: "futura-pt", Futura, -apple-system, BlinkMacSystemFont,
+$font-family-sans-serif: futura-pt, -apple-system, BlinkMacSystemFont,
   "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
   "Segoe UI Emoji", "Segoe UI Symbol" !default;
 $font-family-monospace: "SFMono-Regular", Menlo, Monaco, Consolas,

--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -26,7 +26,7 @@ span {
 }
 
 .navbar {
-  font-family: 'futura-pt', Futura, sans-serif;
+  font-family: futura-pt, sans-serif;
 }
 
 .navbar-nav .nav-link {

--- a/app/assets/v2/css/carousel.css
+++ b/app/assets/v2/css/carousel.css
@@ -109,7 +109,7 @@
 }
 
 .carousel .testimonial {
-  font-family: 'futura-pt', Futura, sans-serif !important;
+  font-family: futura-pt, sans-serif !important;
   font-weight: bold;
   padding-right: 30px;
 }

--- a/app/assets/v2/css/external_bounties/bounties.css
+++ b/app/assets/v2/css/external_bounties/bounties.css
@@ -137,7 +137,7 @@
 .bounties-header__title .sub-title,
 .aside .title,
 .aside .sub-title {
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   text-transform: uppercase;
   font-weight: bolder;
   letter-spacing: 0;
@@ -307,7 +307,7 @@
   border-radius: 30px 0 0 30px;
   display: flex;
   color: #fff;
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   font-weight: bolder;
   justify-content: space-around;
   text-align: right;
@@ -355,7 +355,7 @@
 
 .bounty__fiat-price {
   color: #15D17C;
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   font-size: 0.9rem;
   font-weight: bolder;
   padding: 0 0.5em;

--- a/app/assets/v2/css/external_bounties/bounty.css
+++ b/app/assets/v2/css/external_bounties/bounty.css
@@ -28,7 +28,7 @@
 }
 
 .bounty-container .sub-title {
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   text-transform: none;
   letter-spacing: 0;
   margin-bottom: 1rem;
@@ -63,7 +63,7 @@
 
 .bounty__crypto-price,
 .bounty__fiat-price {
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   text-transform: none;
   font-weight: bolder;
   letter-spacing: 0;

--- a/app/assets/v2/css/gitcoin.css
+++ b/app/assets/v2/css/gitcoin.css
@@ -123,7 +123,7 @@
 } */
 
 body {
-  font-family: 'futura-pt', Futura, sans-serif;
+  font-family: futura-pt, sans-serif;
   overflow-x: hidden;
   width: 100%;
 }
@@ -268,7 +268,7 @@ div.button-pink {
 
 .header-line {
   color: white;
-  font-family: Futura, sans-serif;
+  font-family: futura-pt, sans-serif;
   font-size: 3em;
   font-weight: 500;
   font-style: italic;
@@ -278,7 +278,7 @@ div.button-pink {
 
 .subheader-line {
   color: #70efbe;
-  font-family: Futura, sans-serif;
+  font-family: futura-pt, sans-serif;
   font-size: 2em;
   font-weight: 500;
   font-style: italic;

--- a/app/assets/v2/css/ios.css
+++ b/app/assets/v2/css/ios.css
@@ -31,7 +31,7 @@
 }
 
 .ios-hero__container .header-line p {
-  font-family: Futura, sans-serif;
+  font-family: 'futura-pt', sans-serif;
   font-size: 2em;
 }
 

--- a/app/assets/yge/css/main.css
+++ b/app/assets/yge/css/main.css
@@ -20,7 +20,7 @@
 
 body {
   line-height: 1;
-  font-family: 'futura-pt', Futura, sans-serif !important;
+  font-family: futura-pt, sans-serif !important;
   -webkit-text-size-adjust: none;
   overflow-x: hidden;
   width: 100%;


### PR DESCRIPTION
##### Description

Looks like we've been using the wrong font name (cause it to default to sans-serif)  in a few places around the site 
This PR just fixes those up

Pointed out :  https://github.com/gitcoinco/web/pull/1260#issuecomment-392054296

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css
