### PR TITLE
Fix #2335 - If IPFS_HOST is ipfs pass localhost to IPFSJS

### DIFF
--- a/app/app/context.py
+++ b/app/app/context.py
@@ -57,7 +57,7 @@ def insert_settings(request):
         'profile_id': profile.id if profile else '',
         'hotjar': settings.HOTJAR_CONFIG,
         'ipfs_config': {
-            'host': settings.IPFS_HOST,
+            'host': settings.JS_IPFS_HOST,
             'port': settings.IPFS_API_PORT,
             'protocol': settings.IPFS_API_SCHEME,
             'root': settings.IPFS_API_ROOT,

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -577,6 +577,7 @@ COLO_ACCOUNT_ADDRESS = env('COLO_ACCOUNT_ADDRESS', default='')  # TODO
 COLO_ACCOUNT_PRIVATE_KEY = env('COLO_ACCOUNT_PRIVATE_KEY', default='')  # TODO
 
 IPFS_HOST = env('IPFS_HOST', default='ipfs.infura.io')
+JS_IPFS_HOST = IPFS_HOST if IPFS_HOST != 'ipfs' else 'localhost'
 IPFS_SWARM_PORT = env.int('IPFS_SWARM_PORT', default=4001)
 IPFS_UTP_PORT = env.int('IPFS_UTP_PORT', default=4002)
 IPFS_API_PORT = env.int('IPFS_API_PORT', default=5001)


### PR DESCRIPTION
##### Description

The goal of this PR is to resolve a bug encountered while attempting to communicate with the local IPFS docker instance from IPFS JS by defaulting to `localhost` for IPFS JS if `IPFS_HOST == 'ipfs'`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

ipfs, context, settings

##### Testing

Locally

##### Refers/Fixes

Fix #2335 
