### PR TITLE
/results page is slow, this PR perf profile helps diagnose that and makes it faster

### DIFF
--- a/app/faucet/views.py
+++ b/app/faucet/views.py
@@ -35,6 +35,7 @@ from faucet.models import FaucetRequest
 from gas.utils import recommend_min_gas_price_to_confirm_in_time
 from marketing.mails import new_faucet_request, processed_faucet_request, reject_faucet_request
 
+
 @require_GET
 def faucet(request):
     params = {

--- a/app/retail/utils.py
+++ b/app/retail/utils.py
@@ -217,6 +217,7 @@ def build_stat_results():
 
     # Bounties
     completion_rate = get_completion_rate()
+    pp.profile_time('completion_rate')
     bounty_abandonment_rate = round(100 - completion_rate, 1)
     context['universe_total_usd'] = sum(base_bounties.filter(network='mainnet').values_list('_val_usd_db', flat=True))
     pp.profile_time('universe_total_usd')

--- a/app/retail/utils.py
+++ b/app/retail/utils.py
@@ -23,6 +23,7 @@ import statistics
 import time
 
 from django.conf import settings
+from django.core.cache import cache
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -156,6 +157,19 @@ def get_bounty_median_turnaround_time(func='turnaround_time_started'):
 
 
 def build_stat_results():
+    timeout = 60 * 60 * 24
+    key = 'build_stat_results'
+    results = cache.get(key)
+    if results:
+        return results
+
+    results = build_stat_results_helper()
+    cache.set(key, results, timeout)
+
+    return results
+
+
+def build_stat_results_helper():
     from dashboard.models import Bounty
 
     """Buidl the results page context."""


### PR DESCRIPTION
those code produces the following output:

```

pulled alumni in 0.0 seconds (total: 0.0 sec)
pulled count_* in 0.01 seconds (total: 0.01 sec)
pulled orgs in 0.0 seconds (total: 0.01 sec)
pulled Stats1 in 0.15 seconds (total: 0.17 sec)
pulled Stats2 in 0.17 seconds (total: 0.34 sec)
pulled bounty_history in 0.08 seconds (total: 0.42 sec)
pulled completion_rate in 0.01 seconds (total: 0.43 sec)
pulled universe_total_usd in 0.01 seconds (total: 0.44 sec)
pulled bounty_average_turnaround in 0.61 seconds (total: 1.05 sec)
pulled bounty_median_pickup_time in 0.59 seconds (total: 1.64 sec)
pulled final in 0.0 seconds (total: 1.64 sec)


```

and introduces caching of that information
