### PR TITLE
bug: set title attribute to null when switching to right network

### DIFF
--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -560,6 +560,7 @@ var currentNetwork = function(network) {
   if (document.location.href.startsWith('https://gitcoin.co')) { // Live
     if (network == 'mainnet') {
       $('#current-network').text('Main Ethereum Network');
+      $('.navbar-network').attr('title', '');
       $('.navbar-network i').addClass('green');
       $('.navbar-network i').removeClass('red');
       $('#navbar-network-banner').removeClass('network-banner--warning');
@@ -593,6 +594,7 @@ var currentNetwork = function(network) {
   } else { // Staging
     if (network == 'rinkeby') {
       $('#current-network').text('Rinkeby Network');
+      $('.navbar-network').attr('title', '');
       $('.navbar-network i').addClass('green');
       $('.navbar-network i').removeClass('red');
       $('#navbar-network-banner').removeClass('network-banner--warning');


### PR DESCRIPTION
##### Description

The tooltip persists when you switch from the wrong network to the right network.
This PR fixes that

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

