### PR TITLE
avatar schwag request form

### DIFF
--- a/app/dashboard/templates/ftux/avatar.html
+++ b/app/dashboard/templates/ftux/avatar.html
@@ -101,7 +101,7 @@
       {% trans "Save Avatar" %}
     </button>
     <div>
-      <a href="https://github.com/gitcoinco/web/issues/1550" target="_blank">{% trans "Don't see the right schwag?  Request new avatar attributes here" %}
+      <a href="https://github.com/gitcoinco/web/issues/1550" target="_blank" rel="noopener noreferrer">{% trans "Don't see the right schwag?  Request new avatar attributes here" %}
       </a>
     </div>
   </div>

--- a/app/dashboard/templates/ftux/avatar.html
+++ b/app/dashboard/templates/ftux/avatar.html
@@ -100,6 +100,10 @@
     <button disabled type="button" id="save-button" class="button button--primary" onclick="saveAvatar()">
       {% trans "Save Avatar" %}
     </button>
+    <div>
+      <a href="https://github.com/gitcoinco/web/issues/1550" target="_blank">{% trans "Don't see the right schwag?  Request new avatar attributes here" %}
+      </a>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
adds the following link on the avatar builder page:

<img width="575" alt="screen shot 2018-06-26 at 8 01 39 am" src="https://user-images.githubusercontent.com/513929/41917293-444eb92a-7917-11e8-82f2-1e612c2f9ec7.png">

which allows users to request more avatar items on a github thread