### PR TITLE
restructuted profiles

### DIFF
--- a/app/dashboard/templates/profiles/hidden.html
+++ b/app/dashboard/templates/profiles/hidden.html
@@ -1,0 +1,38 @@
+{% comment %}
+    Copyright (C) 2017 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+{% endcomment %}
+{% load i18n static %}
+<div class="row">
+  <div class="col pt-4">
+    <h2>{% trans "Four oh Four" %}</h2>
+  </div>
+</div>
+<div class="row">
+  <div class="col pb-4">
+    <h5>{% trans "This profile is not available." %}</h5>
+  </div>
+</div>
+<div class="row">
+  <div class="col pb-4">
+    <p>{% trans "This profile is either doesn't exist, is not a member of Gitcoin, or the user has chosen not to make their profile available." %}</p>
+  </div>
+</div>
+<div class="row">
+  <div class="col pb-4">
+    <p><a href="https://github.com/{{profile.handle}}">{% trans "Try looking for their profile on Github" %}</a> or <a href="{% url 'slack' %}">{% trans "Contact us on Slack" %}</a></p>
+  </div>
+</div>

--- a/app/dashboard/templates/profiles/hidden.html
+++ b/app/dashboard/templates/profiles/hidden.html
@@ -1,19 +1,18 @@
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static %}
 <div class="row">
@@ -28,11 +27,11 @@
 </div>
 <div class="row">
   <div class="col pb-4">
-    <p>{% trans "This profile is either doesn't exist, is not a member of Gitcoin, or the user has chosen not to make their profile available." %}</p>
+    <p>{% trans "This profile either doesn't exist, is not a member of Gitcoin, or the user has chosen not to make their profile available." %}</p>
   </div>
 </div>
 <div class="row">
   <div class="col pb-4">
-    <p><a href="https://github.com/{{profile.handle}}">{% trans "Try looking for their profile on Github" %}</a> or <a href="{% url 'slack' %}">{% trans "Contact us on Slack" %}</a></p>
+    <p><a href="https://github.com/{{ profile.handle }}">{% trans "Try looking for their profile on Github" %}</a> or <a href="{% url 'slack' %}">{% trans "Contact us on Slack" %}</a></p>
   </div>
 </div>

--- a/app/dashboard/templates/profiles/organization.html
+++ b/app/dashboard/templates/profiles/organization.html
@@ -1,0 +1,44 @@
+{% comment %}
+    Copyright (C) 2017 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+{% endcomment %}
+{% load i18n static %}
+<div class="col-12 col-lg-4">
+  <div class="profile-header__stats profile-header__stats--contributor card mb-4">
+    <div class="card-header font-subheader">
+      {% trans "Organization" %}
+    </div>
+    <div class="card-body font-subheader">
+      <ul>
+        <li><span class="highlight">{{ count_bounties_on_repo }}</span> {% trans "bounties" %}</li>
+        <li><span class="highlight">{{ sum_eth_on_repos|floatformat:2 }}</span> {% trans "ETH" %}</li>
+        {% if scoreboard_position_org %}
+            <li><span class="highlight">#{{ scoreboard_position_org }}</span> {% trans "org" %}</li>
+        {% endif %}
+        <li class="works_with_list">
+          {% if works_with_org|length != 0 %}
+            <span class="font-body">( <i class="fa fa-code"></i> ) Contributors:</span>
+            {% for profile, num_times in works_with_org.items %}
+              <a href="{% url 'profile' profile %} ">
+                <img src='{% if profile.avatar and profile.avatar.svg %}{{ profile.avatar.svg.url }}{% else %}/static/avatar/{{ profile }}{% endif %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+              </a>
+            {% endfor %}
+          {% endif %}
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/dashboard/templates/profiles/organization.html
+++ b/app/dashboard/templates/profiles/organization.html
@@ -1,19 +1,18 @@
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static %}
 <div class="col-12 col-lg-4">
@@ -26,11 +25,11 @@
         <li><span class="highlight">{{ count_bounties_on_repo }}</span> {% trans "bounties" %}</li>
         <li><span class="highlight">{{ sum_eth_on_repos|floatformat:2 }}</span> {% trans "ETH" %}</li>
         {% if scoreboard_position_org %}
-            <li><span class="highlight">#{{ scoreboard_position_org }}</span> {% trans "org" %}</li>
+          <li><span class="highlight">#{{ scoreboard_position_org }}</span> {% trans "org" %}</li>
         {% endif %}
         <li class="works_with_list">
           {% if works_with_org|length != 0 %}
-            <span class="font-body">( <i class="fa fa-code"></i> ) Contributors:</span>
+            <span class="font-body">( <i class="fa fa-code"></i> ) {% trans "Contributors" %}:</span>
             {% for profile, num_times in works_with_org.items %}
               <a href="{% url 'profile' profile %} ">
                 <img src='{% if profile.avatar and profile.avatar.svg %}{{ profile.avatar.svg.url }}{% else %}/static/avatar/{{ profile }}{% endif %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -45,124 +45,79 @@
               </div>
             {% endif %}
           </div>
-        {% if not hidden %}
-        {% if profile.is_org %}
-          <div class="col-12 col-lg-4">
-            <div class="profile-header__stats profile-header__stats--contributor card mb-4">
-              <div class="card-header font-subheader">
-                {% trans "Organization" %}
-              </div>
-              <div class="card-body font-subheader">
-                <ul>
-                  <li><span class="highlight">{{ count_bounties_on_repo }}</span> {% trans "bounties" %}</li>
-                  <li><span class="highlight">{{ sum_eth_on_repos|floatformat:2 }}</span> {% trans "ETH" %}</li>
-                  {% if scoreboard_position_org %}
-                      <li><span class="highlight">#{{ scoreboard_position_org }}</span> {% trans "org" %}</li>
-                  {% endif %}
-                  <li class="works_with_list">
-                    {% if works_with_org|length != 0 %}
-                      <span class="font-body">( <i class="fa fa-code"></i> ) Contributors:</span>
-                      {% for profile, num_times in works_with_org.items %}
-                        <a href="{% url 'profile' profile %} ">
-                          <img src='{% if profile.avatar and profile.avatar.svg %}{{ profile.avatar.svg.url }}{% else %}/static/avatar/{{ profile }}{% endif %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
-                        </a>
-                      {% endfor %}
-                    {% endif %}
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        {% else %}
-          <div class="col-12 col-lg-4">
-            <div class="profile-header__stats profile-header__stats--contributor card mb-4">
-              <div class="card-header font-subheader">
-                {% trans "Contributor" %}
-              </div>
-              <div class="card-body font-subheader">
-                <ul>
-                  <li><span class="highlight">{{ count_bounties_completed }}</span> {% trans "bounties completed" %}</li>
-                  <li><span class="highlight">{{ sum_eth_collected|floatformat:2 }}</span> {% trans "ETH collected" %}</li>
-                  {% if no_times_been_removed %}
-                      <li> - {% trans "removed from" %} <span class="highlight">{{ no_times_been_removed }}</span> {% trans "bounties" %}</li>
-                  {% endif %}
-                  {% if scoreboard_position_contributor %}
-                      <li><span class="highlight">#{{ scoreboard_position_contributor }}</span> {% trans "contributor" %}</li>
-                  {% endif %}
-                  <li class="works_with_list">
-                    {% if works_with_collected|length != 0 %}
-                        <span class="font-body">( <i class="fa fa-code"></i> ) Contributes To:</span>
-                        {% if works_with_collected|length > 2 %}
-                        <br>
+          {% if not hidden %}
+            {% if profile.is_org %}
+              {% include 'profiles/organization.html' %}
+            {% else %}
+              <div class="col-12 col-lg-4">
+                <div class="profile-header__stats profile-header__stats--contributor card mb-4">
+                  <div class="card-header font-subheader">
+                    {% trans "Contributor" %}
+                  </div>
+                  <div class="card-body font-subheader">
+                    <ul>
+                      <li><span class="highlight">{{ count_bounties_completed }}</span> {% trans "bounties completed" %}</li>
+                      <li><span class="highlight">{{ sum_eth_collected|floatformat:2 }}</span> {% trans "ETH collected" %}</li>
+                      {% if no_times_been_removed %}
+                          <li> - {% trans "removed from" %} <span class="highlight">{{ no_times_been_removed }}</span> {% trans "bounties" %}</li>
+                      {% endif %}
+                      {% if scoreboard_position_contributor %}
+                          <li><span class="highlight">#{{ scoreboard_position_contributor }}</span> {% trans "contributor" %}</li>
+                      {% endif %}
+                      <li class="works_with_list">
+                        {% if works_with_collected|length != 0 %}
+                            <span class="font-body">( <i class="fa fa-code"></i> ) Contributes To:</span>
+                            {% if works_with_collected|length > 2 %}
+                            <br>
+                            {% endif %}
+                            {% for profile, num_times in works_with_collected.items %}
+                                <a href="{% url 'profile' profile %} ">
+                                  <img src='/static/avatar/{{ profile }}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                                </a>
+                            {% endfor %}
                         {% endif %}
-                        {% for profile, num_times in works_with_collected.items %}
-                            <a href="{% url 'profile' profile %} ">
-                              <img src='/static/avatar/{{ profile }}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
-                            </a>
-                        {% endfor %}
-                    {% endif %}
-                  </li>
-                </ul>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-          <div class="col-12 col-lg-4">
-            <div class="profile-header__stats profile-header__stats--funder card mb-4">
-              <div class="card-header font-subheader">
-                {% trans "Funder" %}
-              </div>
-              <div class="card-body font-subheader">
-                <ul>
-                  <li><span class="highlight">{{ funded_bounties_count }}</span> {% trans "bounties funded" %}</li>
-                  <li><span class="highlight">{{ sum_eth_funded|floatformat:2 }}</span> {% trans "ETH funded" %}</li>
-                  {% if scoreboard_position_funder %}
-                      <li><span class="highlight">#{{ scoreboard_position_funder }}</span> {% trans "funder" %}</li>
-                  {% endif %}
-                  <li class="works_with_list">
-                    {% if works_with_funded|length %}
-                        <span class="font-body">( <i class="fab fa-ethereum"></i> ) </i> {% trans "Funds" %}:</span>
-                        {% if works_with_funded|length > 2 %}
-                        <br>
+              <div class="col-12 col-lg-4">
+                <div class="profile-header__stats profile-header__stats--funder card mb-4">
+                  <div class="card-header font-subheader">
+                    {% trans "Funder" %}
+                  </div>
+                  <div class="card-body font-subheader">
+                    <ul>
+                      <li><span class="highlight">{{ funded_bounties_count }}</span> {% trans "bounties funded" %}</li>
+                      <li><span class="highlight">{{ sum_eth_funded|floatformat:2 }}</span> {% trans "ETH funded" %}</li>
+                      {% if scoreboard_position_funder %}
+                          <li><span class="highlight">#{{ scoreboard_position_funder }}</span> {% trans "funder" %}</li>
+                      {% endif %}
+                      <li class="works_with_list">
+                        {% if works_with_funded|length %}
+                            <span class="font-body">( <i class="fab fa-ethereum"></i> ) </i> {% trans "Funds" %}:</span>
+                            {% if works_with_funded|length > 2 %}
+                            <br>
+                            {% endif %}
+                            {% for profile, num_times in works_with_funded.items %}
+                              <a href="{% url 'profile' profile %} ">
+                                <img src='/static/avatar/{{ profile }}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                              </a>
+                            {% endfor %}
                         {% endif %}
-                        {% for profile, num_times in works_with_funded.items %}
-                          <a href="{% url 'profile' profile %} ">
-                            <img src='/static/avatar/{{ profile }}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
-                          </a>
-                        {% endfor %}
-                    {% endif %}
-                  </li>
-                </ul>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        {% endif %}
-        {% endif %}
-
+            {% endif %}
+          {% endif %}
         </div>
       </div>
     </div>
     <div class="container">
     {% if hidden %}
-      <div class="row">
-        <div class="col pt-4">
-          <h2>{% trans "Four oh Four" %}</h2>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col pb-4">
-          <h5>{% trans "This profile is not available." %}</h5>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col pb-4">
-          <p>{% trans "This profile is either doesn't exist, is not a member of Gitcoin, or the user has chosen not to make their profile available." %}</p>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col pb-4">
-          <p><a href="https://github.com/{{profile.handle}}">{% trans "Try looking for their profile on Github" %}</a> or <a href="{% url 'slack' %}">{% trans "Contact us on Slack" %}</a></p>
-        </div>
-      </div>
+      {% include 'profiles/hidden.html' %}
     {% else %}
       <div class="row">
         <div class="col py-4">

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -925,11 +925,11 @@ def profile(request, handle):
                 },
             },
         }
-        return TemplateResponse(request, 'profile_details.html', params)
+        return TemplateResponse(request, 'profiles/profile.html', params)
 
     params = profile.to_dict()
 
-    return TemplateResponse(request, 'profile_details.html', params)
+    return TemplateResponse(request, 'profiles/profile.html', params)
 
 
 @csrf_exempt


### PR DESCRIPTION
##### Description

- Indent + Restructure
- All profile templates resides within `profile/`  & have been broken down into smaller templates
  to make code more maintainable

This is not being pushed to the orgs branch as I wanna avoid dealing with conflicts due to this restructuring. All further changes will be made in the `mark-orgs` branch 

##### Refers
- https://github.com/gitcoinco/web/issues/1798