### PR TITLE
Update django logger and deploy script handling

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -206,20 +206,24 @@ if not ENV in ['local', 'test']:
                 'maxBytes': 1024 * 1024 * 10,  # 10 MB
                 'backupCount': 100,  # max 100 logs
             },
-            'mail_admins': {
-                'level': 'ERROR',
-                'class': 'django.utils.log.AdminEmailHandler',
-                'include_html': True,
-            },
         },
         'loggers': {
             'django': {
-                'handlers': ['rotatingfilehandler', 'mail_admins'],
+                'handlers': ['rotatingfilehandler', ],
                 'propagate': True,
                 'filters': ['require_debug_is_false'],
             },
         },
     }
+
+    if ENV == 'prod':
+        LOGGING['handlers']['mail_admins'] = {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'include_html': True,
+        }
+        LOGGING['loggers']['django']['handlers'].append('mail_admins')
+
     LOGGING['loggers']['django.request'] = LOGGING['loggers']['django']
     for ia in INSTALLED_APPS:
         LOGGING['loggers'][ia] = LOGGING['loggers']['django']

--- a/scripts/deploy.bash
+++ b/scripts/deploy.bash
@@ -17,51 +17,74 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 END
 
-BRANCH=$1
-DISTID=$2
-ISFRONTENDPUSH=$3
-
 # deploy script
 # assumes that gitcoin repo lives at $HOME/gitcoin
 # and that gitcoinenv is the virtualenv under which it lives
 
 # setup
-cd
-cd gitcoin/coin
+cd || echo "Cannot find directory!"
+cd gitcoin/coin || echo "Cannot find coin directory!"
+
+# Load the .env file into the local environment.
+# shellcheck disable=SC2046
+export $(grep -v '^#' app/app/.env | xargs)
+
+BRANCH=$1
+DISTID=$2
+ISFRONTENDPUSH=$3
+UPDATE_CRONTAB=${UPDATE_CRONTAB:-$4}
+MIGRATE_DB=${MIGRATE_DB:-$5}
+CREATE_CACHE_TABLE=${CREATE_CACHE_TABLE:-$6}
+
+# shellcheck disable=SC1091
 source ../gitcoin-3/bin/activate
 
 # pull from git
 git add .
 git stash
-# If no $BRANCH is specified, it will use the current one
-git checkout $BRANCH
-git pull origin $BRANCH
 
-#deploy hooks
+# If no $BRANCH is specified, it will use the current one
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+# deploy hooks
 echo "- install req"
-pip install -r requirements/base.txt 2>&1 >> /dev/null
+{ pip3 install -r requirements/base.txt >> /dev/null; } 2>&1
+
 echo "- cleaning up pyc files"
 find . -name \*.pyc -delete
-echo "- install crontab"
-crontab scripts/crontab
-cd app
-echo "- collect static"
-if [ $ISFRONTENDPUSH ]; then
-    ./manage.py collectstatic --noinput -i other;
+
+if [ "$UPDATE_CRONTAB" ]; then
+    echo "- updating crontab"
+    crontab scripts/crontab
 fi
+
+cd app || echo "Cannot find app directory!"
+echo "- collect static"
+if [ "$ISFRONTENDPUSH" ]; then
+    python3 manage.py collectstatic --noinput -i other;
+fi
+
 rm -Rf ~/gitcoin/coin/app/static/other
-echo "- db"
-./manage.py migrate
-./manage.py createcachetable
+
+if [ "$MIGRATE_DB" ]; then
+    echo "- db"
+    python3 manage.py migrate
+fi
+
+if [ "$CREATE_CACHE_TABLE" ]; then
+    echo "- creating cache table"
+    python3 manage.py createcachetable
+fi
 
 # let gunicorn know its ok to restart
 echo "- gunicorn"
 sudo systemctl restart gunicorn
 
 # invalidate cloudfront
-if [ $ISFRONTENDPUSH ]; then
-    if [ $DISTID ]; then
-        cd ~/gitcoin/coin; bash scripts/bustcache.bash $DISTID
+if [ "$ISFRONTENDPUSH" ]; then
+    if [ "$DISTID" ]; then
+        cd ~/gitcoin/coin || echo "Cannot find coin directory!"; bash scripts/bustcache.bash "$DISTID"
     fi
 fi
 
@@ -69,5 +92,8 @@ fi
 cd ~/gitcoin/coin || echo "Cannot find coin directory!"
 bash scripts/run_management_command.bash ping_google
 
-# Handle rollbar deployment
-bash scripts/rollbar.bash
+if [ "$ENV" = "prod" ]; then
+    # Handle rollbar deployment
+    echo "- publishing deployment information to Rollbar"
+    bash scripts/rollbar.bash
+fi

--- a/scripts/rollbar.bash
+++ b/scripts/rollbar.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# shellcheck disable=SC2163
-while read -r line; do export "$line"; done < ./app/app/.env
+# Load the .env file into the local environment.
+# shellcheck disable=SC2046
+export $(grep -v '^#' app/app/.env | xargs)
 
 REVISION=$(git rev-parse --verify HEAD)
 USER=$(whoami)


### PR DESCRIPTION
##### Description
The goal of this PR is to disable the `mail_admins` log handler for all environments except `prod` and add granular control to other steps (crontab, etc) in the `deploy.bash` script.

Additionally, this allows us to disable the crontab update step (for staging) to avoid the mushrooming `sync_geth.log`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
deploy

##### Testing
Local and stage

