### PR TITLE
fix for https://github.com/gitcoinco/web/issues/1661

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -821,7 +821,7 @@ const render_actions = function(actions) {
   }
 };
 
-const build_uri_for_pull_bounty_from_api = function(not_current) {
+const build_uri_for_pull_bounty_from_api = function() {
   let uri = '/actions/api/v0.1/bounties/?github_url=' + document.issueURL;
 
   if (typeof document.issueNetwork != 'undefined') {
@@ -830,20 +830,16 @@ const build_uri_for_pull_bounty_from_api = function(not_current) {
   if (typeof document.issue_stdbounties_id != 'undefined') {
     uri = uri + '&standard_bounties_id=' + document.issue_stdbounties_id;
   }
-  if (not_current) {
-    uri = uri + '&not_current=1';
-  }
   return uri;
 };
 
 var pull_bounty_from_api = function() {
   let all_results = [];
 
-  $.get(build_uri_for_pull_bounty_from_api(true)).then(results => {
+  $.get(build_uri_for_pull_bounty_from_api()).then(results => {
     all_results = sanitizeAPIResults(results);
-    return $.get(build_uri_for_pull_bounty_from_api());
+    return all_results;
   }).then(function(results) {
-    results = sanitizeAPIResults(results);
     let nonefound = true;
     // potentially make this a lot faster by only pulling the specific issue required
 

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -627,7 +627,7 @@ def record_bounty_activity(event_name, old_bounty, new_bounty, _fulfillment=None
     fulfillment = _fulfillment
     try:
         user_profile = Profile.objects.filter(handle__iexact=new_bounty.bounty_owner_github_username).first()
-        funder_actions = ['new_bounty', 'worker_approved']
+        funder_actions = ['new_bounty', 'worker_approved', 'killed_bounty', 'increased_bounty', 'worker_rejected']
         if event_name not in funder_actions:
             if not fulfillment:
                 fulfillment = new_bounty.fulfillments.order_by('-pk').first()

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -486,11 +486,16 @@ def create_new_bounty(old_bounties, bounty_payload, bounty_details, bounty_id):
             )
             new_bounty.fetch_issue_item()
 
-            # Pull the interested parties off the last old_bounty
+            # migrate data objects from old bounty
             if latest_old_bounty:
+                # Pull the interested parties off the last old_bounty
                 for interest in latest_old_bounty.interested.all():
                     new_bounty.interested.add(interest)
 
+                # pull the activities off the last old bounty 
+                for activity in latest_old_bounty.activities.all():
+                    new_bounty.activities.add(activity)
+                
             # set cancel date of this bounty
             canceled_on = latest_old_bounty.canceled_on if latest_old_bounty and latest_old_bounty.canceled_on else None
             if not canceled_on and new_bounty.status == 'cancelled':

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -627,14 +627,16 @@ def record_bounty_activity(event_name, old_bounty, new_bounty, _fulfillment=None
     fulfillment = _fulfillment
     try:
         user_profile = Profile.objects.filter(handle__iexact=new_bounty.bounty_owner_github_username).first()
-        if not fulfillment:
-            fulfillment = new_bounty.fulfillments.order_by('-pk').first()
-            if event_name == 'work_done':
-                fulfillment = new_bounty.fulfillments.filter(accepted=True).latest('fulfillment_id')
-        if fulfillment:
-            user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
-            if not user_profile:
-                user_profile = sync_profile(fulfillment.fulfiller_github_username)
+        funder_actions = ['new_bounty', 'worker_approved']
+        if event_name not in funder_actions:
+            if not fulfillment:
+                fulfillment = new_bounty.fulfillments.order_by('-pk').first()
+                if event_name == 'work_done':
+                    fulfillment = new_bounty.fulfillments.filter(accepted=True).latest('fulfillment_id')
+            if fulfillment:
+                user_profile = Profile.objects.filter(handle__iexact=fulfillment.fulfiller_github_username).first()
+                if not user_profile:
+                    user_profile = sync_profile(fulfillment.fulfiller_github_username)
 
     except Exception as e:
         logging.error(f'{e} during record_bounty_activity for {new_bounty}')

--- a/app/dashboard/management/commands/create_activity_records.py
+++ b/app/dashboard/management/commands/create_activity_records.py
@@ -19,7 +19,7 @@
 from django.core.management.base import BaseCommand
 
 from dashboard import helpers
-from dashboard.models import Bounty, Activity
+from dashboard.models import Activity, Bounty
 from dashboard.views import record_bounty_activity
 
 

--- a/app/dashboard/management/commands/create_activity_records.py
+++ b/app/dashboard/management/commands/create_activity_records.py
@@ -19,7 +19,7 @@
 from django.core.management.base import BaseCommand
 
 from dashboard import helpers
-from dashboard.models import Bounty
+from dashboard.models import Bounty, Activity
 from dashboard.views import record_bounty_activity
 
 
@@ -71,9 +71,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         force_refresh = options['force_refresh']
+        if force_refresh:
+            Activity.objects.all().delete()
         bounties = Bounty.objects.filter(current_bounty=True)
         for bounty in bounties:
-            if force_refresh:
-                bounty.activities.clear()
             if force_refresh or not bounty.activities.count():
                 create_activities(bounty)

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1078,7 +1078,7 @@ class Activity(models.Model):
     def __str__(self):
         """Define the string representation of an interested profile."""
         return f"{self.profile.handle} type: {self.activity_type}" \
-               f"created: {naturalday(self.created_on)}"
+               f"created: {naturalday(self.created)}"
 
 
 class Profile(SuperModel):


### PR DESCRIPTION
fix for https://github.com/gitcoinco/web/issues/1661

1. clears ALL activity if `force_refresh`, not just for current_bounty
2. fixes the attribution of worker_approved, work_applied, etc to be for the funder, not the bounty hunter.

TODOS:

1. why are we making two requests

http://localhost:8000/actions/api/v0.1/bounties/?github_url=https://github.com/XLNT/gnarly/issues/11&network=mainnet&standard_bounties_id=677&not_current=1
and
http://localhost:8000/actions/api/v0.1/bounties/?github_url=https://github.com/XLNT/gnarly/issues/11&network=mainnet&standard_bounties_id=677

??

i think we should only care about activites related to teh current bounty and we should migrate the actions to the current_bounty=1 when we create a new current_bounty