### PR TITLE
Add name linking to vivek's slack notification and welcomebot

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -758,14 +758,13 @@ def maybe_notify_bounty_user_escalated_to_slack(bounty, username, last_heard_fro
     if not bounty.is_notification_eligible(var_to_check=settings.SLACK_TOKEN):
         return False
 
-    msg = f"@vivek, {bounty.github_url} is being escalated to you, due to inactivity for {last_heard_from_user_days} days from @{username} on the github thread."
+    msg = f"<@U88M8173P>, {bounty.github_url} is being escalated to you, due to inactivity for {last_heard_from_user_days} days from <@{username}> on the github thread."
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)
         channel = 'notif-gitcoin'
         sc.api_call(
             "chat.postMessage",
-            link_names=1,
             channel=channel,
             text=msg,
             icon_url=settings.GITCOIN_SLACK_ICON_URL,

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -765,6 +765,7 @@ def maybe_notify_bounty_user_escalated_to_slack(bounty, username, last_heard_fro
         channel = 'notif-gitcoin'
         sc.api_call(
             "chat.postMessage",
+            link_names=1,
             channel=channel,
             text=msg,
             icon_url=settings.GITCOIN_SLACK_ICON_URL,

--- a/ops/lambdas/welcomebot/app.py
+++ b/ops/lambdas/welcomebot/app.py
@@ -57,7 +57,7 @@ Here's how to get started with bounties:
 We have more details in our onboarding guide at https://gitcoin.co/docs/onboard . We also have a FAQ and tutorials available at https://gitcoin.co/help
 
 If you have any feedback for the team, or just want to say hi, this is them:
-- <@U55F2LT5L>, <@U88M8173P>, <@U8J2TK1L6>, <@U87BL3KS6>, <@U7Z23ATPB>, <@U9UKDGS01>
+- <@U55F2LT5L>, <@U88M8173P>, <@U8J2TK1L6>, <@U87BL3KS6>, <@U7Z23ATPB>, <@U9UKDGS01>, <@U88BVQAJD>, <@U9PL1BSAC>, <@U7J5ZPCPQ>, <@U85EFS1MM>
 
 See you around! :spock-hand:
 Welcome_bot (and the Gitcoin Team)

--- a/ops/lambdas/welcomebot/app.py
+++ b/ops/lambdas/welcomebot/app.py
@@ -104,11 +104,8 @@ def new_user_welcome(event):
         channel = sc.api_call('im.open', user=user)
         channel_id = channel['channel']['id']
         sc.api_call(
-            'chat.postMessage',
-            channel=channel_id,
-            unfurl_links=False,
-            text=MESSAGE,
-            as_user=True)
+            'chat.postMessage', link_names=1, channel=channel_id, unfurl_links=False, text=MESSAGE, as_user=True
+        )
 
 
 # Serve the slack welcomebot flask app.

--- a/ops/lambdas/welcomebot/app.py
+++ b/ops/lambdas/welcomebot/app.py
@@ -57,7 +57,7 @@ Here's how to get started with bounties:
 We have more details in our onboarding guide at https://gitcoin.co/docs/onboard . We also have a FAQ and tutorials available at https://gitcoin.co/help
 
 If you have any feedback for the team, or just want to say hi, this is them:
-- @owocki, @vivek, @Pixelant, @mbeacom, @coderberry, @justin-bean
+- <@U55F2LT5L>, <@U88M8173P>, <@U8J2TK1L6>, <@U87BL3KS6>, <@U7Z23ATPB>, <@U9UKDGS01>
 
 See you around! :spock-hand:
 Welcome_bot (and the Gitcoin Team)
@@ -104,7 +104,7 @@ def new_user_welcome(event):
         channel = sc.api_call('im.open', user=user)
         channel_id = channel['channel']['id']
         sc.api_call(
-            'chat.postMessage', link_names=1, channel=channel_id, unfurl_links=False, text=MESSAGE, as_user=True
+            'chat.postMessage', channel=channel_id, unfurl_links=False, text=MESSAGE, as_user=True
         )
 
 


### PR DESCRIPTION
##### Description
The goal of this PR is to link names mentioned in suspension slack messages to @vs77bb and slack handles in the welcomebot message.

*EDIT: Updated this PR to use user IDs since username linking was deprecated.  Additionally, added @SaptakS, @thelostone-mc, Scott, and Ben*
https://api.slack.com/changelog/2017-09-the-one-about-usernames

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
welcomebot, notifications
