### PR TITLE
Add gitcoin bounty details url to start work github bot copy

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -447,11 +447,8 @@ def build_github_notification(bounty, event_name, profile_pairs=None):
               f"${amount_open_work} more funded OSS Work available on the [Gitcoin Issue Explorer](https://gitcoin.co/explorer)\n"
     elif event_name == 'work_started':
         interested = bounty.interested.all().order_by('created')
-        # interested_plural = "s" if interested.count() != 0 else ""
         from_now = naturaltime(bounty.expires_date)
         started_work = bounty.interested.filter(pending=False).all()
-        # pending_approval = bounty.interested.filter(pending=True).all()
-        bounty_owner_clear = f"@{bounty.bounty_owner_github_username}" if bounty.bounty_owner_github_username else ""
         approval_required = bounty.permission_type == 'approval'
 
         if started_work.exists():
@@ -480,9 +477,8 @@ def build_github_notification(bounty, event_name, profile_pairs=None):
 
             issue_message = interest.issue_message.strip()
             if issue_message:
-                msg += f"\t\n * Q: " \
-                       f"{issue_message}"
-            msg += "\n\n"
+                msg += f"\t\n * Q: {issue_message}"
+            msg += "\n\nLearn more [on the Gitcoin Issue Details page]({absolute_url})]\n\n"
 
     elif event_name == 'work_submitted':
         sub_msg = ""


### PR DESCRIPTION
##### Description

The goal of this PR is to add a GC issue details URL to the `start work` gitcoinbot notification comment as requested in: #1794

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
bot, notifications

##### Testing

Locally

##### Refers/Fixes

Fix #1794