### PR TITLE
Changes color of getting started from green to gc blue

### DIFF
--- a/app/retail/templates/contributor_landing.html
+++ b/app/retail/templates/contributor_landing.html
@@ -70,7 +70,7 @@
             <h2 class="join-gitcoin-heading">{% trans "<span class=\"light\">All that's left to do is to join</span> <strong>Gitcoin</strong>" %}</h2>
             <div class="mt-4 contributors-cta-text light">Start exploring <strong>{{available_bounties_count}}</strong> bounties worth <strong>${{available_bounties_worth}}</strong></div>
             <div class="mt-5">
-              <a class="btn btn-gc-green text-purple" role="button" href="onboard/contributor" target="_blank" rel="noopener noreferrer">
+              <a class="btn btn-gc-purple text-purple" role="button" href="onboard/contributor" target="_blank" rel="noopener noreferrer">
                 <span>{% trans "Get Started" %}</span>
               </a>
             </div>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Make color from green to blue for "Get Started" button. cc: @PixelantDesign 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->

##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
