### PR TITLE
Increase Funding Limit Request Form

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -232,6 +232,11 @@ urlpatterns = [
     re_path(r'^youtube/?', retail.views.youtube, name='youtube'),
     re_path(r'^web3/?', retail.views.web3, name='web3'),
 
+    # increase funding limit
+    re_path(r'^requestincrease/?',
+            retail.views.increase_funding_limit_request,
+            name='increase_funding_limit_request'),
+
     # link shortener
     url(r'^l/(.*)$/?', linkshortener.views.linkredirect, name='redirect'),
     url(r'^credit/(.*)$/?', credits.views.credits, name='credit'),

--- a/app/assets/v2/js/pages/increase_funding_limit_request_form.js
+++ b/app/assets/v2/js/pages/increase_funding_limit_request_form.js
@@ -1,5 +1,6 @@
 
 // Overwrite from shared.js
+// eslint-disable-next-line no-empty-function
 var trigger_form_hooks = function() {
 };
 

--- a/app/assets/v2/js/pages/increase_funding_limit_request_form.js
+++ b/app/assets/v2/js/pages/increase_funding_limit_request_form.js
@@ -1,0 +1,63 @@
+
+// Overwrite from shared.js
+var trigger_form_hooks = function() {
+};
+
+$(document).ready(function() {
+  $('[for=id_comment]').append(
+    ' (<span id="charcount">500</span> ' + gettext('characters left') + ')'
+  );
+  $('[name=comment]').bind('input propertychange', function() {
+    this.value = this.value.replace(/ +(?= )/g, '');
+
+    if (this.value.length > 500) {
+      this.value = this.value.substring(0, 500);
+    }
+
+    $('#charcount').html(500 - this.value.length);
+  });
+
+  const form = $('#increase_request_form');
+
+  form.validate({
+    submitHandler: function(form) {
+      const inputElements = $(form).find(':input');
+      const formData = {};
+
+      inputElements.removeAttr('disabled');
+      $.each($(form).serializeArray(), function() {
+        formData[this.name] = this.value;
+      });
+
+      inputElements.attr('disabled', 'disabled');
+      loading_button($('.js-submit'));
+
+      const payload = JSON.stringify(formData);
+
+      $.post('/requestincrease', payload).then(
+        function(result) {
+          inputElements.removeAttr('disabled');
+          $('#requested_by').attr('disabled', 'disabled');
+          unloading_button($('.js-submit'));
+
+          $('#primary_form').hide();
+          $('#success_container').show();
+        }
+      ).fail(
+        function(result) {
+          inputElements.removeAttr('disabled');
+          $('#requested_by').attr('disabled', 'disabled');
+          unloading_button($('.js-submit'));
+
+          var alertMsg = result && result.responseJSON ? result.responseJSON.error : null;
+
+          if (alertMsg === null) {
+            alertMsg = gettext('Network error. Please reload the page and try again.');
+          }
+
+          _alert({ message: alertMsg }, 'error');
+        }
+      );
+    }
+  });
+});

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -338,12 +338,13 @@ def send_tip_3(request):
     if is_over_tip_tx_limit:
         response['status'] = 'error'
         response['message'] = _('This tip is over the per-transaction limit of $') +\
-                              str(max_per_tip) + '. ' + increase_funding_form
+            str(max_per_tip) + '. ' + increase_funding_form
     elif is_over_tip_weekly_limit:
         response['status'] = 'error'
         response['message'] = _('You are over the weekly tip send limit of $') +\
-                              str(request.user.profile.max_tip_amount_usdt_per_week) +\
-                              '. ' + increase_funding_form
+            str(request.user.profile.max_tip_amount_usdt_per_week) +\
+            '. ' + increase_funding_form
+
     return JsonResponse(response)
 
 

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -332,14 +332,18 @@ def send_tip_3(request):
             is_over_tip_weekly_limit = tips_last_week_value > request.user.profile.max_tip_amount_usdt_per_week
 
     increase_funding_form_title = _('Request a Funding Limit Increasement')
-    increase_funding_form = f'<a target="_blank" href="{settings.BASE_URL}requestincrease">{increase_funding_form_title}</a>'
+    increase_funding_form = f'<a target="_blank" href="{settings.BASE_URL}'\
+                            f'requestincrease">{increase_funding_form_title}</a>'
 
     if is_over_tip_tx_limit:
         response['status'] = 'error'
-        response['message'] = _('This tip is over the per-transaction limit of $') + str(max_per_tip) + '. ' + increase_funding_form
+        response['message'] = _('This tip is over the per-transaction limit of $') +\
+                              str(max_per_tip) + '. ' + increase_funding_form
     elif is_over_tip_weekly_limit:
         response['status'] = 'error'
-        response['message'] = _('You are over the weekly tip send limit of $') + str(request.user.profile.max_tip_amount_usdt_per_week) + '. ' + increase_funding_form
+        response['message'] = _('You are over the weekly tip send limit of $') +\
+                              str(request.user.profile.max_tip_amount_usdt_per_week) +\
+                              '. ' + increase_funding_form
     return JsonResponse(response)
 
 

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -21,6 +21,7 @@ from __future__ import print_function, unicode_literals
 import json
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.http import JsonResponse
 from django.shortcuts import redirect
@@ -329,12 +330,16 @@ def send_tip_3(request):
                 if this_tip.value_in_usdt_now:
                     tips_last_week_value += this_tip.value_in_usdt_now
             is_over_tip_weekly_limit = tips_last_week_value > request.user.profile.max_tip_amount_usdt_per_week
+
+    increase_funding_form_title = _('Request a Funding Limit Increasement')
+    increase_funding_form = f'<a target="_blank" href="{settings.BASE_URL}requestincrease">{increase_funding_form_title}</a>'
+
     if is_over_tip_tx_limit:
         response['status'] = 'error'
-        response['message'] = _('This tip is over the per-transaction limit of $') + str(max_per_tip) + ('.  Please try again later or contact support.')
+        response['message'] = _('This tip is over the per-transaction limit of $') + str(max_per_tip) + '. ' + increase_funding_form
     elif is_over_tip_weekly_limit:
         response['status'] = 'error'
-        response['message'] = _('You are over the weekly tip send limit of $') + str(request.user.profile.max_tip_amount_usdt_per_week) + ('.  Please try again later or contact support.')
+        response['message'] = _('You are over the weekly tip send limit of $') + str(request.user.profile.max_tip_amount_usdt_per_week) + '. ' + increase_funding_form
     return JsonResponse(response)
 
 

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -642,3 +642,31 @@ def new_bounty_request(model):
         send_mail(from_email, to_email, subject, body, from_name=_("No Reply from Gitcoin.co"))
     finally:
         translation.activate(cur_language)
+
+
+def new_funding_limit_increase_request(profile, cleaned_data):
+    to_email = 'founders@gitcoin.co'
+    from_email = profile.email or settings.SERVER_EMAIL
+    cur_language = translation.get_language()
+    usdt_per_tx = cleaned_data.get('usdt_per_tx', 0)
+    usdt_per_week = cleaned_data.get('usdt_per_week', 0)
+    comment = cleaned_data.get('comment', '')
+    accept_link = f'{settings.BASE_URL}requestincrease?'\
+                  f'profile_pk={profile.pk}&'\
+                  f'usdt_per_tx={usdt_per_tx}&'\
+                  f'usdt_per_week={usdt_per_week}'
+
+    try:
+        setup_lang(to_email)
+        subject = _('New Funding Limit Increase Request')
+        body = f'New Funding Limit Request from {profile} ({profile.absolute_url}).\n\n'\
+               f'New Limit in USD per Transaction: {usdt_per_tx}\n'\
+               f'New Limit in USD per Week: {usdt_per_week}\n\n'\
+               f'To accept the Funding Limit, visit: {accept_link}\n'\
+               f'Administration Link: ({settings.BASE_URL}_administrationdashboard/profile/'\
+               f'{profile.pk}/change/#id_max_tip_amount_usdt_per_tx)\n\n'\
+               f'Comment:\n{comment}'
+
+        send_mail(from_email, to_email, subject, body, from_name=_("No Reply from Gitcoin.co"))
+    finally:
+        translation.activate(cur_language)

--- a/app/retail/forms.py
+++ b/app/retail/forms.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Define retail related forms.
+
+Copyright (C) 2018 Gitcoin Core
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+from django import forms
+from django.utils.html import escape, strip_tags
+from django.utils.translation import gettext_lazy as _
+
+
+class FundingLimitIncreaseRequestForm(forms.Form):
+    """Define the FundingLimitIncreaseRequestForm handling."""
+
+    usdt_per_tx = forms.DecimalField(label=_('New Limit in USD per Transaction'), initial=500, max_digits=50)
+    usdt_per_week = forms.DecimalField(label=_('New Limit in USD per Week'), initial=1500, max_digits=50)
+    comment = forms.CharField(max_length=500, widget=forms.Textarea)
+
+    def __init__(self, *args, **kwargs):
+        super(FundingLimitIncreaseRequestForm, self).__init__(*args, **kwargs)
+
+        self.fields['comment'].widget.attrs['placeholder'] = _('Please tell us why you need a limit increase.')
+        self.fields['comment'].widget.attrs['rows'] = '4'
+        self.fields['comment'].widget.attrs['cols'] = '50'
+
+        for field in self.fields:
+            self.fields[field].widget.attrs['class'] = 'form__input'
+
+    def clean_comment(self):
+        comment = self.cleaned_data['comment'] or ''
+        return escape(strip_tags(comment))

--- a/app/retail/templates/increase_funding_limit_request_form.html
+++ b/app/retail/templates/increase_funding_limit_request_form.html
@@ -1,0 +1,81 @@
+{% comment %}
+  Copyright (C) 2018 Gitcoin Core
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+{% endcomment %}
+{% load i18n static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include 'shared/head.html' %}
+    {% include 'shared/cards.html' %}
+  </head>
+  <body class="interior {{ active }}">
+    <div class="container-fluid header dash">
+      {% include 'shared/nav.html' %}
+    </div>
+    <div class="row no-gutter">
+      <div class="col body">
+        <div class="container-fluid no-gutter">
+          <div class="m-4">
+            <div>
+              <div class="request-form" id="primary_form">
+                <h3>{{ title }}</h3>
+                <p>{{ card_desc }}</p>
+                <div class="mb-3">
+                  <label for="requested_by" class="form__label">{% trans 'Your Github Profile' %}
+                    {% if not user.is_authenticated %}
+                    (<a href="{% url 'social:begin' 'github' %}?next={{ request.get_full_path }}">{% trans 'Login' %}</a>)
+                    {% endif %}
+                  </label>
+                  <input name="requested_by" placeholder="{% trans "Please Login First" %}" id="requested_by" class="form__input" type="text" value="{% if github_handle %}{{ github_handle }}{% endif %}" required disabled />
+                </div>
+                <form id="increase_request_form">
+                  {% for field in form %}
+                    <div class="mb-3">
+                      <label for="id_{{ field.name }}" class="form__label">{{ field.label }}</label>
+                      {{ field }}
+                    </div>
+                  {% endfor %}
+                  <div class="form__footer">
+                    <button class="button button--primary btn-block js-submit" type="submit">{% trans 'Proceed' %}</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+            <div id="success_container" class="text-center" style="display: none;">
+              <h3>{% trans 'Funding Limit Request Received' %}</h3>
+              {% include 'svgs/success.svg' %}
+              <div>
+                <p>
+                  {% trans 'It takes us usually 1 business day to process your request.' %}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 offset-md-1 col-md-10">
+            {% include 'shared/newsletter.html' %}
+          </div>
+        </div>
+      </div>
+    </div>
+    {% include 'shared/bottom_notification.html' %}
+    {% include 'shared/analytics.html' %}
+    {% include 'shared/footer_scripts.html' %}
+    {% include 'shared/footer.html' %}
+    {% include 'shared/messages.html' %}
+  </body>
+  <script src="{% static "v2/js/shared.js" %}"></script>
+  <script src="{% static "v2/js/pages/increase_funding_limit_request_form.js" %}"></script>
+</html>

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -16,6 +16,7 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
+from json import loads as json_parse
 from os import walk as walkdir
 
 from django.conf import settings
@@ -33,14 +34,16 @@ from django.views.decorators.csrf import csrf_exempt
 
 from app.utils import get_default_network
 from cacheops import cached_as, cached_view, cached_view_as
-from dashboard.models import Activity
+from dashboard.models import Activity, Profile
 from dashboard.notifications import amount_usdt_open_work, open_bounties
 from economy.models import Token
-from marketing.mails import new_token_request
+from marketing.mails import new_funding_limit_increase_request, new_token_request
 from marketing.models import Alumni, LeaderboardRank
 from marketing.utils import get_or_save_email_subscriber, invite_to_slack
+from ratelimit.decorators import ratelimit
 from retail.helpers import get_ip
 
+from .forms import FundingLimitIncreaseRequestForm
 from .utils import build_stat_results, programming_languages
 
 
@@ -1065,3 +1068,52 @@ def ui(request):
 
 def lbcheck(request):
     return HttpResponse(status=200)
+
+
+@csrf_exempt
+@ratelimit(key='ip', rate='5/m', method=ratelimit.UNSAFE, block=True)
+def increase_funding_limit_request(request):
+    user = request.user if request.user.is_authenticated else None
+    profile = request.user.profile if user and hasattr(request.user, 'profile') else None
+    usdt_per_tx = request.GET.get('usdt_per_tx', None)
+    usdt_per_week = request.GET.get('usdt_per_week', None)
+    is_staff = user.is_staff if user else False
+
+    if is_staff and usdt_per_tx and usdt_per_week:
+        try:
+            profile_pk = request.GET.get('profile_pk', None)
+            target_profile = Profile.objects.get(pk=profile_pk)
+            target_profile.max_tip_amount_usdt_per_tx = usdt_per_tx
+            target_profile.max_tip_amount_usdt_per_week = usdt_per_week
+            target_profile.save()
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=400)
+
+        return JsonResponse({'msg': _('Success')}, status=200)
+
+    if request.body:
+        if not user or not profile or not profile.handle:
+            return JsonResponse(
+                {'error': _('You must be Authenticated via Github to use this feature!')},
+                status=401)
+
+        try:
+            result = FundingLimitIncreaseRequestForm(json_parse(request.body))
+            if not result.is_valid():
+                raise
+        except Exception as e:
+            return JsonResponse({'error': _('Invalid JSON.')}, status=400)
+
+        new_funding_limit_increase_request(profile, result.cleaned_data)
+
+        return JsonResponse({'msg': _('Request received.')}, status=200)
+
+    form = FundingLimitIncreaseRequestForm()
+    params = {
+        'form': form,
+        'title': _('Request a Funding Limit Increase'),
+        'card_title': _('Gitcoin - Request a Funding Limit Increase'),
+        'card_desc': _('Do you hit the Funding Limit? Request a increasement!')
+    }
+
+    return TemplateResponse(request, 'increase_funding_limit_request_form.html', params)


### PR DESCRIPTION
Fixes #2199

- [x] when presented with an error message, user is linked to https://gitcoin.co/requestincrease
- [x] https://gitcoin.co/requestincrease is a form that asks them how much of an increase they expect (denominated in per-tx limits and per-week limits).
- [x] they should also input a comment about why they want a limit increase.
- [x] user must be logged in to submit form
- [x] when users submits form, it displays a success message and promises a 1 business day turnaround
- [x] when user submits form, it emails founders@gitcoin.co with a link to the user's profile and all of the inputs they submitted.
- [x] admin can approve the funding increase from there