### PR TITLE
adds kudos activity stream to the kudos landing page

### DIFF
--- a/app/assets/v2/css/activity_stream.css
+++ b/app/assets/v2/css/activity_stream.css
@@ -35,3 +35,7 @@
 #activity_stream .tag {
   display: inline-block;
 }
+#activity_stream .activity.new_kudos .token,
+#activity_stream .activity.new_kudos .usd{
+  display: none;
+}

--- a/app/kudos/templates/kudos_about.html
+++ b/app/kudos/templates/kudos_about.html
@@ -105,6 +105,13 @@
       </div>
 
     </section>
+
+    {% if activities|length %}
+      <section class="container-fluid p-5 activity">
+        {% include 'landing/contributor/activity.html' with title='Recently Sent Kudos' suppress_cta=1 %}
+      </section>
+    {% endif %}
+
     <section class="container-fluid bg-cellarius white py-5">
       <div class="container pt-5 font-bigger-2">
         <div class="row mb-5 text-center">

--- a/app/kudos/views.py
+++ b/app/kudos/views.py
@@ -82,10 +82,12 @@ def about(request):
         contract__network=settings.KUDOS_NETWORK,
         hidden=False,
     ).order_by('-popularity_week').cache()
+    activities = Activity.objects.select_related('bounty').filter(bounty__network='mainnet', activity_type='new_kudos').order_by('-created').cache()
     context = {
         'is_outside': True,
         'active': 'about',
-        'title': 'About Kudos',
+        'activities': [a.view_props for a in activities],
+        'title': 'Kudos',
         'card_title': _('Each Kudos is a unique work of art.'),
         'card_desc': _('It can be sent to highlight, recognize, and show appreciation.'),
         'avatar_url': static('v2/images/kudos/assets/kudos-image.png'),

--- a/app/retail/templates/landing/contributor/activity.html
+++ b/app/retail/templates/landing/contributor/activity.html
@@ -17,7 +17,13 @@
 {% load i18n static  %}
 <link rel="stylesheet" href={% static "v2/css/activity_stream.css" %}>
 <div class="col text-center mb-2">
-  <h2 class="mb-4">{% trans "Recent" %} {{ tech_stack|capfirst }} {% trans "Activity on Gitcoin" %}</h2>
+  <h2 class="mb-4">
+  {% if title %}
+    {{title}}
+  {% else %}
+    {% trans "Recent" %} {{ tech_stack|capfirst }} {% trans "Activity on Gitcoin" %}
+  {% endif %}
+  </h2>
 </div>
 <div id=activity_stream style="max-height: 400px; overflow-y: scroll;">
   <div class="mb-4 col offset-lg-1 col-lg-10">
@@ -26,6 +32,8 @@
     {% endfor %}
   </div>
 </div>
+
+{% if not suppress_cta %}
 <div class="col text-center mt-5">
   <a href="/explorer?q={{ tech_stack }}" class="button button--primary" target="_blank" rel="noopener noreferrer">
     {% if tech_stack %}
@@ -35,3 +43,4 @@
     {% endif %}
   </a>
 </div>
+{% endif %}

--- a/app/retail/templates/shared/activity.html
+++ b/app/retail/templates/shared/activity.html
@@ -16,7 +16,7 @@
 
 {% endcomment %}
 {% load humanize i18n static %}
-<div class="row box activity">
+<div class="row box activity {{row.activity_type}}">
   <div class="col-12 col-md-1">
     <div class="activity-avatar">
       <img class="avatar" src="/dynamic/avatar/{{ row.profile.handle }}"/>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://docs.gitcoin.co/mk_contributors/
-->

##### Description

<!-- A description of what this PR aims to solve -->
- adds kudos activity stream to the kudos landing page (makes it look like kudos is being used which provides social proof)
- hides kudos price from the activity stream (its tacky)

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
kudos / activity


##### Testing

screenshot
<img width="470" alt="screen shot 2018-11-13 at 4 40 45 pm" src="https://user-images.githubusercontent.com/513929/48450328-fd764d00-e762-11e8-848d-edf7b43206a8.png">



<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
self
