### PR TITLE
workaround for ipfs hashes not existing

### DIFF
--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -484,7 +484,6 @@ def process_bounty_details(bounty_details):
     # what schema are we workign with?
     schema_name = meta.get('schemaName')
     schema_version = meta.get('schemaVersion', 'Unknown')
-
     if not schema_name or schema_name != 'gitcoinBounty':
         raise UnsupportedSchemaException(
             f'Unknown Schema: Unknown - Version: {schema_version}')

--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -21,6 +21,7 @@ import json
 import logging
 import subprocess
 import time
+from json.decoder import JSONDecodeError
 
 from django.conf import settings
 
@@ -223,6 +224,7 @@ def getBountyContract(network):
 def get_bounty(bounty_enum, network):
     if (settings.DEBUG or settings.ENV != 'prod') and network == 'mainnet':
         # This block will return {} if env isn't prod and the network is mainnet.
+        print("--*--")
         return {}
 
     standard_bounties = getBountyContract(network)
@@ -231,7 +233,6 @@ def get_bounty(bounty_enum, network):
         issuer, contract_deadline, fulfillmentAmount, paysTokens, bountyStage, balance = standard_bounties.functions.getBounty(bounty_enum).call()
     except BadFunctionCallOutput:
         raise BountyNotFoundException
-
     # pull from blockchain
     bountydata = standard_bounties.functions.getBountyData(bounty_enum).call()
     arbiter = standard_bounties.functions.getBountyArbiter(bounty_enum).call()
@@ -246,8 +247,12 @@ def get_bounty(bounty_enum, network):
 
         # pull from blockchain
         accepted, fulfiller, data = standard_bounties.functions.getFulfillment(bounty_enum, fulfill_enum).call()
-        data_str = ipfs_cat(data)
-        data = json.loads(data_str)
+        try:
+            data_str = ipfs_cat(data)
+            data = json.loads(data_str)
+        except JSONDecodeError:
+            logger.error(f'Could not get {data} from ipfs')
+            continue
 
         # validation
         if 'Failed to get block' in str(data_str):
@@ -296,6 +301,7 @@ def web3_process_bounty(bounty_data):
     # Check whether or not the bounty data payload is for mainnet and env is prod or other network and not mainnet.
     if not bounty_data or (settings.DEBUG or settings.ENV != 'prod') and bounty_data.get('network') == 'mainnet':
         # This block will return None if running in debug/non-prod env and the network is mainnet.
+        print(f"--*--")
         return None
 
     did_change, old_bounty, new_bounty = process_bounty_details(bounty_data)


### PR DESCRIPTION
This is a workaround for IPFS hashes of fulfillments not existing on IPFS.

```
ERROR:dashboard.utils:Could not get QmbaKB87MVLhEvqvQcMSYrgg2R136MxCEVDi2e6kdrXNj5 from ipfs
ERROR:dashboard.utils:Could not get QmNk6bdJypXJ2h4JovvMHiDtAbMrX4zq6YzfAUtkctzMwi from ipfs
```

@mbeacom i'm not sure the root cause of these hashes not existing. I hope there's not a broader issue with the pinning of the IPFS hashes on our node!