### PR TITLE
tip : autocomplete shows payout address

### DIFF
--- a/app/assets/onepager/js/send.js
+++ b/app/assets/onepager/js/send.js
@@ -54,6 +54,7 @@ var wait_for_metadata = function(callback) {
 };
 
 $(document).ready(function() {
+  userSearch('.username-search', true);
   set_metadata();
   // jquery bindings
   $('#advanced_toggle').click(function() {

--- a/app/assets/v2/js/user-search.js
+++ b/app/assets/v2/js/user-search.js
@@ -92,5 +92,5 @@ function userSearch(elem, showAddress) {
 }
 
 $('document').ready(function() {
-  userSearch();
+  userSearch('.username-search', true);
 });

--- a/app/assets/v2/js/user-search.js
+++ b/app/assets/v2/js/user-search.js
@@ -90,7 +90,3 @@ function userSearch(elem, showAddress) {
     }
   });
 }
-
-$('document').ready(function() {
-  userSearch('.username-search', true);
-});

--- a/app/dashboard/templates/onepager/send2.html
+++ b/app/dashboard/templates/onepager/send2.html
@@ -29,6 +29,7 @@
   <script src="/dynamic/js/tokens_dynamic.js"></script>
   <script src="{% static "onepager/js/send.js" %}"></script>
   <script src="{% static "onepager/js/confetti.js" %}"></script>
+  <script src="{% static "v2/js/truncate-hash.js" %}"></script>
   <script src="{% static "v2/js/user-search.js" %}"></script>
   <script src="{% static "v2/js/tooltip_hover.js" %}"></script>
 {% endblock %}
@@ -57,6 +58,17 @@
   .send2 .navbar-network {
     padding: 3px;
   }
+
+  .pb-1 {
+    padding-bottom: 1rem;
+  }
+
+  #fromName,
+  #advanced_toggle,
+  .to_name .select2-container,
+  .terms {
+    margin-top: 0.75rem;
+  }
 </style>
 <div>
   <canvas id="world" style="position:absolute; top:0px; left: 0px;"></canvas>
@@ -81,8 +93,8 @@
     </div>
     <div id="usd_amount"> &nbsp;</div>
     <div id="tooltip">{% trans "Where is my Eth going? " %}<i class='fa fa-info-circle'></i></div><br>
-    <div>
-      <label for="">{% trans "To Github Username" %}:</label> <br>
+    <div class="pb-1 to_name">
+      <label>{% trans "To Github Username" %}:</label> <br>
       <select id="username" class="username-search custom-select" style="max-width: 400px; margin-left: auto; margin-right: auto;"></select>
     </div>
     <div>
@@ -128,7 +140,7 @@
         <textarea id="comments_public" style="width:400px; margin: 0px auto;" ></textarea>
       </div>
     </div>
-    <div class="mb-1 mb-3">
+    <div class="terms pb-1">
       <input type="checkbox" id="tos" value="1" >
       <label for="tos">{% blocktrans %}I understand &amp; agree to the <a href="https://gitcoin.co/terms">terms of service</a>.{% endblocktrans %}</label>
     </div>


### PR DESCRIPTION
##### Description

![x](https://user-images.githubusercontent.com/5358146/46581437-6bd63a00-ca56-11e8-8ed6-2a1d8c194cf9.gif)


@octavioamu I removed the default function call which happens within `user-search.js` and whichever page needs -> needs to individually invoke the function. 


If you want only the name invoke function as `userSearch('element-identifier', false);`
If you want the set payout address also -> `userSearch('element-identifier', true);`


Fixes: https://github.com/gitcoinco/web/issues/2362