### PR TITLE
Do not display an 'wrong network' alert banner if metamask is locked.

### DIFF
--- a/app/assets/v2/js/pages/wallet_estimate.js
+++ b/app/assets/v2/js/pages/wallet_estimate.js
@@ -90,7 +90,7 @@ function prefill_recommended_prices() {
     $('#default-recommended-gas').hide();
     $('#average-recommended-gas').hide();
     $('#fast-recommended-gas').show();
-    $('.message').html('Good news! Gas is pretty fast right now').show();
+    $('.gas-rates .message').html('Good news! Gas is pretty fast right now').show();
     $('#fast-recommended-gas').html('Fast $' + parseFloat(fast_data['usd']).toFixed(2) + ' ~' + fast_data['time'] + ' minutes').addClass('active');
     $('#fast-recommended-gas').data('amount', parseFloat(fast_data['usd']).toFixed(2));
     $('#fast-recommended-gas').parent().removeClass('justify-content-between').addClass('justify-content-around');

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -795,13 +795,24 @@ var listen_for_web3_changes = function() {
 var actions_page_warn_if_not_on_same_network = function() {
   var user_network = document.web3network;
 
+  if (user_network === 'locked') {
+    // handled by the unlock MetaMask banner
+    return;
+  }
+
   if (typeof user_network == 'undefined') {
     user_network = 'no network';
   }
   var bounty_network = $('input[name=network]').val();
 
   if (bounty_network != user_network) {
-    var msg = 'Warning: You are on ' + user_network + ' and this bounty is on the ' + bounty_network + ' network.  Please change your network to the ' + bounty_network + ' network.';
+    var msg = 'Warning: You are on ' +
+              user_network +
+              ' and this bounty is on the ' +
+              bounty_network +
+              ' network.  Please change your network to the ' +
+              bounty_network +
+              ' network.';
 
     _alert({ message: gettext(msg) }, 'error');
   }


### PR DESCRIPTION
Also, we should display the gas rate message in the right location
if a banner is shown.

Fixes #1792
