### PR TITLE
Fix rare `is_metamask_approved is not defined` race condition.

### DIFF
--- a/app/assets/v2/js/metamask-approval.js
+++ b/app/assets/v2/js/metamask-approval.js
@@ -1,3 +1,7 @@
+
+var is_metamask_approved = is_metamask_approved;
+var is_metamask_unlocked = is_metamask_unlocked;
+
 async function metamaskApproval() {
   if (window.ethereum) {
     window.web3 = new Web3(ethereum);

--- a/app/assets/v2/js/metamask-approval.js
+++ b/app/assets/v2/js/metamask-approval.js
@@ -1,6 +1,6 @@
 
-var is_metamask_approved = is_metamask_approved;
-var is_metamask_unlocked = is_metamask_unlocked;
+var is_metamask_approved = is_metamask_approved || false;
+var is_metamask_unlocked = is_metamask_unlocked || false;
 
 async function metamaskApproval() {
   if (window.ethereum) {

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -668,9 +668,6 @@ var mixpanel_track_once = function(event, params) {
   }
 };
 
-var is_metamask_approved = is_metamask_approved;
-var is_metamask_unlocked = is_metamask_unlocked;
-
 /* eslint-disable no-lonely-if */
 var currentNetwork = function(network) {
 

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -668,6 +668,9 @@ var mixpanel_track_once = function(event, params) {
   }
 };
 
+var is_metamask_approved = is_metamask_approved;
+var is_metamask_unlocked = is_metamask_unlocked;
+
 /* eslint-disable no-lonely-if */
 var currentNetwork = function(network) {
 


### PR DESCRIPTION
Sometimes, the window's `load` handler get executed in another order
which breaks variable lookup.
Fix that by explicit declaring `is_metamask_approved` and `is_metamask_unlocked`.

Fixes #2813
