### PR TITLE
Pin django-redis==4.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ oyaml
 pygithub==1.43.2
 raven==6.9.0
 django-cacheops==4.0.7
-django-redis==4.9.0
+django-redis==4.10.0
 collectfast==0.6.2
 django-health-check==3.7.0
 elastic-apm==3.0.1


### PR DESCRIPTION
I get random errors on my local docker setup if I use
the site and constant errors for things like POST and
api calls.

For example:
```
web_1    | redis.exceptions.DataError: Invalid input of type: 'CacheKey'. Convert to a byte, string or number first.
```

Details of this issue are here:
https://github.com/niwinz/django-redis/issues/342

The latest djang-redis release fixes the issues.
