### PR TITLE
Replace project length with time commitment

### DIFF
--- a/app/dashboard/templates/bounty/details.html
+++ b/app/dashboard/templates/bounty/details.html
@@ -93,7 +93,7 @@
                 </div>
 
                 <div>
-                  <span class="bounty-info-heading">{% trans "Project Length" %}</span>
+                  <span class="bounty-info-heading">{% trans "Time Commitment" %}</span>
                   <span class="bounty-info-text" id="project_length"></span>
                 </div>
 

--- a/app/dashboard/templates/shared/issue_details.html
+++ b/app/dashboard/templates/shared/issue_details.html
@@ -45,7 +45,7 @@
   </div>
   <div class="form__select2 form__group-item">
     <select class="js-select2" name="project_length">
-      <option value="Unknown">{% trans "Project Length" %}</option>
+      <option value="Unknown">{% trans "Time Commitment" %}</option>
       <option>{% trans "Hours" %}</option>
       <option>{% trans "Days" %}</option>
       <option>{% trans "Weeks" %}</option>

--- a/app/dashboard/templates/shared/sidebar_search.html
+++ b/app/dashboard/templates/shared/sidebar_search.html
@@ -197,7 +197,7 @@
     </div>
 
     <div class="col">
-      <div class="col-12 subheading font-body accordion">{% trans "Project Length" %}</div>
+      <div class="col-12 subheading font-body accordion">{% trans "Time Commitment" %}</div>
       <div class="col-12 options panel">
         <div class="checkbox_container">
           <input name="project_length" id="hours" type="checkbox" value="hours" val-ui='Hours-Long' />

--- a/app/retail/templates/emails/bounty.html
+++ b/app/retail/templates/emails/bounty.html
@@ -119,7 +119,7 @@
         </p>
         <p>
           <b>{% trans "Specs:" %}</b><br>
-          {% trans "Project Length" %}: {% if bounty.project_length %}{{ bounty.project_length }}{%else%}Not specified{%endif%}
+          {% trans "Time Commitment" %}: {% if bounty.project_length %}{{ bounty.project_length }}{%else%}Not specified{%endif%}
           <br>
           {% trans "Type:" %} {% if bounty.bounty_type %}{{ bounty.bounty_type }}{%else%}Not specified{%endif%}
           <br>


### PR DESCRIPTION
Replace text 'Project Length' with 'Time Commitment'
Replace on funder form, issue details, and left rail filters on issue explorer.

Let's see if it fits here:
<img width="224" alt="screen shot 2018-09-10 at 10 19 18 pm" src="https://user-images.githubusercontent.com/238235/45334158-9b714f80-b547-11e8-8626-3dbba1841dc1.png">

If not maybe we can go down a font size or two on all of the headers.


/cc @PixelantDesign 