### PR TITLE
bot: updated markdown

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -476,11 +476,11 @@ def build_github_notification(bounty, event_name, profile_pairs=None):
             if not interest.pending and approval_required:
                 action = 'been approved to start work'
 
-            msg += f"\n{i}. {profile_link} has {action}."
+            msg += f"\n**{i}) {profile_link} has {action}.**"
 
             issue_message = interest.issue_message.strip()
             if issue_message:
-                msg += f"\n    \n    {issue_message}"
+                msg += f"\n\n{issue_message}"
             msg += f"\n\nLearn more [on the Gitcoin Issue Details page]({absolute_url}).\n\n"
 
     elif event_name == 'work_submitted':


### PR DESCRIPTION
##### Description

A contributor is expected to provide plan of action before starting work on an permissioned issue.
Occasionaly they use ordered list and when we render this in bot message (which itself is a ordered list), it ends up looking like [this](https://github.com/gitcoinco/web/issues/2200#issuecomment-420528664)

This PR changes the latter to unordered-list
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)


##### Testing

<img width="1141" alt="screen shot 2018-09-12 at 8 51 43 pm" src="https://user-images.githubusercontent.com/5358146/45435228-c1286100-b6cd-11e8-9cd5-de72ba8261b9.png">




###### How it looks on a github comment

 Issue Status: 1. **Open** 2. Started 3. Submitted 4. Done

 <hr>

 __Workers have applied to start work__.


 These users each claimed they can complete the work by 5 months, 3 weeks from now.
 Please review their action plans below:


 **1) [thelostone-mc](http://localhost:8000/profile/thelostone-mc) has applied to start work _(Funders only: [approve worker](http://localhost:8000/issue/mbeacom/test-repo/5/461?mutate_worker_action=approve&worker=thelostone-mc) | [reject worker](http://localhost:8000/issue/mbeacom/test-repo/5/461?mutate_worker_action=reject&worker=thelostone-mc))_.**

 1. Will first build out the screen.
  2. Implement the already contributed functionality.
  3. Discuss with the team how to send out the message to users.

 Learn more [on the Gitcoin Issue Details page](http://localhost:8000/issue/mbeacom/test-repo/5/461).
