### PR TITLE
Fix assemble_leaderboards to catch missing all_ cases

### DIFF
--- a/app/marketing/tests/management/commands/test_assemble_leaderboards.py
+++ b/app/marketing/tests/management/commands/test_assemble_leaderboards.py
@@ -104,7 +104,7 @@ class TestAssembleLeaderboards(TestCase):
     def test_sum_tips(self):
         """Test sum tips of assemble leaderboards."""
         total = 7
-        user = 'johnny'
+        user = 'john'
         rank_types = [
             'all_fulfilled', 'all_earners', 'weekly_fulfilled',
             'weekly_earners', 'weekly_all', 'monthly_fulfilled',


### PR DESCRIPTION
##### Description

The goal of this PR is to resolve broken logic that is resulting in missed `LeaderboardRank` impressions and fix pytest to allow tests to pass.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

tests, leaderboards, backend

##### Testing

Locally

##### Refers/Fixes

https://github.com/gitcoinco/web/commit/76e330a55cf2164465b2aeae7b39b0c341537898