### PR TITLE
Upgrade Django to 2.0.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ bs4
 ccxt
 cryptocompare==0.6
 cryptography==2.1.4
-django==2.0.6
+django==2.0.7
 django-bootstrap3==8.2.3
 django-cors-headers==2.2.0
 django-filter


### PR DESCRIPTION
##### Description
The goal of this PR is to upgrade Django to `2.0.7` to resolve the bugs outlined in:
https://docs.djangoproject.com/en/2.0/releases/2.0.7/

Specifically:

`Fixed migrations crash with namespace packages on Python 3.7` 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Testing
Locally

