### PR TITLE
no flex on alert messages

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -583,7 +583,6 @@ input[type=text].loading {
 
 .alert .message {
   align-items: center;
-  display: flex;
 }
 
 .alert .message::before {

--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -583,6 +583,10 @@ input[type=text].loading {
 
 .alert .message {
   align-items: center;
+  display: flex;
+}
+.alert .message .content{
+  display: inline;
 }
 
 .alert .message::before {

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -150,7 +150,9 @@ var _alert = function(msg, _class) {
     return (
       `<div class="alert ${_class}" style="top: ${top}px">
         <div class="message">
-          ${alertMessage(msg)}
+          <div class="content">
+            ${alertMessage(msg)}
+          </div>
         </div>
         ${closeButton(msg)}
       </div>;`


### PR DESCRIPTION
it seems to me that the alert messages `.alert .message` should not be `display:flex`

see this gif with a before and after for why:

![screen recording 2018-06-12 at 07 26 am](https://user-images.githubusercontent.com/513929/41293289-19c0ff8e-6e12-11e8-8211-9ed0de81b9bd.gif)
