### PR TITLE
Contributor landing page: change text color of 'Get started' to white.

### DIFF
--- a/app/retail/templates/contributor_landing.html
+++ b/app/retail/templates/contributor_landing.html
@@ -71,7 +71,7 @@
             <div class="mt-4 contributors-cta-text light">Start exploring <strong>{{available_bounties_count}}</strong> bounties worth <strong>${{available_bounties_worth}}</strong></div>
             <div class="mt-5">
               <a class="btn btn-gc-purple text-purple" role="button" href="onboard/contributor" target="_blank" rel="noopener noreferrer">
-                <span>{% trans "Get Started" %}</span>
+                <span class="text-white">{% trans "Get Started" %}</span>
               </a>
             </div>
           </div>


### PR DESCRIPTION
Fixes #1686