### PR TITLE
bounty: changes cancel button to red

### DIFF
--- a/app/assets/v2/css/bounty.css
+++ b/app/assets/v2/css/bounty.css
@@ -344,10 +344,15 @@ a.btn {
   margin-bottom: 10px;
 }
 
+#moderator-admin-actions:not(:empty).sticky {
+  text-align: center;
+}
+
 .sticky {
   position: fixed;
   top: 0;
   z-index: 1010;
+  text-align: center;
 }
 
 #btn-white {
@@ -531,7 +536,7 @@ a.btn {
 #moderator-admin-actions:not(:empty) {
   background: #F2F6F9;
   padding: 16px 0 10px;
-  text-align: center;
+  text-align: left;
   left: 0;
 }
 

--- a/app/assets/v2/css/forms/button.css
+++ b/app/assets/v2/css/forms/button.css
@@ -52,3 +52,7 @@
 .button--warning {
   background-color: #ca001a;
 }
+
+.button--warning:hover {
+  background-color: #d43247;
+}

--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -844,7 +844,8 @@ var do_actions = function(result) {
       href: result['action_urls']['cancel'],
       text: gettext('Cancel Bounty'),
       parent: 'right_actions',
-      title: gettext('Cancel bounty and reclaim funds for this issue')
+      title: gettext('Cancel bounty and reclaim funds for this issue'),
+      buttonclass: 'button--warning'
     };
 
     actions.push(_entry);

--- a/app/dashboard/templates/bounty/kill.html
+++ b/app/dashboard/templates/bounty/kill.html
@@ -65,8 +65,8 @@
                       <label required class="form__label" for="terms">{% url "terms" as termsurl %}{% blocktrans %}I have read, understand, and agree to, the <a href="{{ termsurl }}" target="_blank" rel="noopener noreferrer">Terms of Service</a>.{% endblocktrans %}</label>
                     </div>
                   </div>
-                  <div class="form__footer form__footer--right">
-                      <button class="button button--primary js-submit">{% trans "Cancel Bounty" %}</button>
+                  <div class="form__footer text-center">
+                      <button class="button button--primary button--warning js-submit">{% trans "Cancel Bounty" %}</button>
                       <a class="font-caption" style="display: block;" target="_blank" rel="noopener noreferrer" href="https://github.com/gitcoinco/web#high-level-flows">
                         Your transaction is secured by the audited StandardBounties contract on the Ethereum blockchain.</br>
                         Learn more here.

--- a/app/dashboard/templates/shared/no_issue_error.html
+++ b/app/dashboard/templates/shared/no_issue_error.html
@@ -33,7 +33,7 @@
   </div>
 </div>
 {% elif page == 'kill_bounty' %}
-<div id="no_issue_error" class="submit-notification container-fluid" style="display: block; background-color: #4a4a4a;">
+<div id="no_issue_error" class="submit-notification container-fluid" style="display: block; background-color: #d43247;">
   <div class="row align-items-center px-4 py-2 text-center text-lg-left">
     <div class="col-lg-10 col-sm-12 py-2 px-5">
       <h3>{% trans "Cancelling a Bounty is Sometimes Necessary" %}</h3>


### PR DESCRIPTION
PR does three things

- bounty details page -> updates cancel button color to red
- update banner & cancel button color to red
- prettifies admin control


<img width="489" alt="screen shot 2018-09-03 at 7 50 12 pm" src="https://user-images.githubusercontent.com/5358146/44991720-9eea6100-afb2-11e8-863a-b15db092dd97.png">


![screencapture-localhost-8000-issue-cancel-2018-09-04-16_22_29](https://user-images.githubusercontent.com/5358146/45027456-107fe900-b05f-11e8-8abd-52082e690bac.png)




![x](https://user-images.githubusercontent.com/5358146/44994225-410e4700-afbb-11e8-8536-345617d43cd5.gif)


Fixes: #2145