### PR TITLE
Add middleware to disable autodetect lang by header

### DIFF
--- a/app/app/middleware.py
+++ b/app/app/middleware.py
@@ -1,0 +1,18 @@
+def drop_accept_langauge(get_response):
+    """Define the middleware to remove accept-language headers from requests.
+
+    This middleware is essentially a hack to allow us to continue to use the
+    standard Django LocaleMiddleware without modification, but simply disable
+    the autodetection aspect based on the Accept-Language header.
+
+    """
+
+    def middleware(request):
+        """Define the middleware method that removes the accept-language header."""
+        if 'HTTP_ACCEPT_LANGUAGE' in request.META:
+            del request.META['HTTP_ACCEPT_LANGUAGE']
+
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -107,6 +107,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'app.middleware.drop_accept_langauge',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
##### Description

The goal of this PR is to drop the `Accept-Language` header in the standard request context `META` allowing us to use the standard Django `LocaleMiddleware`, but disable the autodetection/header based aspect.

I'm open to adjusting this middleware to mimic `LocaleMiddleware` and not drop the header, but this seemed like the fastest/simplest path to success without rewriting core django functionality into a custom middleware.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

system wide, middleware, translations, i18n

##### Testing

Locally

##### Refers/Fixes

