### PR TITLE
Adjust deploy bash to only run provisioning on jobs_node

### DIFF
--- a/scripts/deploy.bash
+++ b/scripts/deploy.bash
@@ -19,7 +19,7 @@ END
 
 # deploy script
 # assumes that gitcoin repo lives at $HOME/gitcoin
-# and that gitcoinenv is the virtualenv under which it lives
+# and that gitcoin-37 is the virtualenv under which it lives
 
 # setup
 cd || echo "Cannot find directory!"
@@ -54,25 +54,25 @@ echo "- install req"
 echo "- cleaning up pyc files"
 find . -name \*.pyc -delete
 
-if [ "$UPDATE_CRONTAB" ]; then
+if [ "$UPDATE_CRONTAB" ] && [ "$JOBS_NODE" ]; then
     echo "- updating crontab"
     crontab scripts/crontab
 fi
 
 cd app || echo "Cannot find app directory!"
 echo "- collect static"
-if [ "$ISFRONTENDPUSH" ]; then
+if [ "$ISFRONTENDPUSH" ] && [ "$JOBS_NODE" ]; then
     python3 manage.py collectstatic --noinput -i other;
 fi
 
 rm -Rf ~/gitcoin/coin/app/static/other
 
-if [ "$MIGRATE_DB" ]; then
+if [ "$MIGRATE_DB" ] && [ "$JOBS_NODE" ]; then
     echo "- db"
     python3 manage.py migrate
 fi
 
-if [ "$CREATE_CACHE_TABLE" ]; then
+if [ "$CREATE_CACHE_TABLE" ] && [ "$JOBS_NODE" ]; then
     echo "- creating cache table"
     python3 manage.py createcachetable
 fi
@@ -82,7 +82,7 @@ echo "- gunicorn"
 sudo systemctl restart gunicorn
 
 # invalidate cloudfront
-if [ "$ISFRONTENDPUSH" ]; then
+if [ "$ISFRONTENDPUSH" ] && [ "$JOBS_NODE" ]; then
     if [ "$DISTID" ]; then
         cd ~/gitcoin/coin || echo "Cannot find coin directory!"; bash scripts/bustcache.bash "$DISTID"
     fi
@@ -92,7 +92,7 @@ fi
 cd ~/gitcoin/coin || echo "Cannot find coin directory!"
 bash scripts/run_management_command.bash ping_google
 
-if [ "$ENV" = "prod" ]; then
+if [ "$ENV" = "prod" ] && [ "$JOBS_NODE" ]; then
     # Handle sentry deployment
     echo "- publishing deployment information to Sentry"
     bash scripts/sentry.bash


### PR DESCRIPTION
##### Description

Ensure deploy.bash crontab, static, invalidation, and migrations only run on one instance.

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Affected core subsystem(s)

deployments, internal

##### Testing

Locally

##### Refers/Fixes

Fix #2607 