### PR TITLE
bounty: enable accept / reject worker for owner

### DIFF
--- a/app/dashboard/templates/bounty/details.html
+++ b/app/dashboard/templates/bounty/details.html
@@ -270,7 +270,7 @@
               </div>
             [[/if]]
           </div>
-        [[else activity_type == 'start_work' || activity_type == 'worker_approved' || activity_type == 'worker_applied' ]]
+        [[else activity_type == 'start_work' || activity_type == 'worker_approved' ]]
           <div class="col-12 col-md-7 started-status-column">
             <div class="activity-status">
               [[:text]]
@@ -302,14 +302,14 @@
             [[if can_approve_worker ]]
               <div class="stop-work">
                 <span title="<div class='tooltip-info tooltip-sm'>Reject worker</div>">
-                  <a target="_blank" href="[[:reject_worker_url]]">
+                  <a class="button button--primary" href="[[:reject_worker_url]]">
                     <span class="font-smaller-4">Reject worker</span>
                   </a>
                 </span>
-              </div> |
+              </div>
               <div class="stop-work">
                 <span title="<div class='tooltip-info tooltip-sm'>Approve worker</div>">
-                  <a target="_blank" href="[[:approve_worker_url]]">
+                  <a class="button button--primary" href="[[:approve_worker_url]]">
                     <span class="font-smaller-4">Approve worker</span>
                   </a>
                 </span>


### PR DESCRIPTION
##### Description

This is to ensure that the accept / reject options appear on the screen when the funder is logged in on his permission-ed bounty

To test : 
- Create Permissioned bounty as X  -> Start work as another user Y

Y should not see any options on the work applied section 
X should see 2 buttons Approve & Reject on the work applied section 

Tested it out locally but needs one more round of testing on stage 

![x1](https://user-images.githubusercontent.com/5358146/44141337-795dca16-a09a-11e8-9c7d-6f004b5ce291.gif)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)


##### Refers/Fixes

https://github.com/gitcoinco/web/issues/1947