### PR TITLE
Fix #2329 - Adjust email template URL references and fix bad ref

### DIFF
--- a/app/retail/templates/emails/bounty_changed.html
+++ b/app/retail/templates/emails/bounty_changed.html
@@ -26,7 +26,7 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %}  <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
+{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %}  <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/bounty_startwork_expire_warning.html
+++ b/app/retail/templates/emails/bounty_startwork_expire_warning.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize %}
 
@@ -24,33 +23,33 @@
 
 
 <p>
-    {% trans "Hey there, " %}
+  {% trans "Hey there, " %}
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-     You <strong>started work upon</strong> a funded issue {{interest.created | naturaltime}}.  But we haven't heard from you on the github thread{% if time_delta_days %} in {{time_delta_days}} days{%endif%}.
+    You <strong>started work upon</strong> a funded issue {{ interest.created|naturaltime }}.  But we haven't heard from you on the github thread{% if time_delta_days %} in {{ time_delta_days }} days{% endif %}.
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-    {% trans "Do you still want to work on this?  Please let us know so we can find someone else to work on it if not!" %}
+  {% trans "Do you still want to work on this?  Please let us know so we can find someone else to work on it if not!" %}
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-    {% trans "If so, please leave a comment on the github thread to check in." %}
-    <br>
-    -{% trans "OR" %}-
-    <br>
-    {% blocktrans %}If not, click 'Stop Work' on the <a href="{{bounty.absolute_url}}">issue detail page</a>.{% endblocktrans %}
+  {% trans "If so, please leave a comment on the github thread to check in." %}
+  <br>
+  -{% trans "OR" %}-
+  <br>
+  {% blocktrans %}If not, click 'Stop Work' on the <a href="{{ bounty.absolute_url }}">issue detail page</a>.{% endblocktrans %}
 
-    <br>
-    <br>
-    {% blocktrans %}If you have any questions, feel free to reach out <a href="https://gitcoin.co/slack">on slack</a>.{% endblocktrans %}
+  <br>
+  <br>
+  {% blocktrans %}If you have any questions, feel free to reach out <a href="{% url 'slack' %}">on slack</a>.{% endblocktrans %}
 
-    <br>
-    <h5>{% trans "Funded Issue Details" %}</h5>
+  <br>
+  <h5>{% trans "Funded Issue Details" %}</h5>
 </p>
 
 <br>
@@ -58,7 +57,7 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %} <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
+  {% trans "You are receiving this email because your email address is on the notification list for this funded issue." %} <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/bounty_startwork_expire_warning.txt
+++ b/app/retail/templates/emails/bounty_startwork_expire_warning.txt
@@ -4,16 +4,16 @@
 Hey there,
 
 
-You started work upon a funded issue {{interest.created | naturaltime}}.  We haven't heard from you on the github thread{% if time_delta_days %} in {{time_delta_days}} days{%endif%}.
+You started work upon a funded issue {{ interest.created|naturaltime }}.  We haven't heard from you on the github thread{% if time_delta_days %} in {{ time_delta_days }} days{% endif %}.
 
 Do you still want to work on this?
 
 
 If so, please leave a comment on the github thread to check in.
 -OR-
-If not, click 'Stop Work' on at {{bounty.absolute_url}}
+If not, click 'Stop Work' on at {{ bounty.absolute_url }}
 
-If you have any questions, feel free to reach out on slack => https://gitcoin.co/slack
+If you have any questions, feel free to reach out on slack => {% url 'slack' %}
 
 Funded Issue Details
 

--- a/app/retail/templates/emails/bounty_uninterested.html
+++ b/app/retail/templates/emails/bounty_uninterested.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load humanize %}
 
@@ -24,15 +23,15 @@
 
 
 <p>
-    Hey there,
+  Hey there,
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-     We are sorry, but the funder has <strong>removed</strong> You from the issue.
+    We are sorry, but the funder has <strong>removed</strong> You from the issue.
 
-    <br>
-    <h5>Funded Issue Details</h5>
+  <br>
+  <h5>Funded Issue Details</h5>
 </p>
 
 <br>
@@ -40,13 +39,13 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-You are receiving this email because your email address is on the notification list for this funded issue. <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">Manage Email Settings</a>.
+  You are receiving this email because your email address is on the notification list for this funded issue. <a href="{% url 'email_settings' subscriber.priv %}">Manage Email Settings</a>.
 </p>
 
 <p>
-    Keep Pushing Open Source Forward,
-    <br>
-    -- Gitcoin Core
+  Keep Pushing Open Source Forward,
+  <br>
+  -- Gitcoin Core
 </p>
 
 

--- a/app/retail/templates/emails/faucet_request_rejected.html
+++ b/app/retail/templates/emails/faucet_request_rejected.html
@@ -1,23 +1,21 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load i18n humanize %}
-{% load static %}
+{% load i18n humanize static %}
 
 {% block content %}
 
@@ -26,34 +24,34 @@
 <img src="{% static 'v2/images/gas.png' %}" width=200px height=200px >
 
 <p>
-    {% trans "Hey" %} @{{fr.github_username}},
+  {% trans "Hey" %} @{{ fr.github_username }},
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-    {% blocktrans %}Gitcoin *could not* approve your faucet request for {{amount}} ETH to{% endblocktrans %} <a href=https://etherscan.io/address/{{fr.address}}>{{fr.address}}</a>.
+  {% blocktrans %}Gitcoin *could not* approve your faucet request for {{ amount }} ETH to{% endblocktrans %} <a href="https://etherscan.io/address/{{ fr.address }}">{{ fr.address }}</a>.
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-    {% if fr.comment_admin %}
+  {% if fr.comment_admin %}
 
-    {% trans "Here are somme comments from the administrator:" %}
+  {% trans "Here are somme comments from the administrator:" %}
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-        > {{fr.comment_admin}}
+    > {{ fr.comment_admin }}
 
-    <br>
-    <br>
+  <br>
+  <br>
 
-    {% endif %}
+  {% endif %}
 
-    {% trans "You are welcome to re-apply at" %} <a href="https://gitcoin.co/faucet">https://gitcoin.co/faucet</a>
+  {% trans "You are welcome to re-apply at" %} <a href="{% url 'faucet' %}">{% url 'faucet' %}</a>
 
-    <br>
-    <br>
+  <br>
+  <br>
 
 </p>
 

--- a/app/retail/templates/emails/faucet_request_rejected.txt
+++ b/app/retail/templates/emails/faucet_request_rejected.txt
@@ -1,13 +1,13 @@
-Hey @{{fr.github_username}},
+Hey @{{ fr.github_username }},
 
-Gitcoin *could not* approve your faucet request for {{amount}} ETH to {{fr.address}}
+Gitcoin *could not* approve your faucet request for {{ amount }} ETH to {{ fr.address }}
 
 {% if fr.comment_admin %}
 
 Here are somme comments from the administrator:
 
-> {{fr.comment_admin}}
+> {{ fr.comment_admin }}
 
 {% endif %}
 
-You are welcome to re-apply at https://gitcoin.co/faucet
+You are welcome to re-apply at {% url 'faucet' %}

--- a/app/retail/templates/emails/gdpr_reconsent.html
+++ b/app/retail/templates/emails/gdpr_reconsent.html
@@ -28,7 +28,7 @@
   We hope that our content is useful to you. If you'd like to continue hearing from us, please update your subscription settings.
 </p>
 <p>
-  <a class="button" href="https://gitcoin.co/settings/email/{{ subscriber.priv }}">
+  <a class="button" href="{% url 'email_settings' subscriber.priv %}">
     Click here to update your subscription settings.
   </a>
 </p>

--- a/app/retail/templates/emails/gdpr_reconsent.txt
+++ b/app/retail/templates/emails/gdpr_reconsent.txt
@@ -5,7 +5,7 @@ To help comply with GDPR consent requirements, we need to confirm that you would
 
 We hope that our content is useful to you. If you'd like to continue hearing from us, please update your subscription settings.
 
-Click here to update your subscription settings: https://gitcoin.co/settings/email/{{ subscriber.priv }}
+Click here to update your subscription settings: {% url 'email_settings' subscriber.priv %}
 
 Best,
 @owocki

--- a/app/retail/templates/emails/new_bounty.html
+++ b/app/retail/templates/emails/new_bounty.html
@@ -1,46 +1,45 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize %}
 
 {% block content %}
 
-<h1>{{bounties | length}} {% trans "New Funded Issue" %}{% if bounties|length != 1 %}s{%endif%}</h1>
-<h3>Matching your profile</h3>
+<h1>{{ bounties|length }} {% trans "New Funded Issue" %}{% if bounties|length != 1 %}s{% endif %}</h1>
+<h3>{% trans "Matching your profile" %}</h3>
 
 {% for bounty in bounties %}
-    {% include 'emails/bounty_small.html' with bounty=bounty count=forloop.counter  %}
+  {% include 'emails/bounty_small.html' with bounty=bounty count=forloop.counter  %}
 {% endfor %}
 
 {% if old_bounties %}
 
-<h1>{{old_bounties | length}} {% trans "Other Open Funded Issue" %}{% if old_bounties|length != 1 %}s{%endif%}</h1>
-<h3>Matching your profile</h3>
-    {% for bounty in old_bounties %}
-      {% include 'emails/bounty_small.html' with bounty=bounty count=forloop.counter  %}
-    {% endfor %}
+<h1>{{ old_bounties|length }} {% trans "Other Open Funded Issue" %}{% if old_bounties|length != 1 %}s{% endif %}</h1>
+<h3>{% trans "Matching your profile" %}</h3>
+  {% for bounty in old_bounties %}
+    {% include 'emails/bounty_small.html' with bounty=bounty count=forloop.counter  %}
+  {% endfor %}
 
 {% endif %}
 
 <p>
-    {% if keywords %}
-    {% trans "You are receiving this email because your email preferences matched with these keywords:" %} {{keywords}}.  <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
-    {% endif %}
+  {% if keywords %}
+  {% trans "You are receiving this email because your email preferences matched with these keywords:" %} {{ keywords }}.  <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
+  {% endif %}
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/new_bounty_acceptance.html
+++ b/app/retail/templates/emails/new_bounty_acceptance.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize %}
 
@@ -32,7 +31,7 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-{% trans "You are receiving this email because your email address is on the bounty notification list for this funded issue." %}   <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
+{% trans "You are receiving this email because your email address is on the bounty notification list for this funded issue." %}   <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/new_bounty_expire_warning.html
+++ b/app/retail/templates/emails/new_bounty_expire_warning.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize static %}
 
@@ -24,50 +23,50 @@
 
 
 <p style="color: #4A4A4A;">
-    {% if is_owner %}
-        {% blocktrans %}Heads up! The funded issue that you posted (below) is expiring in {{num}} {{unit}}.{% endblocktrans %}
-    {% else %}
-        {% blocktrans %}Heads up! The funded issue that you fulfilled (below) is expiring in {{num}} {{unit}}.{% endblocktrans %}
-    {% endif %}
+  {% if is_owner %}
+    {% blocktrans %}Heads up! The funded issue that you posted (below) is expiring in {{ num }} {{ unit }}.{% endblocktrans %}
+  {% else %}
+    {% blocktrans %}Heads up! The funded issue that you fulfilled (below) is expiring in {{ num }} {{ unit }}.{% endblocktrans %}
+  {% endif %}
+
+  <br>
+  <br>
+  <img src="{% static "v2/images/expiring_clock.png"%}" style="padding: 20px 0;">
+  <br>
+  <br>
+  {% if is_owner %}
+  <a class="button button--primary" href="{{ bounty.absolute_url }}">{% trans "Extend Expiration Date" %}</a>
+  {% if bounty.status == 'submitted' %}
+    <br>
+    <br>
+    {% trans "There is a currently pending claim against this funded issue. Please make sure you process them!" %}
+  {% endif %}
+
+  <br>
+  <br>
+  {% trans "After a funded issue has expired, a contributor is still able to submit work and you will still be able to accept work." %}
+  <br>
+  <br>
+  {% trans "You can also cancel the bounty on the issue details page if needed." %}
+
+  <br>
+  <br>
+  <br>
+  {% blocktrans %}If you have any questions, feel free to reach out <a href="{% url 'slack' %}">on slack</a>.{% endblocktrans %}
+
+  {% else %}
+
+    {% blocktrans %}Why don't you leave a comment <a href="{{ bounty.github_url }}">on github</a> and let the bounty owner know that you'd like to wrap this up soon? :){% endblocktrans %}
 
     <br>
     <br>
-    <img src="{% static "v2/images/expiring_clock.png"%}" style="padding: 20px 0;">
-    <br>
-    <br>
-    {% if is_owner %}
-    <a class="button button--primary" href="{{bounty.absolute_url}}">{% trans "Extend Expiration Date" %}</a>
-    {% if bounty.status == 'submitted' %}
-        <br>
-        <br>
-        {% trans "There is a currently pending claim agains this funded issue. Please make sure you process them!" %}
-    {% endif %}
-
-    <br>
-    <br>
-    {% trans "After a funded issue has expired, a contributor is still able to submit work and you will still be able to accept work." %}
-    <br>
-    <br>
-    {% trans "You can also cancel the bounty on the issue details page if needed." %}
-
-    <br>
-    <br>
-    <br>
-    {% blocktrans %}If you have any questions, feel free to reach out <a href="https://gitcoin.co/slack">on slack</a>.{% endblocktrans %}
-
-    {% else %}
-
-        {% blocktrans %}Why don't you leave a comment <a href="{{bounty.github_url}}">on github</a> and let the bounty owner know that you'd like to wrap this up soon? :){% endblocktrans %}
-
-        <br>
-        <br>
-        {% blocktrans %}If you have any problems, feel free to reach out <a href="https://gitcoin.co/slack">on slack</a>.{% endblocktrans %}
+    {% blocktrans %}If you have any problems, feel free to reach out <a href="{% url 'slack' %}">on slack</a>.{% endblocktrans %}
 
 
-    {% endif %}
+  {% endif %}
 
-    <br>
-    <h5>{% trans "Funded Issue Details" %}</h5>
+  <br>
+  <h5>{% trans "Funded Issue Details" %}</h5>
 </p>
 
 <br>
@@ -75,7 +74,7 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %} <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
+{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %} <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/new_bounty_rejection.html
+++ b/app/retail/templates/emails/new_bounty_rejection.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize %}
 
@@ -31,7 +30,7 @@
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %}  <a href="https://gitcoin.co/settings/email/{{subscriber.priv}}">{% trans "Manage Email Settings" %}</a>.
+{% trans "You are receiving this email because your email address is on the notification list for this funded issue." %}  <a href="{% url 'email_settings' subscriber.priv %}">{% trans "Manage Email Settings" %}</a>.
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/new_match.html
+++ b/app/retail/templates/emails/new_match.html
@@ -1,20 +1,19 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n humanize %}
 
@@ -23,54 +22,53 @@
 
 <style>
 a{
-    word-wrap: break-word;
+  word-wrap: break-word;
 }
-
 p, pre{
-    margin-top: 25px;
-    text-align: left;
+  margin-top: 25px;
+  text-align: left;
 }
 .match div{
-    display: inline-block;;
-    vertical-align: middle;;
+  display: inline-block;
+  vertical-align: middle;
 }
 </style>
 
 <h1>⚡️ {% trans "New Match Alert" %} ⚡️</h1>
 
 <h3>
-    @{{github_username}},{% trans "meet" %} {{bounty.org_name}}.  {{bounty.org_name}}, {% trans "meet" %} @{{github_username}}.
+  @{{ github_username }},{% trans "meet" %} {{ bounty.org_name }}.  {{ bounty.org_name }}, {% trans "meet" %} @{{ github_username }}.
 </h3>
 
 <div class="match">
-    <div>
-        <a href="https://github.com/{{github_username}}"><img src="https://gitcoin.co/dynamic/avatar/{{github_username}}" width="100" height="100" /></a>
-        <br>
-        <a href="https://github.com/{{github_username}}">
-            @{{github_username}}
-        </a>
-    </div>
-    <div>
-        &lt;&gt;
-    </div>
-    <div>
-        <a href="https://github.com/{{bounty.org_name}}"><img src="{{bounty.avatar_url}}" width="100" height="100"></a>
-        <br>
-        <a href="https://github.com/{{bounty.org_name}}">
-            {{bounty.org_name}}
-        </a>
-    </div>
+  <div>
+    <a href="https://github.com/{{ github_username }}"><img src="{% url 'org_avatar' github_username %}" width="100" height="100" /></a>
+    <br>
+    <a href="https://github.com/{{ github_username }}">
+      @{{ github_username }}
+    </a>
+  </div>
+  <div>
+      &lt;&gt;
+  </div>
+  <div>
+    <a href="https://github.com/{{ bounty.org_name }}"><img src="{{ bounty.avatar_url }}" width="100" height="100"></a>
+    <br>
+    <a href="https://github.com/{{ bounty.org_name }}">
+      {{ bounty.org_name }}
+    </a>
+  </div>
 </div>
 
 
 <p>
-    @{{github_username}} expressed interest in <a href="{{bounty.absolute_url}}">{{bounty.title_or_desc}}</a>
+  @{{ github_username }} expressed interest in <a href="{{ bounty.absolute_url }}">{{ bounty.title_or_desc }}</a>
 </p>
 <h4>Matched Issue</h4>
 {% include 'emails/bounty.html' with bounty=bounty %}
 
 <p>
-    {% trans "You are both CCed on this email.  Feel free to reply all and say hey." %}
+  {% trans "You are both CCed on this email.  Feel free to reply all and say hey." %}
 </p>
 
 {% endblock %}

--- a/app/retail/templates/emails/render_bounty_startwork_expired.html
+++ b/app/retail/templates/emails/render_bounty_startwork_expired.html
@@ -29,7 +29,7 @@
   <br>
   <br>
 
-   You <strong>started work upon</strong> a funded issue {{interest.created | naturaltime}}.  But we haven't heard from you on the github thread{% if time_delta_days %} in {{time_delta_days}} days{%endif%}.
+   You <strong>started work upon</strong> a funded issue {{ interest.created|naturaltime }}.  But we haven't heard from you on the github thread{% if time_delta_days %} in {{ time_delta_days }} days{% endif %}.
 
   <br>
   <br>
@@ -46,11 +46,11 @@
   <br>
   -{% trans "AND" %}-
   <br>
-  {% blocktrans %}Click 'Start Work' on the <a href="{{bounty.absolute_url}}">issue detail page</a>.{% endblocktrans %}
+  {% blocktrans %}Click 'Start Work' on the <a href="{{ bounty.absolute_url }}">issue detail page</a>.{% endblocktrans %}
 
   <br>
   <br>
-  {% blocktrans %}If you have any questions, feel free to reach out <a href="https://gitcoin.co/slack">on slack</a>.{% endblocktrans %}
+  {% blocktrans %}If you have any questions, feel free to reach out <a href="{% url 'slack' %}">on slack</a>.{% endblocktrans %}
 
   <br>
   <h5>{% trans "Funded Issue Details" %}</h5>

--- a/app/retail/templates/emails/render_bounty_startwork_expired.txt
+++ b/app/retail/templates/emails/render_bounty_startwork_expired.txt
@@ -4,7 +4,7 @@
 Hey there,
 
 
-You started work upon a funded issue {{interest.created | naturaltime}}.  We haven't heard from you on the github thread{% if time_delta_days %} in {{time_delta_days}} days{%endif%}.
+You started work upon a funded issue {{ interest.created|naturaltime }}.  We haven't heard from you on the github thread{% if time_delta_days %} in {{ time_delta_days }} days{% endif %}.
 
 Since we have a responsibility to the community to keep the list of claimees for this issue current, Gitcoin removed you from the task.
 
@@ -12,9 +12,9 @@ Do you still want to work on this?  No big deal!  We can help with that:
 
 Please leave a comment on the github thread to check in.
 -AND-
-Click 'Start Work' at {{bounty.absolute_url}}
+Click 'Start Work' at {{ bounty.absolute_url }}
 
-If you have any questions, feel free to reach out on slack => https://gitcoin.co/slack
+If you have any questions, feel free to reach out on slack => {% url 'slack' %}
 
 Funded Issue Details
 

--- a/app/retail/templates/emails/start_work_rejected.html
+++ b/app/retail/templates/emails/start_work_rejected.html
@@ -1,36 +1,33 @@
 {% extends 'emails/template.html' %}
 {% comment %}
-    Copyright (C) 2017 Gitcoin Core
+  Copyright (C) 2018 Gitcoin Core
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program. If not, see <http://www.gnu.org/licenses/>.
-
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load i18n humanize %}
-{% load static %}
+{% load i18n humanize static %}
 
 {% block content %}
-
 <h1>{% trans "Work Request Rejected" %}</h1>
 <div style="text-align: left! important">
   <p>
-    {% trans "Hello" %} @{{interest.profile.handle}},
+    {% trans "Hello" %} @{{ interest.profile.handle }},
   </p>
   <p>
-    {% trans "The funder has denied your request to work on "%}<a href="{{bounty.url}}">{% trans "this bounty" %}</a>.  {% trans "Checkout the issue explorer for other projects on the platform!" %}
+    {% trans "The funder has denied your request to work on "%}<a href="{{ bounty.url }}">{% trans "this bounty" %}</a>.  {% trans "Checkout the issue explorer for other projects on the platform!" %}
   </p>
   <p style="text-align: center; margin: 30px 50px;">
-    <a class="button" href="https://gitcon.co/explorer">{% trans "Issue Explorer" %}</a>
+    <a class="button" href="{% url 'explorer' %}">{% trans "Issue Explorer" %}</a>
   </p>
   <p>
     {% blocktrans %}

--- a/app/retail/templates/emails/start_work_rejected.txt
+++ b/app/retail/templates/emails/start_work_rejected.txt
@@ -5,4 +5,4 @@ Checkout the issue explorer for other projects on the platform!
  " %}
 
 
-https://gitcon.co/explorer
+{% url 'explorer' %}

--- a/app/retail/templates/emails/template.html
+++ b/app/retail/templates/emails/template.html
@@ -171,7 +171,7 @@
 <body class="g-font-muli">
   {% if not hide_header %}
   <div id="header">
-    <a href="https://gitcoin.co">
+    <a href="{% url 'index' %}">
       <span style="display: inline-block;height: 100%;vertical-align: middle;"></span><img id="logo" src="{% static "v2/images/logo_large.png" %}" alt="Gitcoin" title="Gitcoin Logo">
     </a>
   </div>
@@ -193,7 +193,7 @@
 
       <a href="https://reddit.com/r/gitcoincommunity"><img class="social-img" src="{% static "v2/images/social/reddit_new.png" %}"></a>
 
-      <a href="https://gitcoin.co/slack"><img class="social-img" src="{% static "v2/images/social/slack_new.png" %}"></a>
+      <a href="{% url 'slack' %}"><img class="social-img" src="{% static "v2/images/social/slack_new.png" %}"></a>
     </div>
     <div>
       <div id="copyright">


### PR DESCRIPTION
##### Description

The goal of this PR is to standardize most of our email templates (at least those living in `app/retail/templates/emails/`) to use `{% url '' %}` vs hardcoded paths.  This will mitigate the chances of errors like:  `https://gitcon.co/` occurring in the future and allow us to update URL paths without updating numerous files referencing the paths.  Additionally, this PR aims to migrate these templates to 2-space indentation and standard django template formatting for template variables and functions:  `{{ var|somefilter }}` and `{% endif %}`

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

emails, templates

##### Testing

Locally

##### Refers/Fixes

Fix #2329 