### PR TITLE
Fix for #1457 (Updated zIndex for Cookie Banner)

### DIFF
--- a/app/assets/cookielaw/css/cookielaw.css
+++ b/app/assets/cookielaw/css/cookielaw.css
@@ -4,7 +4,7 @@
   bottom: 0;
   background-color: #F2F6F9;
   width: 100%;
-  z-index: 20;
+  z-index: 10000;
   font-family: 'Muli', sans-serif;
 }
 

--- a/app/assets/yge/css/main.css
+++ b/app/assets/yge/css/main.css
@@ -22,7 +22,7 @@ body {
   line-height: 1;
   font-family: futura-pt, sans-serif !important;
   -webkit-text-size-adjust: none;
-  overflow-x: hidden;
+  overflow: hidden;
   width: 100%;
   height: 100%;
   color: #000000;


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Updated the zIndex for the cookie banner on the ENS page so that the login box doesn't go above it. 

Before: 

![before](https://user-images.githubusercontent.com/1824604/41941208-4915811c-7969-11e8-84b3-ce702e5f0377.png)

After:

![after](https://user-images.githubusercontent.com/1824604/41941213-4e3b4104-7969-11e8-9eab-1a26506c0b03.png)

This also includes a fix for the body vertically expanding due to the rain effect on the page. Modified body to use overflow rather than just overflow-x. As the yge and ens both use this main.css module, I made sure this didn't break both which it doesn't seem to.

I can revert this if there is a specific reason for using overflow-x here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->

ENS

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

Simple CSS change so mostly just by checking both pages that use the css module I modified. Let me know if I missed anything

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->

Refs: #1457 
