### PR TITLE
Refactor GH issue details endpoint

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -57,7 +57,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions', 'django.contrib.messages', 'whitenoise.runserver_nostatic', 'django.contrib.staticfiles',
     'storages', 'social_django', 'cookielaw', 'django.contrib.humanize', 'django.contrib.sitemaps',
     'django.contrib.sites', 'django_extensions', 'easy_thumbnails', 'app', 'avatar', 'retail', 'rest_framework',
-    'bootstrap3', 'marketing', 'economy', 'dashboard', 'enssubdomain', 'faucet', 'tdi', 'gas', 'github', 'legacy',
+    'bootstrap3', 'marketing', 'economy', 'dashboard', 'enssubdomain', 'faucet', 'tdi', 'gas', 'git', 'legacy',
     'chartit', 'email_obfuscator', 'linkshortener', 'credits', 'gitcoinbot', 'external_bounties', 'dataviz',
     'impersonate',
 ]

--- a/app/app/utils.py
+++ b/app/app/utils.py
@@ -16,7 +16,7 @@ import requests
 import rollbar
 from dashboard.models import Profile
 from geoip2.errors import AddressNotFoundError
-from github.utils import _AUTH, HEADERS, get_user
+from git.utils import _AUTH, HEADERS, get_user
 from ipware.ip import get_real_ip
 from marketing.utils import get_or_save_email_subscriber
 from pyshorteners import Shortener

--- a/app/avatar/models.py
+++ b/app/avatar/models.py
@@ -29,7 +29,6 @@ from django.utils.translation import gettext_lazy as _
 from django_extensions.db.fields import AutoSlugField
 from easy_thumbnails.fields import ThumbnailerImageField
 from economy.models import SuperModel
-from git.utils import get_user
 from svgutils.compose import SVG, Figure, Line
 
 from .utils import build_avatar_component, get_svg_templates, get_upload_filename

--- a/app/avatar/models.py
+++ b/app/avatar/models.py
@@ -29,7 +29,7 @@ from django.utils.translation import gettext_lazy as _
 from django_extensions.db.fields import AutoSlugField
 from easy_thumbnails.fields import ThumbnailerImageField
 from economy.models import SuperModel
-from github.utils import get_user
+from git.utils import get_user
 from svgutils.compose import SVG, Figure, Line
 
 from .utils import build_avatar_component, get_svg_templates, get_upload_filename

--- a/app/avatar/utils.py
+++ b/app/avatar/utils.py
@@ -27,7 +27,7 @@ from django.http import HttpResponse, JsonResponse
 from django.template import loader
 
 import requests
-from github.utils import get_user
+from git.utils import get_user
 from PIL import Image, ImageOps
 from svgutils.compose import SVG, Figure, Line
 

--- a/app/avatar/views.py
+++ b/app/avatar/views.py
@@ -24,7 +24,7 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from dashboard.utils import create_user_action
-from github.utils import org_name
+from git.utils import org_name
 from PIL import Image, ImageOps
 
 from .models import Avatar

--- a/app/dashboard/embed.py
+++ b/app/dashboard/embed.py
@@ -5,7 +5,7 @@ from django.utils.cache import patch_response_headers
 
 import requests
 from dashboard.models import Bounty
-from github.utils import get_user, org_name
+from git.utils import get_user, org_name
 from PIL import Image, ImageDraw, ImageFont
 from ratelimit.decorators import ratelimit
 

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -38,7 +38,7 @@ from dashboard.notifications import (
 )
 from dashboard.tokens import addr_to_token
 from economy.utils import convert_amount
-from github.utils import _AUTH
+from git.utils import _AUTH, get_gh_issue_details, get_url_dict, github_connect, issue_number, org_name, repo_name
 from jsondiff import diff
 from pytz import UTC
 from ratelimit.decorators import ratelimit
@@ -150,44 +150,6 @@ def issue_details(request):
     url_val = URLValidator()
     try:
         url_val(url)
-    except ValidationError as e:
-        response['message'] = 'invalid arguments'
-        return JsonResponse(response)
-
-    if url.lower()[:19] != 'https://github.com/':
-        response['message'] = 'invalid arguments'
-        return JsonResponse(response)
-
-    # Web format:  https://github.com/jasonrhaas/slackcloud/issues/1
-    # API format:  https://api.github.com/repos/jasonrhaas/slackcloud/issues/1
-    gh_api = url.replace('github.com', 'api.github.com/repos')
-
-    try:
-        api_response = requests.get(gh_api, auth=_AUTH)
-    except ValidationError:
-        response['message'] = 'could not pull back remote response'
-        return JsonResponse(response)
-
-    if api_response.status_code != 200:
-        response['message'] = f'there was a problem reaching the github api, status code {api_response.status_code}'
-        response['github_resopnse'] = api_response.json()
-        return JsonResponse(response)
-
-    try:
-        response = api_response.json()
-        body = response['body']
-    except (KeyError, ValueError) as e:
-        response['message'] = str(e)
-    else:
-        response['description'] = body.replace('\n', '').strip()
-        response['title'] = response['title']
-
-    keywords = []
-
-    url = request.GET.get('url')
-    url_val = URLValidator()
-    try:
-        url_val(url)
     except ValidationError:
         response['message'] = 'invalid arguments'
         return JsonResponse(response)
@@ -197,38 +159,14 @@ def issue_details(request):
         return JsonResponse(response)
 
     try:
-        repo_url = None
-        url = clean_bounty_url(url)
-        if '/pull' in url:
-            repo_url = url.split('/pull')[0]
-        if '/issue' in url:
-            repo_url = url.split('/issue')[0]
-        split_repo_url = repo_url.split('/')
-        keywords.append(split_repo_url[-1])
-        keywords.append(split_repo_url[-2])
-
-        html_response = requests.get(repo_url, auth=_AUTH)
-    except (AttributeError, ValidationError):
-        response['message'] = 'could not pull back remote response'
-        return JsonResponse(response)
-
-    try:
-        soup = BeautifulSoup(html_response.text, 'html.parser')
-
-        eles = soup.findAll("span", {"class": "lang"})
-        for ele in eles:
-            keywords.append(ele.text)
-
-    except ValidationError:
-        response['message'] = 'could not parse html'
-        return JsonResponse(response)
-
-    try:
-        response['keywords'] = keywords
+        url_dict = get_url_dict(clean_bounty_url(url))
+        if url_dict:
+            response = get_gh_issue_details(**url_dict)
+        else:
+            response['message'] = 'could not parse Github url'
     except Exception as e:
-        print(e)
-        response['message'] = 'could not find a title'
-
+        logger.warning(e)
+        response['message'] = 'could not pull back remote response'
     return JsonResponse(response)
 
 
@@ -493,10 +431,10 @@ def create_new_bounty(old_bounties, bounty_payload, bounty_details, bounty_id):
                 for interest in latest_old_bounty.interested.all():
                     new_bounty.interested.add(interest)
 
-                # pull the activities off the last old bounty 
+                # pull the activities off the last old bounty
                 for activity in latest_old_bounty.activities.all():
                     new_bounty.activities.add(activity)
-                
+
             # set cancel date of this bounty
             canceled_on = latest_old_bounty.canceled_on if latest_old_bounty and latest_old_bounty.canceled_on else None
             if not canceled_on and new_bounty.status == 'cancelled':

--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -28,9 +28,7 @@ from django.db import transaction
 from django.http import Http404, JsonResponse
 from django.utils import timezone
 
-import requests
 from app.utils import sync_profile
-from bs4 import BeautifulSoup
 from dashboard.models import Activity, Bounty, BountyFulfillment, BountySyncRequest, UserAction
 from dashboard.notifications import (
     maybe_market_to_email, maybe_market_to_github, maybe_market_to_slack, maybe_market_to_twitter,
@@ -38,7 +36,7 @@ from dashboard.notifications import (
 )
 from dashboard.tokens import addr_to_token
 from economy.utils import convert_amount
-from git.utils import _AUTH, get_gh_issue_details, get_url_dict, github_connect, issue_number, org_name, repo_name
+from git.utils import get_gh_issue_details, get_url_dict
 from jsondiff import diff
 from pytz import UTC
 from ratelimit.decorators import ratelimit

--- a/app/dashboard/ios.py
+++ b/app/dashboard/ios.py
@@ -7,7 +7,7 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from dashboard.models import Bounty, Interest, Profile
-from github.utils import get_github_user_data
+from git.utils import get_github_user_data
 from marketing.mails import new_match
 from marketing.models import Match
 from ratelimit.decorators import ratelimit

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -43,9 +43,7 @@ import requests
 from dashboard.tokens import addr_to_token
 from economy.models import SuperModel
 from economy.utils import ConversionRateNotFoundError, convert_amount, convert_token_to_usdt
-from git.utils import (
-    _AUTH, HEADERS, TOKEN_URL, build_auth_dict, get_issue_comments, issue_number, org_name, repo_name,
-)
+from git.utils import _AUTH, HEADERS, TOKEN_URL, build_auth_dict, get_issue_comments, issue_number, org_name, repo_name
 from marketing.models import LeaderboardRank
 from rest_framework import serializers
 from web3 import Web3

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -43,7 +43,7 @@ import requests
 from dashboard.tokens import addr_to_token
 from economy.models import SuperModel
 from economy.utils import ConversionRateNotFoundError, convert_amount, convert_token_to_usdt
-from github.utils import (
+from git.utils import (
     _AUTH, HEADERS, TOKEN_URL, build_auth_dict, get_issue_comments, issue_number, org_name, repo_name,
 )
 from marketing.models import LeaderboardRank
@@ -1234,7 +1234,7 @@ class Profile(SuperModel):
 
     @property
     def repos_data(self):
-        from github.utils import get_user
+        from git.utils import get_user
         from app.utils import add_contributors
         # TODO: maybe rewrite this so it doesnt have to go to the internet to get the info
         # but in a way that is respectful of db size too

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -30,7 +30,7 @@ import requests
 import rollbar
 import twitter
 from economy.utils import convert_token_to_usdt
-from github.utils import delete_issue_comment, org_name, patch_issue_comment, post_issue_comment, repo_name
+from git.utils import delete_issue_comment, org_name, patch_issue_comment, post_issue_comment, repo_name
 from marketing.mails import tip_email
 from marketing.models import GithubOrgToTwitterHandleMapping
 from pyshorteners import Shortener

--- a/app/dashboard/tests/test_dashboard_helpers.py
+++ b/app/dashboard/tests/test_dashboard_helpers.py
@@ -47,26 +47,6 @@ class DashboardHelpersTest(TestCase):
         request = self.factory.get('/sync/get_amount', params)
         assert amount(request).content == b'{"eth": 5.0, "usdt": 10.0}'
 
-    def test_issue_details(self):
-        """Test the dashboard helper description method."""
-        sample_url = 'https://github.com/gitcoinco/web/issues/353'
-        params = {'url': sample_url}
-        with requests_mock.Mocker() as m:
-            m.get('https://api.github.com/repos/gitcoinco/web/issues/353',
-                  text='{ "title": "Increase Code Coverage by 4%",'
-                       '"body" : "This bounty will be paid out to anyone '
-                                 'who meaningfully increases the code coverage '
-                                 'of the repository by 4%."}')
-            m.get('https://github.com/gitcoinco/web',
-                  text='<span class="lang">hello</span><span class="lang">world</span>')
-            request = self.factory.get('/sync/get_issue_details', params)
-            response = json.loads(issue_details(request).content)
-            assert response['description'] == "This bounty will be paid out to anyone who " \
-                                              "meaningfully increases the code coverage of " \
-                                              "the repository by 4%."
-            assert response['keywords'] == ["web", "gitcoinco", "hello", "world"]
-            assert response['title'] == "Increase Code Coverage by 4%"
-
     def test_normalize_url(self):
         """Test the dashboard helper normalize_url method."""
         assert normalize_url('https://gitcoin.co/') == 'https://gitcoin.co'

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -32,7 +32,7 @@ from dashboard.abi import erc20_abi
 from dashboard.utils import generate_pub_priv_keypair, get_web3, has_tx_mined
 from dashboard.views import record_user_action
 from gas.utils import recommend_min_gas_price_to_confirm_in_time
-from github.utils import (
+from git.utils import (
     get_auth_url, get_github_emails, get_github_primary_email, get_github_user_data, is_github_token_valid,
 )
 from marketing.mails import (

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -32,9 +32,7 @@ from dashboard.abi import erc20_abi
 from dashboard.utils import generate_pub_priv_keypair, get_web3, has_tx_mined
 from dashboard.views import record_user_action
 from gas.utils import recommend_min_gas_price_to_confirm_in_time
-from git.utils import (
-    get_auth_url, get_github_emails, get_github_primary_email, get_github_user_data, is_github_token_valid,
-)
+from git.utils import get_github_emails, get_github_primary_email
 from marketing.mails import (
     admin_contact_funder, bounty_uninterested, start_work_approved, start_work_new_applicant, start_work_rejected,
 )

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -42,7 +42,7 @@ from app.utils import ellipses, sync_profile
 from avatar.utils import get_avatar_context
 from economy.utils import convert_amount
 from gas.utils import conf_time_spread, gas_advisories, gas_history, recommend_min_gas_price_to_confirm_in_time
-from github.utils import (
+from git.utils import (
     get_auth_url, get_github_emails, get_github_primary_email, get_github_user_data, is_github_token_valid,
 )
 from marketing.mails import (

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -42,9 +42,7 @@ from app.utils import ellipses, sync_profile
 from avatar.utils import get_avatar_context
 from economy.utils import convert_amount
 from gas.utils import conf_time_spread, gas_advisories, gas_history, recommend_min_gas_price_to_confirm_in_time
-from git.utils import (
-    get_auth_url, get_github_emails, get_github_primary_email, get_github_user_data, is_github_token_valid,
-)
+from git.utils import get_auth_url, get_github_user_data, is_github_token_valid
 from marketing.mails import (
     admin_contact_funder, bounty_uninterested, start_work_approved, start_work_new_applicant, start_work_rejected,
 )

--- a/app/external_bounties/management/commands/sync_known_github_repos.py
+++ b/app/external_bounties/management/commands/sync_known_github_repos.py
@@ -19,7 +19,7 @@
 from django.core.management.base import BaseCommand
 
 from external_bounties.models import ExternalBounty
-from github.utils import get_issues
+from git.utils import get_issues
 
 
 class Command(BaseCommand):

--- a/app/external_bounties/models.py
+++ b/app/external_bounties/models.py
@@ -27,7 +27,7 @@ from django.utils.translation import gettext_lazy as _
 
 from economy.models import SuperModel
 from economy.utils import convert_amount
-from github.utils import org_name, repo_name
+from git.utils import org_name, repo_name
 
 
 class ExternalBounty(SuperModel):

--- a/app/git/apps.py
+++ b/app/git/apps.py
@@ -20,8 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.apps import AppConfig
 
 
-class GithubConfig(AppConfig):
+class GitConfig(AppConfig):
     """Define the Github application configuration."""
 
-    name = 'github'
-    verbose_name = 'Github'
+    name = 'git'
+    verbose_name = 'Git'

--- a/app/git/tests/test_utils.py
+++ b/app/git/tests/test_utils.py
@@ -25,7 +25,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 
 import responses
-from github.utils import (
+from git.utils import (
     BASE_URI, HEADERS, JSON_HEADER, TOKEN_URL, build_auth_dict, delete_issue_comment, get_auth_url, get_github_emails,
     get_github_primary_email, get_github_user_data, get_github_user_token, get_issue_comments,
     get_issue_timeline_events, get_user, is_github_token_valid, org_name, patch_issue_comment, post_issue_comment,
@@ -38,7 +38,7 @@ from test_plus.test import TestCase
 @override_settings(GITHUB_CLIENT_ID='TEST')
 @override_settings(GITHUB_CLIENT_SECRET='TEST')
 @override_settings(GITHUB_SCOPE='user')
-class GithubUtilitiesTest(TestCase):
+class GitUtilitiesTest(TestCase):
     """Define tests for Github utils."""
 
     def setUp(self):

--- a/app/git/utils.py
+++ b/app/git/utils.py
@@ -29,7 +29,8 @@ from django.utils import timezone
 import dateutil.parser
 import requests
 import rollbar
-from github import BadCredentialsException, Github
+from github import Github
+from github.GithubException import BadCredentialsException
 from requests.exceptions import ConnectionError
 from rest_framework.reverse import reverse
 

--- a/app/git/utils.py
+++ b/app/git/utils.py
@@ -29,6 +29,7 @@ from django.utils import timezone
 import dateutil.parser
 import requests
 import rollbar
+from github import BadCredentialsException, Github
 from requests.exceptions import ConnectionError
 from rest_framework.reverse import reverse
 
@@ -42,6 +43,38 @@ JSON_HEADER = {'Accept': 'application/json', 'User-Agent': settings.GITHUB_APP_N
 TIMELINE_HEADERS = {'Accept': 'application/vnd.github.mockingbird-preview'}
 TOKEN_URL = '{api_url}/applications/{client_id}/tokens/{oauth_token}'
 
+
+def github_connect(token=None):
+    """Authenticate the GH wrapper with Github.
+
+    Args:
+        token (str): The Github token to authenticate with.
+            Defaults to: None.
+
+    """
+    if token is None:
+        token = settings.GITHUB_API_TOKEN
+
+    try:
+        github_client = Github(login_or_token='token', password=token)
+    except BadCredentialsException as e:
+        github_client = None
+        logger.exception(e)
+    return github_client
+
+
+def get_gh_issue_details(org, repo, issue_num):
+    details = {'keywords': []}
+    gh_client = github_connect()
+    org_user = gh_client.get_user(login=org)
+    repo_obj = org_user.get_repo(repo)
+    issue_details = repo_obj.get_issue(issue_num)
+    langs = repo_obj.get_languages()
+    for k, _ in langs.items():
+        details['keywords'].append(k)
+    details['title'] = issue_details.title
+    details['description'] = issue_details.body.replace('\n', '').strip()
+    return details
 
 def build_auth_dict(oauth_token):
     """Collect authentication details.
@@ -81,7 +114,6 @@ def check_github(profile):
 
 
 def search_github(q):
-
     params = (('q', q), ('sort', 'updated'), )
     response = requests.get('https://api.github.com/search/users', headers=HEADERS, params=params)
     return response.json()
@@ -251,7 +283,7 @@ def get_github_emails(oauth_token):
         oauth_token (str): The Github OAuth2 token to use for authentication.
 
     Returns:
-        list of str: All of the user's associated email from github.
+        list of str: All of the user's associated email from git.
 
     """
     emails = []
@@ -465,6 +497,29 @@ def post_issue_comment_reaction(owner, repo, comment_id, content):
     url = f'https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'
     response = requests.post(url, data=json.dumps({'content': content}), auth=_AUTH, headers=HEADERS)
     return response.json()
+
+
+def get_url_dict(issue_url):
+    """Get the URL dictionary with specific data we care about.
+
+    Args:
+        issue_url (str): The Github issue URL.
+
+    Raises:
+        IndexError: The exception is raised if accessing a necessary index fails.
+
+    Returns:
+        dict: A mapping of details for the specified issue URL.
+
+    """
+    try:
+        return {
+            'org': issue_url.split('/')[3],
+            'repo': issue_url.split('/')[4],
+            'issue_num': int(issue_url.split('/')[6]),
+        }
+    except IndexError:
+        return {}
 
 
 def repo_url(issue_url):

--- a/app/git/utils.py
+++ b/app/git/utils.py
@@ -29,8 +29,6 @@ from django.utils import timezone
 import dateutil.parser
 import requests
 import rollbar
-from github import Github
-from github.GithubException import BadCredentialsException
 from requests.exceptions import ConnectionError
 from rest_framework.reverse import reverse
 
@@ -53,6 +51,8 @@ def github_connect(token=None):
             Defaults to: None.
 
     """
+    from github import Github
+    from github.GithubException import BadCredentialsException
     if token is None:
         token = settings.GITHUB_API_TOKEN
 

--- a/app/gitcoinbot/actions.py
+++ b/app/gitcoinbot/actions.py
@@ -29,8 +29,8 @@ import requests
 import rollbar
 from dashboard.models import Bounty
 from dashboard.tokens import get_tokens
-from gitcoinbot.models import GitcoinBotResponses
 from git.utils import post_issue_comment_reaction
+from gitcoinbot.models import GitcoinBotResponses
 
 MIN_AMOUNT = 0
 FALLBACK_CURRENCY = 'ETH'

--- a/app/gitcoinbot/actions.py
+++ b/app/gitcoinbot/actions.py
@@ -30,7 +30,7 @@ import rollbar
 from dashboard.models import Bounty
 from dashboard.tokens import get_tokens
 from gitcoinbot.models import GitcoinBotResponses
-from github.utils import post_issue_comment_reaction
+from git.utils import post_issue_comment_reaction
 
 MIN_AMOUNT = 0
 FALLBACK_CURRENCY = 'ETH'

--- a/app/gitcoinbot/management/commands/get_notifications.py
+++ b/app/gitcoinbot/management/commands/get_notifications.py
@@ -23,8 +23,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from git.utils import (
-    get_issue_comments, get_notifications, issue_number, org_name, post_issue_comment, post_issue_comment_reaction,
-    repo_name,
+    get_issue_comments, get_notifications, issue_number, org_name, post_issue_comment_reaction, repo_name,
 )
 
 

--- a/app/gitcoinbot/management/commands/get_notifications.py
+++ b/app/gitcoinbot/management/commands/get_notifications.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from github.utils import (
+from git.utils import (
     get_issue_comments, get_notifications, issue_number, org_name, post_issue_comment, post_issue_comment_reaction,
     repo_name,
 )

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -31,7 +31,7 @@ from dashboard.notifications import (
     maybe_notify_user_escalated_github, maybe_warn_user_removed_github,
 )
 from dashboard.utils import record_user_action_on_interest
-from github.utils import get_interested_actions
+from git.utils import get_interested_actions
 from marketing.mails import bounty_startwork_expire_warning, bounty_startwork_expired
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -117,10 +117,10 @@ class Command(BaseCommand):
 
                             # commenting on the GH issue
                             maybe_notify_user_escalated_github(bounty, interest.profile.handle, last_heard_from_user_days)
-                            
+
                             # commenting in slack
                             maybe_notify_bounty_user_escalated_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
-                            
+
                             # send email
                             bounty_startwork_expired(interest.profile.email, bounty, interest, last_heard_from_user_days)
 
@@ -129,13 +129,13 @@ class Command(BaseCommand):
                             record_user_action_on_interest(interest, 'bounty_abandonment_warning', last_heard_from_user_days)
 
                             print(f'executing should_warn_user for {interest.profile} / {bounty.github_url} ')
-                            
+
                             # commenting on the GH issue
                             maybe_warn_user_removed_github(bounty, interest.profile.handle, last_heard_from_user_days)
-                            
+
                             # commenting in slack
                             maybe_notify_bounty_user_warned_removed_to_slack(bounty, interest.profile.handle, last_heard_from_user_days)
-                            
+
                             # send email
                             bounty_startwork_expire_warning(interest.profile.email, bounty, interest, last_heard_from_user_days)
 

--- a/app/marketing/management/commands/pull_github.py
+++ b/app/marketing/management/commands/pull_github.py
@@ -22,7 +22,7 @@ from django.core.management.base import BaseCommand
 
 from dashboard.models import Profile
 from dashboard.views import profile_keywords_helper
-from github.utils import search
+from git.utils import search
 from marketing.models import EmailSubscriber
 
 

--- a/app/marketing/management/commands/sync_github.py
+++ b/app/marketing/management/commands/sync_github.py
@@ -22,7 +22,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from dashboard.models import Bounty, BountyFulfillment, Interest, Profile, UserAction
-from github.utils import get_user, repo_name
+from git.utils import get_user, repo_name
 from marketing.models import GithubEvent
 
 

--- a/app/marketing/stats.py
+++ b/app/marketing/stats.py
@@ -141,7 +141,7 @@ def user_actions():
 
 
 def github_stars():
-    from github.utils import get_user
+    from git.utils import get_user
     reops = get_user('gitcoinco', '/repos')
     forks_count = sum([repo['forks_count'] for repo in reops])
 
@@ -160,8 +160,8 @@ def github_stars():
 
 def github_issues():
     if settings.DEBUG:
-        return 
-    from github.utils import get_issues, get_user
+        return
+    from git.utils import get_issues, get_user
     repos = []
 
     for org in ['bitcoin', 'gitcoinco', 'ethereum']:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,3 +63,4 @@ pg_activity
 PyYAML==4.2b4
 ecdsa
 pysha3
+pygithub==1.40


### PR DESCRIPTION
##### Description

The goal of this PR is to introduce `pygithub` and refactor the `dashboard.helpers.issue_details` view.

- Removes BS4 for finding keywords
- Slims up the response from `get_issue_details`
- Drops the requests to GH significantly
- Fixes bug in `get_issue_details` where `/pull` urls wouldn't return results, but rather an error.
- Removes some dead imports

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
dashboard helpers, issue details

##### Testing

Locally

##### Refers/Fixes

Ref #1772
