### PR TITLE
fixed avatar builder color handling

### DIFF
--- a/app/assets/v2/js/avatar_builder.js
+++ b/app/assets/v2/js/avatar_builder.js
@@ -82,10 +82,13 @@ function getIdFromPath(path, option) {
 function getColorFromPath(path, option) {
   let color = '';
 
+  // filename without path and extension
+  const basename = path.split('.').slice(-2)[0].split('/').slice(-1)[0];
+
   if (option === 'FacialHair' || option === 'Accessories') {
-    color = path.split('.')[0].split('/').slice(-1)[0].split('-')[2];
+    color = basename.split('-')[2];
   } else {
-    color = path.split('.')[0].split('/').slice(-1)[0].split('-')[1];
+    color = basename.split('-')[1];
   }
 
   return color;


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

Fixes parsing colour from path in avatar builder. The issue was that on `localhost` splitting with `'.'` was working correctly, but in production environment `path` includes actual domain with dots and splitting returns incorrect portion. Fixed this by taking portion not from beginning, but from end (where there's no domain name).

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

Does not affect core subsystems.

##### Refers/Fixes

Fixes: https://github.com/gitcoinco/web/issues/2150.
