### PR TITLE
Make back button work on contributor onboard

### DIFF
--- a/app/assets/v2/js/pages/onboard.js
+++ b/app/assets/v2/js/pages/onboard.js
@@ -14,12 +14,13 @@ $('.js-select2').each(function() {
 onboard.showTab = function(num) {
   $($('.step')[num]).addClass('block').outerWidth();
   $($('.step')[num]).addClass('show');
-  window.history.pushState('', '', '/onboard/' + flow + '/' + $($('.step')[num]).attr('link'));
 
-  if (num === 0)
+  if (num === 0) {
     $('#prev-btn').hide();
-  else
+  } else {
     $('#prev-btn').show();
+    window.history.pushState('', '', '/onboard/' + flow + '/' + $($('.step')[num]).attr('link'));
+  }
 
   if (num === 1 || num === 2 || $($('.step')[num]).attr('link') === 'avatar') {
     $('.controls').hide();


### PR DESCRIPTION
Currently the browser back button doesn't work on the contributor onboard page. This PR allows users to click the back button and return to wherever they came from.

Fixes: https://github.com/gitcoinco/web/issues/1685

<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

<!-- A description on what this PR aims to solve -->
Whenever a user is sent to https://gitcoin.co/onboard/contributor/, they are instantly redirected to https://gitcoin.co/onboard/contributor/github which causes the issue reported in #1685. This PR simply doesn't add this initial redirect to the browser history.


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
ui

##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

I manually tested this.

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/1685

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
