### PR TITLE
Adjust cookie banner for iOS/Safari 

### DIFF
--- a/app/assets/cookielaw/css/cookielaw.css
+++ b/app/assets/cookielaw/css/cookielaw.css
@@ -27,6 +27,11 @@
   justify-content: space-between;
 }
 
+#CookielawBanner .container .d-flex .row.cookie-row {
+  width: 100%;
+  margin-right: 0px;
+}
+
 #CookielawBanner .container .cookie-info {
   width: 90%;
 }
@@ -34,7 +39,6 @@
 #CookielawBanner .container .cookie-info.cookie-body {
   font-size: 0.675rem;
 }
-
 
 #CookielawBanner #CookielawCross {
   background: url('../img/close.png') no-repeat 0 0;
@@ -54,10 +58,9 @@
   }
 
   #CookielawBanner .container {
-    padding-right: 5px;
+    padding-right: 2px;
     padding-left: 10px;
   }
-
 
   #CookielawBanner .container h6 {
     margin-top: 0.5rem;
@@ -67,6 +70,10 @@
 
   #CookielawBanner .container .d-flex {
     display: inline !important;
+  }
+
+  #CookielawBanner .container .d-flex .row.cookie-row .col-4 {
+    padding-right: 5px;
   }
 
   #CookielawBanner .container .cookie-info {
@@ -82,7 +89,5 @@
     float: right;
     font-size: 0.775rem;
   }
-
-
   
 }

--- a/app/assets/cookielaw/css/cookielaw.css
+++ b/app/assets/cookielaw/css/cookielaw.css
@@ -31,6 +31,11 @@
   width: 90%;
 }
 
+#CookielawBanner .container .cookie-info.cookie-body {
+  font-size: 0.675rem;
+}
+
+
 #CookielawBanner #CookielawCross {
   background: url('../img/close.png') no-repeat 0 0;
   cursor: pointer;
@@ -44,11 +49,40 @@
 
 @media (max-width: 767.98px) {
 
+  #CookielawBanner {
+    padding: 0px; 
+  }
+
+  #CookielawBanner .container {
+    padding-right: 5px;
+    padding-left: 10px;
+  }
+
+
+  #CookielawBanner .container h6 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.3rem;
+    font-size: 0.75rem;
+  }
+
   #CookielawBanner .container .d-flex {
     display: inline !important;
   }
 
   #CookielawBanner .container .cookie-info {
+    width: 100%;
     margin-bottom: 1.5rem;
   }
+
+  #CookielawBanner .container .cookie-info.cookie-body-font {
+    font-size: 0.675rem;
+  }
+
+  #CookielawBanner .container a.button{
+    float: right;
+    font-size: 0.775rem;
+  }
+
+
+  
 }

--- a/app/retail/templates/cookielaw/banner.html
+++ b/app/retail/templates/cookielaw/banner.html
@@ -3,11 +3,17 @@
   <div class="container">
     <h6>{% trans "COOKIE_INFO_HEADER" %}</h6>
     <div class="d-flex">
-      <p class="cookie-info font-body">
-        {% trans "By continuing to browse the site, you are agreeing to our use of cookies. Learn more in" %}
-        <a href="{% url 'cookie' %}">{% trans "Gitcoin's Privacy Policy" %}</a>
-      </p>
-      <a class="button button--primary pull-right" href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}</a>
+      <div class="row cookie-row">
+        <div class="col-8 col-sm-8 col-md-12">
+          <p id="cookie-body" class="cookie-info cookie-body-font">
+            {% trans "By continuing to browse the site, you are agreeing to our use of cookies. Learn more in" %}
+            <a href="{% url 'cookie' %}">{% trans "Gitcoin's Privacy Policy" %}</a>
+          </p>
+        </div>
+        <div class="col-4 col-sm-4">
+          <a class="button button--primary pull-right" href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}</a>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/retail/templates/cookielaw/banner.html
+++ b/app/retail/templates/cookielaw/banner.html
@@ -4,13 +4,13 @@
     <h6>{% trans "COOKIE_INFO_HEADER" %}</h6>
     <div class="d-flex">
       <div class="row cookie-row">
-        <div class="col-8 col-sm-8 col-md-12">
+        <div class="col-8 col-sm-8 col-md-9">
           <p id="cookie-body" class="cookie-info cookie-body-font">
             {% trans "By continuing to browse the site, you are agreeing to our use of cookies. Learn more in" %}
             <a href="{% url 'cookie' %}">{% trans "Gitcoin's Privacy Policy" %}</a>
           </p>
         </div>
-        <div class="col-4 col-sm-4">
+        <div class="col-4 col-sm-4 col-md-3">
           <a class="button button--primary pull-right" href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}</a>
         </div>
       </div>

--- a/app/retail/templates/cookielaw/banner.html
+++ b/app/retail/templates/cookielaw/banner.html
@@ -4,14 +4,14 @@
     <h6>{% trans "COOKIE_INFO_HEADER" %}</h6>
     <div class="d-flex">
       <div class="row cookie-row">
-        <div class="col-8 col-sm-8 col-md-9">
+        <div class="col-8 col-md-10">
           <p id="cookie-body" class="cookie-info cookie-body-font">
             {% trans "By continuing to browse the site, you are agreeing to our use of cookies. Learn more in" %}
             <a href="{% url 'cookie' %}">{% trans "Gitcoin's Privacy Policy" %}</a>
           </p>
         </div>
-        <div class="col-4 col-sm-4 col-md-3">
-          <a class="button button--primary pull-right" href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}</a>
+        <div class="col-4 col-md-2">
+          <a class="button button--primary float-right" href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
##### Description

Users can click the 'i agree' button on iOS safari and the cookie banner is displayed  in a small portion at the bottom of the screen 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

Web

##### Testing

Should now look like this in an iPhone 5 which is the smallest screen for  iOS i could test for.

![localhost_8000_ iphone 5_se](https://user-images.githubusercontent.com/2150634/45445064-e6b76980-b6d1-11e8-88f3-e5c0ff33a239.png)

Also all tests are passing so it won't break anything

##### Refers/Fixes

Fixes #2103 
