### PR TITLE
removed the hiding of searchbar on mobile screens.

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -1462,11 +1462,7 @@ input.is-invalid {
   .bounty_def {
     display: none;
   }
-
-  .search_bar span {
-    display: none;
-  }
-
+  
   .interior .body {
     width: 100%;
     flex: 0 0 100%;

--- a/app/assets/v2/css/jquery-ui.css
+++ b/app/assets/v2/css/jquery-ui.css
@@ -811,6 +811,12 @@ button.ui-button::-moz-focus-inner {
   width: 14em;
 }
 
+@media (max-width: 481px) {
+  .ui-selectmenu-button.ui-button {
+    width: 10em;
+  }
+}
+
 .ui-selectmenu-icon.ui-icon {
   float: right;
   margin-top: 0;

--- a/app/assets/v2/css/search_bar.css
+++ b/app/assets/v2/css/search_bar.css
@@ -150,3 +150,9 @@
     display: none;
   }
 }
+
+@media (max-width: 481px) {
+  .search_bar div .heading {
+    padding-right: 0px;
+  }
+}


### PR DESCRIPTION

##### Description

This PR solves the issue of rendering properly in a mobile screen the "sort issues by" select input. As it stands in a mobile phone the SORT select bar is hidden making the explorer unusable. As seen by the image below in an Iphone 8 (according to Safari's dev tools):
 
<img width="707" alt="screen shot 2018-07-15 at 2 05 36 pm" src="https://user-images.githubusercontent.com/15861355/42736690-40df6c5a-8838-11e8-8f59-cf9335dfe3fa.png">

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior

##### Affected core subsystem(s)
- mobile UI

##### Testing
- Screenshot of new behavior (this time from Firefox's dev tools) below. As you can see the changes on the smallest screen at 320px now renders a nice styling and much more importantly a functional filter to explore issues. There are media queries which handle the width and padding-right to reset them back at 481px ( which is already being used throughout project). 


<img width="563" alt="screen shot 2018-07-15 at 2 10 57 pm" src="https://user-images.githubusercontent.com/15861355/42736729-fde47b2e-8838-11e8-8133-0d32def4d9eb.png">

