### PR TITLE
Hide Personal Information on Unselected Option

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -73,13 +73,13 @@ class BountySerializer(serializers.HyperlinkedModelSerializer):
     bounty_owner_name = serializers.SerializerMethodField('override_bounty_owner_name')
 
     def override_bounty_owner_email(self, obj):
-        can_make_visible_via_api = bool(int(obj.privacy_preferences.get('show_email_publicly', 1)))
-        default = "(hidden email)"
+        can_make_visible_via_api = bool(int(obj.privacy_preferences.get('show_email_publicly', 0)))
+        default = "Anonymous"
         return obj.bounty_owner_email if can_make_visible_via_api else default
 
     def override_bounty_owner_name(self, obj):
-        can_make_visible_via_api = bool(int(obj.privacy_preferences.get('show_name_publicly', 1)))
-        default = "(hidden name)"
+        can_make_visible_via_api = bool(int(obj.privacy_preferences.get('show_name_publicly', 0)))
+        default = "Anonymous"
         return obj.bounty_owner_name if can_make_visible_via_api else default
 
     class Meta:


### PR DESCRIPTION
Fixes: https://github.com/gitcoinco/web/issues/1387

##### Description

This PR fixes the issue that was displaying personal information (Name and Email) even when deselecting the option  while creating a bounty.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior

##### Affected core subsystem(s)

UI

##### Testing

Before:
![screen shot 2018-09-04 at 8 53 14 pm](https://user-images.githubusercontent.com/848036/45042056-708a8580-b087-11e8-80de-eedf51efc65f.png)

![screen shot 2018-09-04 at 8 52 24 pm](https://user-images.githubusercontent.com/848036/45042067-77b19380-b087-11e8-9e7e-992671e85905.png)

After:

![screen shot 2018-09-04 at 8 52 08 pm](https://user-images.githubusercontent.com/848036/45042081-8009ce80-b087-11e8-9d7a-b40caf441201.png)

##### Fixes

#1387 
