### PR TITLE
Adjust premailer to use base_url

### DIFF
--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -60,7 +60,8 @@ ALL_EMAILS = MARKETING_EMAILS + TRANSACTIONAL_EMAILS
 
 def premailer_transform(html):
     cssutils.log.setLevel(logging.CRITICAL)
-    return premailer.transform(html)
+    p = premailer.Premailer(html, base_url=settings.BASE_URL)
+    return p.transform()
 
 
 def render_tip_email(to_email, tip, is_new):

--- a/app/retail/templates/emails/template.html
+++ b/app/retail/templates/emails/template.html
@@ -20,7 +20,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="x-apple-disable-message-reformatting" />
 <head>
-  <link rel="stylesheet" href="https://s.gitcoin.co/v2/css/typography.css">
+  <link rel="stylesheet" href="{% static "v2/css/lib/typography.css" %}">
 </head>
 
 <style>


### PR DESCRIPTION
##### Description

The goal of this PR is to resolve a bug with `premailer` not honoring django static paths in email templates.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

emails, templates

##### Testing

Locally

