### PR TITLE
bounty: rename text to express interest for permissioned bounty

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -866,10 +866,17 @@ var do_actions = function(result) {
 
   if (show_start_stop_work) {
     const enabled = true;
+    let text;
+
+    if (result['permission_type'] === 'approval')
+      text = is_interested ? gettext('Stop') : gettext('Express Interest');
+    else
+      text = is_interested ? gettext('Stop Work') : gettext('Start Work');
+
     const interest_entry = {
       enabled: enabled,
       href: is_interested ? '/uninterested' : '/interested',
-      text: is_interested ? gettext('Stop Work') : gettext('Start Work'),
+      text: text,
       parent: 'right_actions',
       title: is_interested ? gettext('Notify the funder that you will not be working on this project') : gettext('Notify the funder that you would like to take on this project'),
       color: is_interested ? '' : '',


### PR DESCRIPTION
Button states `Express Interest` and `Stop` for permission bounty 
Button states `Start Work` and `Stop Work` for permissionless bounty

![untitled](https://user-images.githubusercontent.com/5358146/48004067-32b4e680-e136-11e8-95cd-2b5ec9d3b2dc.gif)


Fixes: https://github.com/gitcoinco/web/issues/2272

