### PR TITLE
fix #1921 replace sync_gas_prices from web scraping to json

### DIFF
--- a/app/gas/management/commands/sync_gas_prices.py
+++ b/app/gas/management/commands/sync_gas_prices.py
@@ -19,7 +19,6 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 import requests
-from bs4 import BeautifulSoup
 from gas.models import GasProfile
 
 
@@ -30,28 +29,25 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         with transaction.atomic():
-            url = 'https://ethgasstation.info/predictionTable.php'
+            url = 'https://ethgasstation.info/json/predictTable.json'
             response = requests.get(url)
-            soup = BeautifulSoup(response.text, 'html.parser')
-            eles = soup.findAll("tr",)
+            eles = response.json()
             print(f'syncing {len(eles)} eles')
             if len(eles) < 10:
                 print(response)
                 raise
             for ele in eles:
-                if ele.find('th'):
-                    continue
-                tds = ele.findAll('td')
-                # TODO: refactor this all to use an API instead of webscraping
-                gas_price = tds[0].text
+                gas_price = str(ele['gasprice'])
+                if gas_price[-2:] == '.0':
+                    gas_price = gas_price.replace('.0', '')
                 mean_time_to_confirm_blocks = 0
-                mean_time_to_confirm_minutes = str(tds[5].text).replace('> 2 hours', '120')
+                mean_time_to_confirm_minutes = str(round(ele['expectedTime'], 1))
                 _99confident_confirm_time_blocks = 0
-                _99confident_confirm_time_mins = str(tds[6].text).replace('> 2 hours', '120')
+                _99confident_confirm_time_mins = str(round(ele['expectedTime'] * 2.5, 1))
                 GasProfile.objects.create(
                     gas_price=gas_price,
                     mean_time_to_confirm_blocks=mean_time_to_confirm_blocks,
                     mean_time_to_confirm_minutes=mean_time_to_confirm_minutes,
                     _99confident_confirm_time_blocks=_99confident_confirm_time_blocks,
                     _99confident_confirm_time_mins=_99confident_confirm_time_mins,
-                    )
+                )


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

<!-- A description on what this PR aims to solve -->
- This PR replace the creation of GasProfile object via scraping using json instead.
- Now `mean_time_to_confirm_minutes` can assume values more than 120 minutes.
-The calculus for `_99confident_confirm_time_mins` has been taken from ethergas frontend code on github.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] linter status: 100% pass
- [X] changes don't break existing behavior
- [X] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
handle a creation of  GasProfile python object 

##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
I have tested the code on mac os.
##### Refers/Fixes
Fixes: #1921 
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
