### PR TITLE
Eliminate additional Milestone query and remove can_edit_milestones

### DIFF
--- a/app/grants/templates/grants/detail.html
+++ b/app/grants/templates/grants/detail.html
@@ -146,7 +146,7 @@
         <div class="col-4">
           <p>
             {% trans "Milestones" %}
-            {% if can_edit_milestones %}<a href="{% url 'grants:milestones' grant.id %}" class="milestones-edit">{% trans "Edit Milestones" %}</a>{% endif %}
+            {% if is_admin %}<a href="{% url 'grants:milestones' grant.id %}" class="milestones-edit">{% trans "Edit Milestones" %}</a>{% endif %}
           </p>
           <div class="milestones-container">
               {% if milestones %}
@@ -155,7 +155,7 @@
                   <li>
                     <div class="milestone-title">{{ milestone.title }}</div>
                     <div class="milestone-date">
-                      {{ milestone.due_date }} - 
+                      {{ milestone.due_date }} -
                       {% if milestone.completion_date %}
                         {{ milestone.completion_date }}
                       {% else %}

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -68,8 +68,8 @@ def grant_details(request, grant_id):
     profile = request.user.profile if request.user.is_authenticated else None
 
     try:
-        grant = Grant.objects.prefetch_related('subscriptions').get(pk=grant_id)
-        milestones = Milestone.objects.filter(grant_id=grant_id).order_by('due_date')
+        grant = Grant.objects.prefetch_related('subscriptions', 'milestones').get(pk=grant_id)
+        milestones = grant.milestones.order_by('due_date')
     except Grant.DoesNotExist:
         raise Http404
 
@@ -137,7 +137,6 @@ def grant_details(request, grant_id):
         'activity': activity_data,
         'gh_activity': gh_data,
         'milestones': milestones,
-        'can_edit_milestones': profile == grant.admin_profile,
         'keywords': get_keywords(),
     }
     return TemplateResponse(request, 'grants/detail.html', params)


### PR DESCRIPTION
##### Description

The goal of this PR is to eliminate the `Milestone.objects.get(...)` query from the `grant_details` view by `prefetch_related('milestones')` and eliminate `can_edit_milestones` for `is_admin`.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://github.com/gitcoinco/web/blob/master/docs/CONTRIBUTING.md#step-4-commit)

##### Affected core subsystem(s)

grants, milestones

##### Testing

Locally
