### PR TITLE
Improve tip slack notification

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -341,11 +341,10 @@ def maybe_market_tip_to_slack(tip, event_name):
     if not tip.is_notification_eligible(var_to_check=settings.SLACK_TOKEN):
         return False
 
-    title = tip.github_url
     msg = f"{event_name} worth {round(tip.amount, 4)} {tip.tokenName}"
 
-    if title:
-        msg = f"{msg}: {title}"
+    if tip.github_url:
+        msg = f"{msg}:\n{tip.github_url}"
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -342,7 +342,10 @@ def maybe_market_tip_to_slack(tip, event_name):
         return False
 
     title = tip.github_url
-    msg = f"{event_name} worth {round(tip.amount, 4)} {tip.tokenName}: {title} \n\n{tip.github_url}"
+    msg = f"{event_name} worth {round(tip.amount, 4)} {tip.tokenName}"
+
+    if title:
+        msg = f"{msg}: {title}"
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -344,7 +344,7 @@ def maybe_market_tip_to_slack(tip, event_name):
     msg = f"{event_name} worth {round(tip.amount, 4)} {tip.tokenName}"
 
     if tip.github_url:
-        msg = f"{msg}:\n{tip.github_url}"
+        msg = f"{msg}:\n\n{tip.github_url}"
 
     try:
         sc = SlackClient(settings.SLACK_TOKEN)

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -305,7 +305,7 @@ def send_tip_4(request):
 
     # notifications
     maybe_market_tip_to_github(tip)
-    maybe_market_tip_to_slack(tip, 'new_tip')
+    maybe_market_tip_to_slack(tip, 'New tip')
     maybe_market_tip_to_email(tip, to_emails)
     record_user_action(tip.from_username, 'send_tip', tip)
     record_tip_activity(tip, tip.from_username, 'new_tip' if tip.username else 'new_crowdfund')


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

![image](https://user-images.githubusercontent.com/7039523/43617204-4e7d3e80-9686-11e8-8a1c-5327db99fc9e.png)

![image](https://user-images.githubusercontent.com/7039523/43617214-5ff5abb6-9686-11e8-99a9-332414f56d44.png)


- Removes duplicate github url
- Removes the colon at the end if the tip doesn't have a github url associated
- Replaces the event name `"new_tip"` to `"New tip"`. I didn't bother to create a dictionary as the function is only called with the new tip event and I can't imagine us broadcasting other tip events at this point.

<!-- A description on what this PR aims to solve -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
