### PR TITLE
explorer:  ensure results from latest api call are served to the user

### DIFF
--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -16,6 +16,8 @@ var sidebar_keys = [
 
 var localStorage;
 
+var explorer = { };
+
 try {
   localStorage = window.localStorage;
 } catch (e) {
@@ -396,7 +398,11 @@ var refreshBounties = function(event) {
   mixpanel.track('Refresh Bounties', params);
 
   // order
-  $.get(uri, function(results) {
+  if (explorer.bounties_request && explorer.bounties_request.readyState != 4) {
+    explorer.bounties_request.abort();
+  }
+
+  explorer.bounties_request = $.get(uri, function(results, x) {
     results = sanitizeAPIResults(results);
 
     if (results.length === 0) {
@@ -484,7 +490,8 @@ var refreshBounties = function(event) {
 
     process_stats(results);
   }).fail(function() {
-    _alert({ message: gettext('got an error. please try again, or contact support@gitcoin.co') }, 'error');
+    if (explorer.bounties_request.readyState != 0)
+      _alert({ message: gettext('got an error. please try again, or contact support@gitcoin.co') }, 'error');
   }).always(function() {
     $('.loading').css('display', 'none');
   });

--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -398,7 +398,7 @@ var refreshBounties = function(event) {
   mixpanel.track('Refresh Bounties', params);
 
   // order
-  if (explorer.bounties_request && explorer.bounties_request.readyState != 4) {
+  if (explorer.bounties_request && explorer.bounties_request.readyState !== 4) {
     explorer.bounties_request.abort();
   }
 
@@ -490,7 +490,7 @@ var refreshBounties = function(event) {
 
     process_stats(results);
   }).fail(function() {
-    if (explorer.bounties_request.readyState != 0)
+    if (explorer.bounties_request.readyState !== 0)
       _alert({ message: gettext('got an error. please try again, or contact support@gitcoin.co') }, 'error');
   }).always(function() {
     $('.loading').css('display', 'none');


### PR DESCRIPTION
##### Description

The second PR is purely to make testing this PR easier.
Needs to be removed before merge

Ensure pending request gets abandoned before firing another request to prevent results from two diff APIs pop-ing up
 
![x1](https://user-images.githubusercontent.com/5358146/43677624-a1d26d38-9822-11e8-950a-4d4faee8af2f.gif)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Fixes

https://github.com/gitcoinco/web/issues/1938