### PR TITLE
activity feed on landing page to increase conversion rate 

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1127,7 +1127,6 @@ class Activity(models.Model):
     def view_props(self):
         from dashboard.tokens import token_by_name
         icons = {
-            'title': 'Activity',
             'new_tip': 'fa-thumbs-up',
             'start_work': 'fa-lightbulb',
             'new_bounty': 'fa-money-bill-alt',

--- a/app/retail/templates/activity.html
+++ b/app/retail/templates/activity.html
@@ -33,64 +33,9 @@
     <div style="background-color: white;">
       <div class="container" id="activity_stream">
         {% include 'shared/pagination.html' %}
-      {% for row in activities %}
-        <div class="row box activity mt-4">
-          <div class="col-12 col-md-1">
-            <div class="activity-avatar">
-              <img class="avatar" src="/funding/avatar?repo=https://github.com/{{ row.profile.handle }}"/>
-            </div>
-          </div>
-          <div class="col-12 col-md-10">
-            <div class="activity-status">
-              <a href="https://gitcoin.co/profile/{{ row.profile.handle }}" target="_blank">
-                @{{ row.profile.handle }}
-              </a>
-              {% if row.activity_type == 'new_tip' %}
-                {% trans "tipped" %}
-                <a href="https://gitcoin.co/profile/{{ row.metadata.to_username }}" target="_blank">
-                  @{{ row.metadata.to_username }}
-                </a>
-              {% elif row.activity_type == 'new_bounty' %}
-                {% trans "funded a new issue: " %}{{ row.urled_title | safe }}
-              {% elif row.activity_type == 'start_work' %}
-                {% trans "started work: " %}{{ row.urled_title | safe }}
-              {% elif row.activity_type == 'stop_work' %}
-                {% trans "stopped work: " %}{{ row.urled_title | safe }}
-              {% elif row.activity_type == 'killed_bounty' %}
-                {% trans "canceled bounty: " %}{{ row.urled_title | safe }}
-              {% elif row.activity_type == 'increased_bounty' %}
-                {% trans "increased funding: " %}{{ row.urled_title | safe }}
-              {% else %}
-                {{ row.i18n_name }}{% if row.urled_title %}: {{ row.urled_title | safe }}{% endif %}
-              {% endif %}
-            </div>
-            <div class="font-caption" >
-              <div class="activity-tags activity-tag-first align-items-center">
-                <div class="tag token">
-                  <p>
-                    {% if row.value_in_token_disp %}
-                    <span>{{ row.value_in_token_disp }} {{row.token_name}}</span>
-                    {% elif row.metadata.value_in_eth %}
-                    <span>{{ row.metadata.value_in_eth }} {{row.token_name}}</span>
-                    {% else %}
-                    <span>{{row.metadata.value_in_token_old}}  - {{row.metadata.value_in_token}}  {{row.metadata.token_name}}</span>
-                    {% endif %}
-                  </p>
-                </div>
-                <div class="tag usd">
-                  <p>
-                    <span>{{ row.value_in_usdt_now }} USD</span>
-                  </p>
-                </div>
-                {{ row.created | naturaltime }}
-              </div>
-            </div>
-          </div>
-          <div class="col-12 col-md-1">
-            <i class="far {{ row.icon }} last-icon"></i>
-          </div>
-        </div>
-      {% endfor %}
+          {% for row in activities %}
+            {% include 'shared/activity.html' %}
+          {% endfor %}
       {% include 'shared/pagination.html' %}
       </div>
     </div>

--- a/app/retail/templates/contributor_landing.html
+++ b/app/retail/templates/contributor_landing.html
@@ -46,6 +46,10 @@
         </div>
       {% endif %}
 
+      <div class="container-fluid p-5 activity">
+        {% include 'landing/contributor/activity.html' %}
+      </div>
+
       <div class="container-fluid p-5 benefits_container">
         {% include 'landing/contributor/benefits.html' %}
       </div>

--- a/app/retail/templates/landing/contributor/activity.html
+++ b/app/retail/templates/landing/contributor/activity.html
@@ -1,0 +1,34 @@
+{% comment %}
+  Copyright (C) 2018 Gitcoin Core
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+{% endcomment %}
+{% load i18n static  %}
+<link rel="stylesheet" href={% static "v2/css/activity_stream.css" %}>
+
+{% if activities|length %}
+  <div id=activity_stream>
+    <div class="col text-center">
+      <h2 class="mb-4">{{ tech_stack|capfirst }} {% trans "Activity on Gitcoin" %}</h2>
+    </div>
+    <div class="mb-4 col offset-lg-1 col-lg-10">
+      {% for row in activities %}
+        {% include 'shared/activity.html' %}
+      {% endfor %}
+    </div>
+    <div class="col text-center">
+      <a href="/explorer?q={{ tech_stack }}" class="button button--primary" target="_blank" rel="noopener noreferrer">{% trans "Get Started With" %} {{ tech_stack|capfirst }} </a> <!-- TODO: Need to invoke resetFilters & set localStorage props -->
+    </div>
+  </div>
+{% endif %}

--- a/app/retail/templates/shared/activity.html
+++ b/app/retail/templates/shared/activity.html
@@ -1,0 +1,74 @@
+{% comment %}
+    Copyright (C) 2017 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+{% endcomment %}
+{% load humanize i18n static %}
+<div class="row box activity mt-4">
+  <div class="col-12 col-md-1">
+    <div class="activity-avatar">
+      <img class="avatar" src="/funding/avatar?repo=https://github.com/{{ row.profile.handle }}"/>
+    </div>
+  </div>
+  <div class="col-12 col-md-10">
+    <div class="activity-status">
+      <a href="https://gitcoin.co/profile/{{ row.profile.handle }}" target="_blank">
+        @{{ row.profile.handle }}
+      </a>
+      {% if row.activity_type == 'new_tip' %}
+        {% trans "tipped" %}
+        <a href="https://gitcoin.co/profile/{{ row.metadata.to_username }}" target="_blank">
+          @{{ row.metadata.to_username }}
+        </a>
+      {% elif row.activity_type == 'new_bounty' %}
+        {% trans "funded a new issue: " %}{{ row.urled_title | safe }}
+      {% elif row.activity_type == 'start_work' %}
+        {% trans "started work: " %}{{ row.urled_title | safe }}
+      {% elif row.activity_type == 'stop_work' %}
+        {% trans "stopped work: " %}{{ row.urled_title | safe }}
+      {% elif row.activity_type == 'killed_bounty' %}
+        {% trans "canceled bounty: " %}{{ row.urled_title | safe }}
+      {% elif row.activity_type == 'increased_bounty' %}
+        {% trans "increased funding: " %}{{ row.urled_title | safe }}
+      {% else %}
+        {{ row.i18n_name }}{% if row.urled_title %}: {{ row.urled_title | safe }}{% endif %}
+      {% endif %}
+    </div>
+    <div class="font-caption" >
+      <div class="activity-tags activity-tag-first align-items-center">
+        <div class="tag token">
+          <p>
+            {% if row.value_in_token_disp %}
+            <span>{{ row.value_in_token_disp }} {{row.token_name}}</span>
+            {% elif row.metadata.value_in_eth %}
+            <span>{{ row.metadata.value_in_eth }} {{row.token_name}}</span>
+            {% else %}
+            <span>{{row.metadata.value_in_token_old}}  - {{row.metadata.value_in_token}}  {{row.metadata.token_name}}</span>
+            {% endif %}
+          </p>
+        </div>
+        <div class="tag usd">
+          <p>
+            <span>{{ row.value_in_usdt_now }} USD</span>
+          </p>
+        </div>
+        {{ row.created | naturaltime }}
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-md-1">
+    <i class="far {{ row.icon }} last-icon"></i>
+  </div>
+</div>

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -217,7 +217,7 @@ def contributor_landing(request, tech_stack):
         'tech_stack': tech_stack,
     }
 
-    #get activity feed
+    # get activity feed
     num_activities = 5
     activities = Activity.objects.filter(bounty__network='mainnet').order_by('-created')
     if tech_stack:
@@ -226,6 +226,7 @@ def contributor_landing(request, tech_stack):
     context['activities'] = [a.view_props for a in activities]
 
     return TemplateResponse(request, 'contributor_landing.html', context)
+
 
 def how_it_works(request, work_type):
     """Show How it Works / Funder page."""
@@ -395,7 +396,7 @@ def activity(request):
     context = {
         'p': p,
         'page': p.get_page(page),
-        'title': 'Activity Feed',
+        'title': _('Activity Feed'),
     }
     context["activities"] = [a.view_props for a in p.get_page(page)]
 

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -30,7 +30,6 @@ from django.views.decorators.csrf import csrf_exempt
 
 from dashboard.models import Activity, Bounty
 from dashboard.notifications import amount_usdt_open_work, open_bounties
-from dashboard.tokens import token_by_name
 from economy.models import Token
 from marketing.mails import new_token_request
 from marketing.models import Alumni, LeaderboardRank
@@ -218,6 +217,14 @@ def contributor_landing(request, tech_stack):
         'tech_stack': tech_stack,
     }
 
+    #get activity feed
+    num_activities = 5
+    activities = Activity.objects.filter(bounty__network='mainnet').order_by('-created')
+    if tech_stack:
+        activities = activities.filter(bounty__metadata__icontains=tech_stack)
+    activities = activities[0:num_activities]
+    context['activities'] = [a.view_props for a in activities]
+
     return TemplateResponse(request, 'contributor_landing.html', context)
 
 def how_it_works(request, work_type):
@@ -380,35 +387,6 @@ def results(request, keyword=None):
 
 def activity(request):
     """Render the Activity response."""
-    icons = {
-        'title': 'Activity',
-        'new_tip': 'fa-thumbs-up',
-        'start_work': 'fa-lightbulb',
-        'new_bounty': 'fa-money-bill-alt',
-        'work_done': 'fa-check-circle',
-    }
-
-
-    def add_view_props(activity):
-        activity.icon = icons.get(activity.activity_type, 'fa-check-circle')
-        obj = activity.metadata
-        if 'new_bounty' in activity.metadata:
-            obj = activity.metadata['new_bounty']
-        activity.title = obj.get('title', '')
-        if 'id' in obj:
-            activity.bounty_url = Bounty.objects.get(pk=obj['id']).get_relative_url()
-            if activity.title:
-                activity.urled_title = f'<a href="{activity.bounty_url}">{activity.title}</a>'
-            else:
-                activity.urled_title = activity.title
-        if 'value_in_usdt_now' in obj:
-            activity.value_in_usdt_now = obj['value_in_usdt_now']
-        if 'token_name' in obj:
-            activity.token = token_by_name(obj['token_name'])
-            if 'value_in_token' in obj and activity.token:
-                activity.value_in_token_disp = round((float(obj['value_in_token']) /
-                                                      10 ** activity.token['decimals']) * 1000) / 1000
-        return activity
 
     activities = Activity.objects.all().order_by('-created')
     p = Paginator(activities, 300)
@@ -419,7 +397,7 @@ def activity(request):
         'page': p.get_page(page),
         'title': 'Activity Feed',
     }
-    context["activities"] = [add_view_props(a) for a in p.get_page(page)]
+    context["activities"] = [a.view_props for a in p.get_page(page)]
 
     return TemplateResponse(request, 'activity.html', context)
 


### PR DESCRIPTION

##### Description

puts an activity feed on the contributor landing page.  ideally this increases conversion rate bc it shows how active the platform is 

<img width="1432" alt="screen shot 2018-07-25 at 9 47 15 am" src="https://user-images.githubusercontent.com/513929/43211897-e763c31e-8fef-11e8-89e6-7ab5694ccba1.png">

works responsive

<!-- A description on what this PR aims to solve -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
ui

##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
tested it 
##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
https://github.com/gitcoinco/web/issues/1733