### PR TITLE
Github notification safeguard for local

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -728,6 +728,9 @@ class Bounty(SuperModel):
             return False
         if self.network == 'mainnet' and (settings.DEBUG or settings.ENV != 'prod'):
             return False
+        if (settings.DEBUG or settings.ENV != 'prod') and settings.GITHUB_API_USER != self.github_org_name:
+            return False
+
         return True
 
     @property
@@ -928,6 +931,13 @@ class Tip(SuperModel):
             return "RECEIVED"
         return "PENDING"
 
+    @property
+    def github_org_name(self):
+        try:
+            return org_name(self.github_url)
+        except Exception:
+            return None
+
     def is_notification_eligible(self, var_to_check=True):
         """Determine whether or not a notification is eligible for transmission outside of production.
 
@@ -938,6 +948,8 @@ class Tip(SuperModel):
         if not var_to_check or self.network != settings.ENABLE_NOTIFICATIONS_ON_NETWORK:
             return False
         if self.network == 'mainnet' and (settings.DEBUG or settings.ENV != 'prod'):
+            return False
+        if (settings.DEBUG or settings.ENV != 'prod') and settings.GITHUB_API_USER != self.github_org_name:
             return False
         return True
 

--- a/docs/THIRD_PARTY_SETUP.md
+++ b/docs/THIRD_PARTY_SETUP.md
@@ -34,6 +34,9 @@ GITHUB_API_USER=xxx
 ```
 
 Make sure you disable gitcoinbot notifications on your local, unless you are specifically testing that feature
+By default, we disable outbound GitHub notifications to any repository that isn't under the `GITHUB_API_USER` repositories.
+
+For example, if `settings.GITHUB_API_USER == gitcoinco` only `github.com/gitcoinco/<repos>` bounties and associated tips will post Github comments.
 
 ```
 # Be VERY CAREFUL when changing this setting.  You don't want to accidently
@@ -51,7 +54,7 @@ Copy the application ID found on the page as the `GITCOINBOT_APP_ID` environment
 Make sure you disable gitcoinbot notifications on your local, unless you are specifically testing that feature
 
 ```
-# Be VERY CAREFUL when changing this setting.  You don't want to accidently
+# Be VERY CAREFUL when changing this setting.  You don't want to accidentally
 # send a bunch of github notifications :)
 ENABLE_NOTIFICATIONS_ON_NETWORK=None
 ```


### PR DESCRIPTION
##### Description
The goal of this PR is to attempt to further mitigate unintentional Github comments/notifications while running notification generating activities on `local` by limiting all GH notifications to only repositories owned by the `GITHUB_API_USER`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
notifications (non-prod)

##### Testing
Local
