### PR TITLE
Fix feedback icons overlap with input value and center the icons vertically

### DIFF
--- a/app/assets/v2/css/forms/input.css
+++ b/app/assets/v2/css/forms/input.css
@@ -21,18 +21,20 @@
 }
 
 .form__input.error {
+  padding-right: 2.8rem;
   color: #D50000;
   background-image: url('/static/v2/images/close-red.png');
   background-repeat: no-repeat;
   background-size: auto 1.313rem;
-  background-position: top 0.4375rem right 1.25rem;
+  background-position: top 0.3rem right 0.5rem;
 }
 
 .form__input.valid {
+  padding-right: 2.8rem;
   background-image: url('/static/v2/images/success.png');
   background-repeat: no-repeat;
   background-size: auto 1.313rem;
-  background-position: top 0.4375rem right 1.25rem;
+  background-position: top 0.3rem right 0.5rem;
 }
 
 .form__input::-webkit-input-placeholder {


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- Fix feedback icons overlap with the input field values
- Center the feedback icons vertically

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
UI

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
I did.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->

Fixes #1348 

#### Screenshots

##### Before

![image](https://user-images.githubusercontent.com/7039523/40888734-1132442e-6721-11e8-90bd-8c9f05402e21.png)


##### After

![image](https://user-images.githubusercontent.com/7039523/40888737-1783d914-6721-11e8-9d8b-69497e7a7565.png)
