### PR TITLE
WIP: Fix record_bounty_activity..

### DIFF
--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -29,6 +29,7 @@ from django.http import Http404, JsonResponse
 from django.utils import timezone
 
 import requests
+from app.utils import sync_profile
 from bs4 import BeautifulSoup
 from dashboard.models import Activity, Bounty, BountyFulfillment, BountySyncRequest, UserAction
 from dashboard.notifications import (
@@ -631,9 +632,9 @@ def record_bounty_activity(event_name, old_bounty, new_bounty, _fulfillment=None
             if event_name == 'work_done':
                 fulfillment = new_bounty.fulfillments.filter(accepted=True).latest('fulfillment_id')
         if fulfillment:
-            maybe_user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
-            if maybe_user_profile:
-                user_profile = maybe_user_profile
+            user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
+            if not user_profile:
+                 user_profile = sync_profile(fulfillment.fulfiller_github_username)
 
     except Exception as e:
         logging.error(f'{e} during record_bounty_activity for {new_bounty}')

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -630,6 +630,10 @@ def record_bounty_activity(event_name, old_bounty, new_bounty, _fulfillment=None
             fulfillment = new_bounty.fulfillments.order_by('-pk').first()
             if event_name == 'work_done':
                 fulfillment = new_bounty.fulfillments.filter(accepted=True).latest('fulfillment_id')
+        if fulfillment:
+            maybe_user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
+            if maybe_user_profile:
+                user_profile = maybe_user_profile
 
     except Exception as e:
         logging.error(f'{e} during record_bounty_activity for {new_bounty}')

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -634,7 +634,7 @@ def record_bounty_activity(event_name, old_bounty, new_bounty, _fulfillment=None
         if fulfillment:
             user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
             if not user_profile:
-                 user_profile = sync_profile(fulfillment.fulfiller_github_username)
+                user_profile = sync_profile(fulfillment.fulfiller_github_username)
 
     except Exception as e:
         logging.error(f'{e} during record_bounty_activity for {new_bounty}')

--- a/app/dashboard/management/commands/create_activity_records.py
+++ b/app/dashboard/management/commands/create_activity_records.py
@@ -60,9 +60,20 @@ class Command(BaseCommand):
 
     help = 'creates activity records for current bounties'
 
-    def handle(self, *args, **options):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-force', '--force',
+            action='store_true',
+            dest='force_refresh',
+            default=False,
+            help='Force the refresh'
+        )
 
+    def handle(self, *args, **options):
+        force_refresh = options['force_refresh']
         bounties = Bounty.objects.filter(current_bounty=True)
         for bounty in bounties:
-            if not bounty.activities.count():
+            if force_refresh:
+                bounty.activities.clear()
+            if force_refresh or not bounty.activities.count():
                 create_activities(bounty)


### PR DESCRIPTION
..so that work_done and work_submitted activities[n].{profile} = {fulfiller_profile}
and not bounty_owner_profile.

Note: we need to purge all activities from all already recorded bounties

Fixes #1659