### PR TITLE
WOC: Prevent advanced payout form submission when recipient address is empty

### DIFF
--- a/app/assets/v2/js/pages/bulk_payout.js
+++ b/app/assets/v2/js/pages/bulk_payout.js
@@ -29,7 +29,7 @@ $(document).ready(function($) {
       self.html(self.html().replace(/(<([^>]+)>)/ig, ''));
     }, 10);
   });
-  
+
 
   $(document).on('click', '#close_bounty', function(event) {
     update_registry();
@@ -157,7 +157,7 @@ $(document).ready(function($) {
 
   $('#acceptBounty').click(function(e) {
     e.preventDefault();
-    
+
     if (!$('#terms').is(':checked')) {
       _alert('Please accept the TOS.', 'error');
       return;
@@ -166,7 +166,16 @@ $(document).ready(function($) {
       _alert('You do not have any transactions to payout.  Please add payees to the form.', 'error');
       return;
     }
+    var usernames = $('.username');
+    
+    for (var i = 0; i < usernames.length; i++) {
+      var username = usernames[i].textContent.trim();
 
+      if (username === null || username === '' || username === '@') {
+        _alert('Please provide a valid recipient Github username', 'error');
+        return;
+      }
+    }
     sendTransaction(0);
   });
 


### PR DESCRIPTION
- Captured prevention of advanced payout form submission when recipient github username is empty
Fixes: https://github.com/gitcoinco/web/issues/2010

##### Description

This PR aims to fix the bug where advance payout form submission was completing despite having empty recipient address (which is a required field)

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)

Advanced Payout form UI

##### Testing

Tested this change locally

Screenshots:

Before:

![screen shot 2018-09-04 at 2 24 06 am](https://user-images.githubusercontent.com/848036/45001370-2acbaf80-afea-11e8-86b9-eac9a41bf955.png)


After:

![screen shot 2018-09-04 at 2 25 28 am](https://user-images.githubusercontent.com/848036/45001373-30c19080-afea-11e8-8522-d9465e06b89f.png)


##### Fixes

Fixes: #2010 
