### PR TITLE
Add (Issue is closed) to the 'View on Github' button if is_issue_closed.

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -881,7 +881,8 @@ var do_actions = function(result) {
     const _entry = {
       enabled: true,
       href: github_url,
-      text: gettext('View On Github'),
+      text: gettext('View On Github') +
+            (result['is_issue_closed'] ? gettext(' (Issue is closed)') : ''),
       parent: 'right_actions',
       title: gettext('View issue details and comments on Github'),
       comments: result['github_comments'],


### PR DESCRIPTION
This serves as a convenient hint.

![screenshot 2018-08-23 at 19 53 29](https://user-images.githubusercontent.com/40266861/44542888-6030ed00-a70e-11e8-8287-0b041ba1d181.png)
