### PR TITLE
Fix redundant `shared.js` includes.

### DIFF
--- a/app/bounty_requests/templates/bounty_request_form.html
+++ b/app/bounty_requests/templates/bounty_request_form.html
@@ -90,6 +90,5 @@
     {% include 'shared/footer.html' %}
     {% include 'shared/messages.html' %}
   </body>
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/pages/bounty_request_form.js" %}"></script>
 </html>

--- a/app/dashboard/templates/bounty/change.html
+++ b/app/dashboard/templates/bounty/change.html
@@ -59,6 +59,5 @@
   document.pk = {{ pk }};
   document.result = {{ result|safe }};
 </script>
-<script src="{% static "v2/js/shared.js" %}"></script>
 <script src="{% static "v2/js/pages/change_bounty.js" %}"></script>
 </html>

--- a/app/dashboard/templates/bounty/increase.html
+++ b/app/dashboard/templates/bounty/increase.html
@@ -127,7 +127,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <script src="{% static "v2/js/abi.js" %}"></script>
   <script src="/dynamic/js/tokens_dynamic.js"></script>
   <script src="{% static "v2/js/tokens.js" %}"></script>
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/pages/shared_bounty_mutation_estimate_gas.js" %}"></script>
   <script src="{% static "v2/js/pages/increase_bounty.js" %}"></script>
   <script src="{% static "onepager/js/send.js" %}"></script>

--- a/app/dashboard/templates/bounty/new.html
+++ b/app/dashboard/templates/bounty/new.html
@@ -176,7 +176,6 @@
 <script src="{% static "v2/js/abi.js" %}"></script>
 <script src="/dynamic/js/tokens_dynamic.js"></script>
 <script src="{% static "v2/js/tokens.js" %}"></script>
-<script src="{% static "v2/js/shared.js" %}"></script>
 <script src="{% static "v2/js/pages/shared_bounty_mutation_estimate_gas.js" %}"></script>
 <script src="{% static "v2/js/pages/new_bounty.js" %}"></script>
 

--- a/app/dashboard/templates/ftux/onboard.html
+++ b/app/dashboard/templates/ftux/onboard.html
@@ -70,7 +70,6 @@
       steps.push("{{step}}");
     {% endfor %};
   </script>
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/pages/onboard.js" %}"></script>
   <script src="{% static "v2/js/avatar_builder.js" %}" defer></script>
   <script src="/dynamic/js/tokens_dynamic.js"></script>

--- a/app/dashboard/templates/grants_index.html
+++ b/app/dashboard/templates/grants_index.html
@@ -296,6 +296,5 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   </body>
 
   <!-- jQuery -->
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/grants_index.js" %}"></script>
 </html>

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -333,7 +333,6 @@
     <script>
       var bootstrapTooltip = $.fn.tooltip.noConflict()
     </script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
     <script src="{% static "v2/js/pages/tabs.js" %}"></script>
 
     <script type="text/javascript">

--- a/app/dashboard/templates/quickstart.html
+++ b/app/dashboard/templates/quickstart.html
@@ -158,7 +158,6 @@
     <script src="/dynamic/js/tokens_dynamic.js"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>
     <script src="{% static "v2/js/pages/quickstart.js" %}"></script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
     {% if keywords %}
       <script>
         document.keywords = {{ keywords|safe }};

--- a/app/dashboard/templates/toolbox.html
+++ b/app/dashboard/templates/toolbox.html
@@ -114,7 +114,6 @@
     <script src="/dynamic/js/tokens_dynamic.js"></script>
     <script src="{% static "v2/js/abi.js" %}"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
     <script src="{% static "v2/js/toolbox.js" %}"></script>
   </body>
 </html>

--- a/app/external_bounties/templates/external_bounties.html
+++ b/app/external_bounties/templates/external_bounties.html
@@ -163,7 +163,6 @@
     <script src="/dynamic/js/tokens_dynamic.js"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>
     <script src="{% static "v2/js/pages/offchain_bounties.js" %}"></script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
 
   </body>
 </html>

--- a/app/external_bounties/templates/external_bounties_new.html
+++ b/app/external_bounties/templates/external_bounties_new.html
@@ -57,6 +57,5 @@
     </script>
     <script src="/dynamic/js/tokens_dynamic.js"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
   </body>
 </html>

--- a/app/external_bounties/templates/external_bounties_show.html
+++ b/app/external_bounties/templates/external_bounties_show.html
@@ -97,7 +97,6 @@
 
     <script src="/dynamic/js/tokens_dynamic.js"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>
-    <script src="{% static "v2/js/shared.js" %}"></script>
 
   </body>
 </html>

--- a/app/retail/templates/increase_funding_limit_request_form.html
+++ b/app/retail/templates/increase_funding_limit_request_form.html
@@ -77,6 +77,5 @@
     {% include 'shared/footer.html' %}
     {% include 'shared/messages.html' %}
   </body>
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/pages/increase_funding_limit_request_form.js" %}"></script>
 </html>

--- a/app/retail/templates/leaderboard.html
+++ b/app/retail/templates/leaderboard.html
@@ -134,7 +134,6 @@
   <script src="{% static "v2/js/abi.js" %}"></script>
   <script src="/dynamic/js/tokens_dynamic.js"></script>
   <script src="{% static "v2/js/tokens.js" %}"></script>
-  <script src="{% static "v2/js/shared.js" %}"></script>
   <script src="{% static "v2/js/pages/leaderboard.js" %}"></script>
 
 </html>

--- a/app/retail/templates/settings/tokens.html
+++ b/app/retail/templates/settings/tokens.html
@@ -76,7 +76,6 @@ document.gas_price = {{gas_price}};
 <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 <script src="{% static "v2/js/jquery.js" %}"></script>
 <script src="{% static "v2/js/abi.js" %}"></script>
-<script src="{% static "v2/js/shared.js" %}"></script>
 <script src="/dynamic/js/tokens_dynamic.js"></script>
 <script src="{% static "v2/js/tokens.js" %}"></script>
 <script src="{% static "v2/js/pages/tokens_settings.js" %}"></script>


### PR DESCRIPTION
`shared.js` is included in footer_scripts.html.

This also fixes errors like this:
`shared.js:1 Uncaught SyntaxError: Identifier 'activity_names' has
already been declared`
