### PR TITLE
bot : remove dibs text from message

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -476,10 +476,7 @@ def build_github_notification(bounty, event_name, profile_pairs=None):
             if not interest.pending and approval_required:
                 action = 'been approved to start work'
 
-            show_dibs = interested.count() > 1 and bounty.project_type == 'traditional'
-            dibs = f" ({get_ordinal_repr(i)} dibs)" if show_dibs else ""
-
-            msg += f"\n{i}. {profile_link} has {action}{dibs}. "
+            msg += f"\n{i}. {profile_link} has {action}."
 
             issue_message = interest.issue_message.strip()
             if issue_message:


### PR DESCRIPTION
##### Description

Update work start Gitcoin bot text 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)
-  gitcoin bot

##### Testing

Ended up printing the msg output which gives follwing msg

<img width="1440" alt="screen shot 2018-09-02 at 1 54 02 am" src="https://user-images.githubusercontent.com/5358146/44949631-1f924b80-ae53-11e8-8747-af565bb00de0.png">

Pasting that here results in the outcome as

1. [thelostone-mc](http://localhost:8000/profile/thelostone-mc) has applied to start work _(Funders only: [approve worker](http://localhost:8000/issue/gitcoinco/web/2005/1151?mutate_worker_action=approve&worker=thelostone-mc) | [reject worker](http://localhost:8000/issue/gitcoinco/web/2005/1151?mutate_worker_action=reject&worker=thelostone-mc))_.


##### Refers/Fixes
Fixes: https://github.com/gitcoinco/web/issues/1535

