### PR TITLE
Adjust lazy_load_kudos to catch nonexistent profile

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1587,7 +1587,6 @@ class Profile(SuperModel):
             contract__network=settings.KUDOS_NETWORK,
         ).distinct('id')
 
-
     @property
     def is_org(self):
         try:

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1202,22 +1202,25 @@ def profile(request, handle):
 @csrf_exempt
 def lazy_load_kudos(request):
     page = request.POST.get('page', 1)
-    address = request.POST.get('address')
     context = {}
     datarequest = request.POST.get('request')
     order_by = request.GET.get('order_by', '-modified_on')
     limit = int(request.GET.get('limit', 8))
     handle = request.POST.get('handle')
-    profile = Profile.objects.get(handle=handle)
-    if datarequest == 'mykudos':
-        key = 'kudos'
-        context[key] = profile.get_my_kudos.order_by('id', order_by)
-    else:
-        key = 'sent_kudos'
-        context[key] = profile.get_sent_kudos.order_by('id', order_by)
+
+    if handle:
+        try:
+            profile = Profile.objects.get(handle=handle)
+            if datarequest == 'mykudos':
+                key = 'kudos'
+                context[key] = profile.get_my_kudos.order_by('id', order_by)
+            else:
+                key = 'sent_kudos'
+                context[key] = profile.get_sent_kudos.order_by('id', order_by)
+        except Profile.DoesNotExist:
+            pass
 
     paginator = Paginator(context[key], limit)
-
     kudos = paginator.get_page(page)
     kudos_html = loader.render_to_string('shared/kudos_card_profile.html', {'kudos': kudos})
     return JsonResponse({'kudos_html': kudos_html, 'has_next': kudos.has_next()})


### PR DESCRIPTION
##### Description

The goal of this PR is to resolve the exception encountered in:  #2655 when attempting to query for a profile that doesn't exist in `lazy_load_kudos`

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Testing

Local

##### Refers/Fixes

Fix #2655