### PR TITLE
Remove duplicate Tip properties

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -915,14 +915,6 @@ class Tip(SuperModel):
 
     @property
     def amount_in_wei(self):
-        return float(self.amount)
-
-    @property
-    def amount_in_whole_units(self):
-        return float(self.get_natural_value())
-
-    @property
-    def amount_in_wei(self):
         token = addr_to_token(self.tokenAddress)
         decimals = token['decimals'] if token else 18
         return float(self.amount) * 10**decimals


### PR DESCRIPTION
##### Description

The goal of this PR is to remove the duplicate `Tip` properties that are being redefined.

- `amount_in_wei`
- `amount_in_whole_units`

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
tips

##### Testing

Locally
