### PR TITLE
grant/email: fix default image in email

### DIFF
--- a/app/retail/templates/emails/grants/new_grant.html
+++ b/app/retail/templates/emails/grants/new_grant.html
@@ -69,8 +69,8 @@
 <p>{% trans "Get ready to buidl and push forward open source!" %}</p>
 
 <hr>
-
-<img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %} {% static grant_logo|addstr:id|add:'.png' %} {% endwith %} {% endif %}" alt="grant logo" width="25%" >
+<br>
+<img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" alt="grant logo" width="25%" >
 
 <p class="grant-email-name">{{ grant.title }}</p>
 <p class="grant-email-subtitle">{{ grant.description }}</p>

--- a/app/retail/templates/emails/grants/new_grant.html
+++ b/app/retail/templates/emails/grants/new_grant.html
@@ -59,6 +59,11 @@
     background-color: #0D0764;
     color: white;
   }
+
+  #grant-logo {
+    max-width: 25rem;
+    width: 100%;
+  }
 </style>
 
 <img src="{% static 'v2/images/new_grant.png' %}" alt="success icon" width="100px" height="100px" >
@@ -70,19 +75,14 @@
 
 <hr>
 <br>
-<img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" alt="grant logo" width="25%" >
-
+<img id="grant-logo" src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" alt="grant logo" >
 <p class="grant-email-name">{{ grant.title }}</p>
 <p class="grant-email-subtitle">{{ grant.description }}</p>
-
 <div>
   <p class="grant-email-subtitle">{% trans "You are seeking " %}{{ grant.amount_goal }} {% trans "DAI monthly" %}</p>
 </div>
-
 <p class="grant-email-subtitle">{% trans "The details of your grant can be seen" %} <a href="{% url 'grants:details' grant.pk grant.slug %}">{% trans "here." %}</a></p>
-
 <hr>
-
 <div>
   <a class="updatesButton" href="{% url 'grants:details' grant.pk grant.slug %}">{% trans "View Grant" %}</a>
 </div>

--- a/app/retail/templates/emails/grants/successful_contribution.html
+++ b/app/retail/templates/emails/grants/successful_contribution.html
@@ -84,6 +84,11 @@
     margin-bottom: 50px;
   }
 
+  #grant-logo {
+    max-width: 25rem;
+    width: 100%;
+  }
+
   @media screen and (min-width: 598px) {
     .rightGrantHeader {
       padding-left: 40px;
@@ -109,9 +114,10 @@
 </div>
 
 <hr>
+<br>
 <div class="grantInfo">
   <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" width="50" height="50" />
+    <img id="grant-logo" src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
   </a>
   <br>
   <a class="grantInfoName" href="{% url 'grants:details' grant.id grant.slug %}">

--- a/app/retail/templates/emails/grants/successful_contribution.html
+++ b/app/retail/templates/emails/grants/successful_contribution.html
@@ -111,7 +111,7 @@
 <hr>
 <div class="grantInfo">
   <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %} {% static grant_logo|addstr:id|add:'.png' %} {% endwith %} {% endif %}" width="50" height="50" />
+    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" width="50" height="50" />
   </a>
   <br>
   <a class="grantInfoName" href="{% url 'grants:details' grant.id grant.slug %}">

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.html
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.html
@@ -112,9 +112,10 @@
 </div>
 
 <hr>
+<br>
 <div class="grantInfo">
   <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %} {% static grant_logo|addstr:id|add:'.png' %} {% endwith %} {% endif %}" width="50" height="50" />
+    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" width="50" height="50" />
   </a>
   <br>
   <a class="grantInfoName" href="{% url 'grants:details' grant.id grant.slug %}">

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.html
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.html
@@ -84,6 +84,11 @@
     margin-bottom: 50px;
   }
 
+  #grant-logo {
+    max-width: 25rem;
+    width: 100%;
+  }
+
   @media (min-width : 1386px) {
     .leftGrantHeader > img {
       transform: translateY(13.5%);
@@ -115,7 +120,7 @@
 <br>
 <div class="grantInfo">
   <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" width="50" height="50" />
+    <img id="grant-logo" src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
   </a>
   <br>
   <a class="grantInfoName" href="{% url 'grants:details' grant.id grant.slug %}">


### PR DESCRIPTION
##### Description

<img width="900" alt="screen shot 2018-12-05 at 12 38 17 am" src="https://user-images.githubusercontent.com/5358146/49466475-2fd90e80-f826-11e8-98c6-8519650ccf76.png">


@captnseagraves it was an extra spacing issue 😂  
They were converted to `%20` when rendered in the email. derpderp

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
https://github.com/gitcoinco/web/issues/3057