### PR TITLE
Add min value for hours worked input field on submit work form

### DIFF
--- a/app/dashboard/templates/shared/hours_worked.html
+++ b/app/dashboard/templates/shared/hours_worked.html
@@ -17,5 +17,5 @@
 {% load i18n %}
 <div class="w-100 mt-2">
   <label class="form__label" for="hoursWorked">{% trans "Hours Worked" %}</label>
-  <input name='hoursWorked' id='hoursWorked' class="form__input" type="number" placeholder="1 (feel free to approximate)" value="" step="0.25" />
+  <input name='hoursWorked' id='hoursWorked' class="form__input" type="number" placeholder="1 (feel free to approximate)" value="" min="0.25" step="0.25" />
 </div>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Currently, we're not validating the hours worked input field. So, a user cannot enter negative numbers though it doesn't make sense. This PR adds a minimum value of `0.25` to the input field.

**Note**: This is a really minor thing as an average gitcoiner wouldn't enter negative numbers but it was bugging me so I decided to submit a patch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

I did, _manually_

##### Screenshots

###### Before

![image](https://user-images.githubusercontent.com/7039523/40889336-8597f5da-672a-11e8-94a9-8ef321f9d98a.png)


###### After

![image](https://user-images.githubusercontent.com/7039523/40889339-8e696220-672a-11e8-8e08-d2490d927a48.png)


