### PR TITLE
Migrate image converter to pyvips

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
         - gunzip GeoLite2-City.mmdb.gz && gunzip GeoLite2-Country.mmdb.gz
         - sudo mkdir -p /opt/GeoIP/
         - sudo mv *.mmdb /opt/GeoIP/
+        # Install libvips dependencies.
+        - sudo apt-get install -y libvips libvips-dev
         # Install Node and Python dependencies.
         - npm install
         - pip install -r requirements/test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY bin/docker-command.bash /bin/docker-command.bash
 RUN dos2unix /bin/docker-command.bash && \
     apt-get purge -y --auto-remove dos2unix wget gcc libc6-dev libc-dev libssl-dev make automake libtool autoconf pkg-config libffi-dev apt-utils
 
-RUN apt-get update && apt-get install -y libmagickwand-dev
+RUN apt-get update && apt-get install -y libvips libvips-dev
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["bash", "/bin/docker-command.bash"]

--- a/app/avatar/utils.py
+++ b/app/avatar/utils.py
@@ -393,20 +393,6 @@ def get_github_avatar(handle):
     return temp_avatar
 
 
-def convert_svg_to_png(svg_buffer):
-    """Convert the provided SVG buffer to a PNG buffer."""
-    svg_image = pyvips.Image.svgload_buffer(svg_buffer)
-    png_buffer = svg_image.pngsave_buffer()
-    return png_buffer
-
-
-def convert_png_to_svg(png_buffer):
-    """Convert the provided SVG buffer to a PNG buffer."""
-    png_image = pyvips.Image.pngsave_buffer(png_buffer)
-    svg_buffer = png_image.pngsave_buffer()
-    return svg_buffer
-
-
 def convert_img(obj, input_fmt='svg', output_fmt='png'):
     """Convert the provided buffer to another format.
 

--- a/app/avatar/utils.py
+++ b/app/avatar/utils.py
@@ -33,7 +33,6 @@ import requests
 from git.utils import get_user
 from PIL import Image, ImageOps
 from svgutils.compose import SVG, Figure, Line
-from wand.image import Image as WandImage
 
 AVATAR_BASE = 'assets/other/avatars/'
 COMPONENT_BASE = 'assets/v2/images/avatar/'

--- a/app/avatar/utils.py
+++ b/app/avatar/utils.py
@@ -398,7 +398,11 @@ def convert_img(obj, input_fmt='svg', output_fmt='png'):
 
     Args:
         obj (File): The File/ContentFile object.
-        fmt (str): The output format. Defaults to: png.
+        input_fmt (str): The input format. Defaults to: svg.
+        output_fmt (str): The output format. Defaults to: png.
+
+    Exceptions:
+        Exception: Cowardly catch blanket exceptions here, log it, and return None.
 
     Returns:
         BytesIO: The BytesIO stream containing the converted File data.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -69,9 +69,9 @@ django-redis==4.9.0
 collectfast==0.6.2
 django-health-check==3.7.0
 elastic-apm==3.0.1
-Wand==0.4.4
 mkdocs==1.0.4
 pymdown-extensions==5.0
 mkdocs-material==3.0.4
 pydoc-markdown==2.0.4
 oauth2client==4.1.3
+pyvips==2.1.3


### PR DESCRIPTION
##### Description

The goal of this PR is to migrate from `Wand`/`libmagickwand` to `pyvips`/`libvips`.
Additionally, this conversion method works with **complex** SVG layers. cc @jasonrhaas 

###### Enhancements:

- **Faster**
- **More performant**
- **Less resources to perform conversion**
- **Less storage usage for dependencies**

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

avatar, images

##### Testing

Locally

