### PR TITLE
Fix font awesome icon classes

### DIFF
--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -140,7 +140,7 @@ var addTechStackKeywordFilters = function(value) {
       isTechStack = true;
 
       $('.filter-tags').append('<a class="filter-tag tech_stack"><span>' + value + '</span>' +
-        '<i class="fa fa-times" onclick="removeFilter(\'tech_stack\', \'' + value + '\')"></i></a>');
+        '<i class="fas fa-times" onclick="removeFilter(\'tech_stack\', \'' + value + '\')"></i></a>');
 
       $('input[name="tech_stack"][value=' + value + ']').prop('checked', true);
     }
@@ -154,7 +154,7 @@ var addTechStackKeywordFilters = function(value) {
     }
 
     $('.filter-tags').append('<a class="filter-tag keywords"><span>' + value + '</span>' +
-      '<i class="fa fa-times" onclick="removeFilter(\'keywords\', \'' + value + '\')"></i></a>');
+      '<i class="fas fa-times" onclick="removeFilter(\'keywords\', \'' + value + '\')"></i></a>');
   }
 };
 
@@ -167,7 +167,7 @@ var getFilters = function() {
     $.each($('input[name="' + key + '"]:checked'), function() {
       if ($(this).attr('val-ui')) {
         _filters.push('<a class="filter-tag ' + key + '"><span>' + $(this).attr('val-ui') + '</span>' +
-          '<i class="fa fa-times" onclick="removeFilter(\'' + key + '\', \'' + $(this).attr('value') + '\')"></i></a>');
+          '<i class="fas fa-times" onclick="removeFilter(\'' + key + '\', \'' + $(this).attr('value') + '\')"></i></a>');
       }
     });
   }
@@ -175,7 +175,7 @@ var getFilters = function() {
   if (localStorage['keywords']) {
     localStorage['keywords'].split(',').forEach(function(v, k) {
       _filters.push('<a class="filter-tag keywords"><span>' + v + '</span>' +
-        '<i class="fa fa-times" onclick="removeFilter(\'keywords\', \'' + v + '\')"></i></a>');
+        '<i class="fas fa-times" onclick="removeFilter(\'keywords\', \'' + v + '\')"></i></a>');
     });
   }
 

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -504,13 +504,13 @@ var randomElement = function(array) {
 
 var trigger_sidebar_web3_disabled = function() {
   $('#upper_left').addClass('disabled');
-  $('#sidebar_head').html('<i class="fa fa-question"></i>');
+  $('#sidebar_head').html('<i class="fas fa-question"></i>');
   $('#sidebar_p').html('<p>Web3 disabled</p><p>Please install <a href="https://metamask.io/?utm_source=gitcoin.co&utm_medium=referral" target="_blank" rel="noopener noreferrer">Metamask</a> <br> <a href="/web3" target="_blank" rel="noopener noreferrer">What is Metamask and why do I need it?</a>.</p>');
 };
 
 var trigger_sidebar_web3_locked = function() {
   $('#upper_left').addClass('disabled');
-  $('#sidebar_head').html('<i class="fa fa-lock"></i>');
+  $('#sidebar_head').html('<i class="fas fa-lock"></i>');
   $('#sidebar_p').html('<p>Web3 locked</p><p>Please unlock <a href="https://metamask.io/?utm_source=gitcoin.co&utm_medium=referral" target="_blank" rel="noopener noreferrer">Metamask</a>.<p>');
 };
 
@@ -547,11 +547,11 @@ var trigger_sidebar_web3 = function(network) {
 
   if (is_supported_network) {
     $('#upper_left').removeClass('disabled');
-    $('#sidebar_head').html("<i class='fa fa-wifi'></i>");
+    $('#sidebar_head').html("<i class='fas fa-wifi'></i>");
     $('#sidebar_p').html('<p>Web3 enabled<p>' + sidebar_p);
   } else {
     $('#upper_left').addClass('disabled');
-    $('#sidebar_head').html("<i class='fa fa-battery-empty'></i>");
+    $('#sidebar_head').html("<i class='fas fa-battery-empty'></i>");
     sidebar_p += '<p>(try ' + recommended_network + ')</p>';
     $('#sidebar_p').html('<p>Unsupported network</p>' + sidebar_p);
   }

--- a/app/dashboard/templates/bounty_details.html
+++ b/app/dashboard/templates/bounty_details.html
@@ -18,7 +18,7 @@
       <div class="col-12 col-md-2 left-rails text-center" style="background: #F2F6F9;">
         {% include 'shared/current_balance.html' %}
         <div class="explorer font-body">
-          <a href="{% url 'explorer' %}"><i class="fa fa-chevron-left"></i> {% trans "Back to Issue Explorer" %}</a>
+          <a href="{% url 'explorer' %}"><i class="fas fa-chevron-left"></i> {% trans "Back to Issue Explorer" %}</a>
         </div>
       </div>
 


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Fixes weird rendering of font awesome icons, a regression introduced in https://github.com/gitcoinco/web/pull/1333

The issue is `fa` prefix has been deprecated in Font Awesome 5. The new default is `fas`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
UI

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->

Fixes #1353