### PR TITLE
Remove range retry attempt from mint_all_kudos

### DIFF
--- a/app/kudos/management/commands/mint_all_kudos.py
+++ b/app/kudos/management/commands/mint_all_kudos.py
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """
 import logging
-import time
 import urllib
 import warnings
 

--- a/app/kudos/management/commands/mint_all_kudos.py
+++ b/app/kudos/management/commands/mint_all_kudos.py
@@ -155,23 +155,18 @@ class Command(BaseCommand):
 
             is_live = options['live']
             if is_live:
-                for __ in range(1, 4):
-                    try:
-                        token_uri_url = kudos_contract.create_token_uri_url(**metadata)
-                        args = (mint_to, kudos['priceFinney'], kudos['numClonesAllowed'], token_uri_url)
-                        kudos_contract.mint(
-                            *args,
-                            account=account,
-                            private_key=private_key,
-                            skip_sync=skip_sync,
-                            gas_price_gwei=gas_price_gwei,
-                        )
-                        print('Live run - Name: ', readable_name, ' - Account: ', account, 'Minted!')
-                    except Exception as e:
-                        logger.error('Error: %s - Trying to mint again' % e)
-                        time.sleep(2)
-                        continue
-                    else:
-                        break
+                try:
+                    token_uri_url = kudos_contract.create_token_uri_url(**metadata)
+                    args = (mint_to, kudos['priceFinney'], kudos['numClonesAllowed'], token_uri_url)
+                    kudos_contract.mint(
+                        *args,
+                        account=account,
+                        private_key=private_key,
+                        skip_sync=skip_sync,
+                        gas_price_gwei=gas_price_gwei,
+                    )
+                    print('Live run - Name: ', readable_name, ' - Account: ', account, 'Minted!')
+                except Exception as e:
+                    print(f'Error minting: {readable_name} - {e}')
             else:
                 print('Dry run - Name: ', readable_name, ' - Account: ', account, 'Skipping!')


### PR DESCRIPTION
##### Description

The goal of this PR is to eliminate the retry attempts when minting a kudos fails in `mint_all_kudos`

##### Checklist

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Affected core subsystem(s)

kudos

##### Testing

Locally

##### Refers/Fixes

Fix #2654 