### PR TITLE
dashboard: results row fix

### DIFF
--- a/app/dashboard/templates/dashboard.html
+++ b/app/dashboard/templates/dashboard.html
@@ -44,11 +44,11 @@
             {% include 'shared/search_bar.html' %}
             <div class="row mt-2 mb-2">
               <div class="col-12 offset-lg-1 col-lg-10 title-row">
-                <div class="col-12 col-md-4 col-lg-3">
+                <div class="col-12 col-md-4">
                   <span id="filter" class="font-title"></span>
-                  <span id="matches" class="font-subheading"></span>
+                  <span id="matches" class="font-body"></span>
                 </div>
-                <div class="col-12 col-md-8 col-lg-9 bounty-info" id="funding-info">
+                <div class="col-12 col-md-8 bounty-info" id="funding-info">
                 </div>
               </div>
             </div>


### PR DESCRIPTION
##### Description

Results found was getting split into two lines

<img width="1113" alt="screen shot 2018-05-29 at 11 34 08 pm" src="https://user-images.githubusercontent.com/5358146/40676597-cfc8eab4-6398-11e8-831a-01a33f02c120.png">


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
- css