### PR TITLE
Fix kudos facebook share url

### DIFF
--- a/app/retail/templates/shared/cards_pic.html
+++ b/app/retail/templates/shared/cards_pic.html
@@ -56,7 +56,11 @@
     <meta property=og:title content="Gitcoin: Grow Open Source.">
     <meta property=og:site_name content="Gitcoin: Grow Open Source.">
 {% endif %}
-<meta property=og:url content="https://gitcoin.co/" >
+{% if request.build_absolute_uri %}
+  <meta property=og:url content="{{request.build_absolute_uri}}" >
+{% else %}
+  <meta property=og:url content="https://gitcoin.co/" >
+{% endif %}
 {% if card_desc %}
     <meta property=og:description content="Gitcoin is the easiest way to monetize or incentivize work in Open Source Software.">
 {% else %}


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://docs.gitcoin.co/mk_contributors/
-->

##### Description

<!-- A description of what this PR aims to solve -->

Change the og:url to be the page one and not gitcoin main page to avoid facebook scraping redirect and wrong image

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->

##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
