### PR TITLE
fix ios text

### DIFF
--- a/app/assets/v2/css/ios.css
+++ b/app/assets/v2/css/ios.css
@@ -55,6 +55,7 @@
   font-size: 3rem;
   font-style: normal;
   padding-top: 150px;
+  color: #FFF;
 }
 
 .ios-hero__container .header-line h3 {


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/gitcoinco/web/blob/contributing/CONTRIBUTING.md
-->

##### Description

gitcoin.co/ios title is now impossible to read due to the green text

<img width="1332" alt="screenshot 2018-10-03 01 23 57" src="https://user-images.githubusercontent.com/19514207/46365414-1fcc7380-c6ab-11e8-83aa-42acba1fca8c.png">

Fix (changed the text color to white):

<img width="1314" alt="screenshot 2018-10-03 01 24 09" src="https://user-images.githubusercontent.com/19514207/46365424-2824ae80-c6ab-11e8-9c4e-42e8d5ef9890.png">


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)
