### PR TITLE
Remove unnecessary letter spacing in emails

### DIFF
--- a/app/retail/templates/emails/template.html
+++ b/app/retail/templates/emails/template.html
@@ -126,7 +126,6 @@
     }
     p, a, span, ul, ol, li{
         font-size: 14px;
-        letter-spacing: 0.1em;
         line-height: 18px;
     }
 


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
There was additional `letter-spacing` applied to text in Gitcoin emails. For headings this is fine, however it causes larger bodies of text to be more difficult to read.

This PR removes the extra spacing for non-heading elements. The most recent Gitcoin Weekly would now appear as follows:

<img width="917" alt="screen shot 2018-06-16 at 13 37 03" src="https://user-images.githubusercontent.com/7497084/41498630-9bb83dc6-716a-11e8-9b8d-6a2c1eb0e171.png">

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
Marketing emails (`app/retail/templates/emails`)

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
No changes in logic, therefore should be without issue

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
Fixes: #1480 
