### PR TITLE
fixes the logic for avatar save checks

### DIFF
--- a/app/avatar/models.py
+++ b/app/avatar/models.py
@@ -82,14 +82,14 @@ class Avatar(SuperModel):
         """Override the save to perform change comparison against PNG and SVG fields."""
         if (self.svg != self.__previous_svg) or (self.svg and not self.custom_avatar_png):
             # If the SVG has changed, perform PNG conversion.
+            self.__previous_svg = self.svg
             self.convert_custom_svg()
         if (self.png != self.__previous_png) or (self.png and not self.github_svg):
             # If the PNG has changed, perform SVG conversion.
+            self.__previous_png = self.png
             self.convert_github_png()
 
         super(Avatar, self).save(force_insert, force_update, *args, **kwargs)
-        self.__previous_svg = self.svg
-        self.__previous_png = self.png
 
     def get_color(self, key='Background', with_hashbang=False):
         if key not in ['Background', 'ClothingColor', 'HairColor', 'ClothingColor', 'SkinTone']:


### PR DESCRIPTION
previous_* was being set every time, when really it should only updated if the field its dervied from is updated

per https://gitcoincore.slack.com/archives/CBZEHJCN7/p1541628897002900