### PR TITLE
Remove Get started with Gitcoin link

### DIFF
--- a/app/retail/templates/index.html
+++ b/app/retail/templates/index.html
@@ -35,8 +35,6 @@
           <span class="text-highlight-gc-purple">{% trans "Want to work on OSS Projects?" %}</span>
           <div class="ml-3 text-highlight-gc-purple">
             <a class="text-highlight-gc-purple" href="{% url "explorer" %}">{% trans "View Available Bounties" %}</a>
-            |
-            <a class="text-highlight-gc-purple" href="{% url "new_bounty" %}">{% trans "Get Started with Gitcoin" %}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

![image](https://user-images.githubusercontent.com/7039523/41187930-7e7a3f34-6b7a-11e8-9a62-739f6f9f48b0.png)


Currently, the 'Get Started with Gitcoin' link (shown in the above screenshot) links to the new bounty page which doesn't make sense from the perspective of a developer who's interested in working on bounties.

Not sure what to replace it with as we're already linking to `/explorer` from 'View Available Bounties' link.

Hence, this PR removes the  'Get Started with Gitcoin' link. Let me know if I should retain it and link to some other page.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

