### PR TITLE
Fix overflowing text on toolbox cards

### DIFF
--- a/app/assets/v2/css/card.css
+++ b/app/assets/v2/css/card.css
@@ -85,7 +85,7 @@
   background: #fff;
   border-radius: 6px;
   display: inline-block;
-  height: 320px;
+  height: 340px;
   margin: 1em 2em 1em 0;
   position: relative;
   width: 240px;
@@ -112,7 +112,7 @@
 
 .card .content {
   margin: 15px 20px;
-  min-height: 140px;
+  min-height: 160px;
   position: relative;
 }
 


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

On gitcoin.co/tools, the card description is covered by the 'Try It' button if the title is two lines.

![screenshot 2018-10-02 23 27 07](https://user-images.githubusercontent.com/19514207/46359509-ffe18380-c69b-11e8-8a8e-90df24ed5051.png)

Fixed:

![screenshot 2018-10-02 23 27 01](https://user-images.githubusercontent.com/19514207/46359649-40410180-c69c-11e8-9992-c0e04ac993c3.png)


<!-- A description of what this PR aims to solve -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
