### PR TITLE
Fix primary button style in receive tip success page

### DIFF
--- a/app/assets/yge/youvegoteth/receive.js
+++ b/app/assets/yge/youvegoteth/receive.js
@@ -121,7 +121,7 @@ window.onload = function() {
       } else {
         startConfetti();
         mixpanel.track('Tip Receive Success', {});
-        $('send_eth').innerHTML = '<h1>Success 🚀!</h1> <a href="https://' + etherscanDomain() + '/tx/' + result + '">See your transaction on the blockchain here</a>.<br><br><strong>Status:</strong> <span id="status">Confirming Transaction … <br><img src="/static/yge/images/loading_v2.gif" style="max-width: 30px; max-height: 30px;"></span><br><br><span id="mighttake">It might take a few minutes to sync, depending upon: <br> - network congestion<br> - network fees that sender allocated to transaction.<br>You may close this browser window.<br></span><br><a href="/" class="button button-primary">⬅ Back to Gitcoin.co</a>';
+        $('send_eth').innerHTML = '<h1>Success 🚀!</h1> <a href="https://' + etherscanDomain() + '/tx/' + result + '">See your transaction on the blockchain here</a>.<br><br><strong>Status:</strong> <span id="status">Confirming Transaction … <br><img src="/static/yge/images/loading_v2.gif" style="max-width: 30px; max-height: 30px;"></span><br><br><span id="mighttake">It might take a few minutes to sync, depending upon: <br> - network congestion<br> - network fees that sender allocated to transaction.<br>You may close this browser window.<br></span><br><a href="/" class="button button--primary">⬅ Back To Gitcoin.co</a>';
         const url = '/tip/receive';
 
         fetch(url, {


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

- Makes the button text in tip receive success page visible.
- Also uppercases 'to' to standardize the way we render button texts.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
UI
##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
Tested it
##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->

Fixes #1313 

### Screenshot

![image](https://user-images.githubusercontent.com/7039523/40734646-a54db6aa-63fe-11e8-98ed-89bb8d0bf248.png)
