### PR TITLE
Adjust sync_geth settings and docs for local

### DIFF
--- a/app/dashboard/management/commands/sync_geth.py
+++ b/app/dashboard/management/commands/sync_geth.py
@@ -21,6 +21,7 @@ import logging
 import sys
 import warnings
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 import rollbar
@@ -32,6 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
+default_start_id = 0 if not settings.DEBUG else 402
 
 
 class Command(BaseCommand):
@@ -40,11 +42,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('network', default='rinkeby', type=str)
-        parser.add_argument('start_id', default=0, type=int)
+        parser.add_argument('start_id', default=default_start_id, type=int)
         parser.add_argument('end_id', default=99999999999, type=int)
 
     def handle(self, *args, **options):
-
         # config
         network = options['network']
         hour = datetime.datetime.now().hour

--- a/docs/RUNNING_LOCALLY.md
+++ b/docs/RUNNING_LOCALLY.md
@@ -84,5 +84,11 @@ Navigate to `http://localhost:8000/`.
 This can be useful if you'd like data to test with:
 
 ```shell
-./manage.py sync_geth rinkeby 40 99999999999
+./manage.py sync_geth
+```
+
+or equivalently:
+
+```shell
+./manage.py sync_geth rinkeby 402 99999999999
 ```

--- a/docs/RUNNING_LOCALLY_DOCKER.md
+++ b/docs/RUNNING_LOCALLY_DOCKER.md
@@ -64,7 +64,13 @@ docker-compose exec web python3 app/manage.py createsuperuser
 This can be useful if you'd like data to test with:
 
 ```shell
-docker-compose exec web python3 app/manage.py sync_geth rinkeby 40 99999999999
+docker-compose exec web python3 app/manage.py sync_geth
+```
+
+or equivalently:
+
+```shell
+docker-compose exec web python3 app/manage.py sync_geth rinkeby 402 99999999999
 ```
 
 ### FAQ

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -9,7 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 ## GITCOIN WEB3 STUFF
 ##TODO: Re-enable this when Gitcoin GETH URL is synced.
 1 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_geth mainnet 0 99999999999  >> /var/log/gitcoin/sync_geth.log  2>&1
-12 */12 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_geth rinkeby 0 99999999999  >> /var/log/gitcoin/sync_geth_rinkeby.log  2>&1
+12 */12 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_geth rinkeby 402 99999999999  >> /var/log/gitcoin/sync_geth_rinkeby.log  2>&1
 
 ## TOOLING
 1 */3 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash get_prices  >> /var/log/gitcoin/get_prices.log  2>&1


### PR DESCRIPTION
##### Description
The goal of this PR is to adjust the `sync_geth` command and related documentation to start at `402` when syncing with rinkeby.  This avoids running through 400 bounties that don't have `payload` data.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
sync_geth

##### Testing
Locally.

##### Refers/Fixes
Fix #1334