### PR TITLE
updated the grant error page

### DIFF
--- a/app/assets/v2/js/grants/shared.js
+++ b/app/assets/v2/js/grants/shared.js
@@ -42,9 +42,11 @@ $(document).ready(function() {
         web3.eth.getBalance(result, function(err, balance) {
           document.balance = balance;
         });
-        web3.eth.net.getNetworkType(function(err, network) {
-          currentNetwork(network);
+
+        web3.eth.net.getId((err, network) => {
+          currentNetwork(getNetwork(network));
         });
+
       } else {
         currentNetwork('locked');
       }


### PR DESCRIPTION
In the web3 version we are using on grantz

```
 const listen_web3_1_changes = () => {
    web3.eth.getCoinbase().then(function(result) {
      if (result) {
        ...
        web3.eth.net.getNetworkType(function(err, network) { // returns null
          currentNetwork(network); 
        });
      } ...
    });
  }
```

` web3.eth.net.getNetworkType` needs to be replaced with `getnNetworkId` as per the [doc](https://web3js.readthedocs.io/en/1.0/web3-eth-net.html#example)

This PR fixes that and ensures you can get the current logged in network via `document.network`

![untitled](https://user-images.githubusercontent.com/5358146/49287585-12254580-f4c4-11e8-838d-3f783d6d1152.gif)
