### PR TITLE
Replace tokenName with USD in crowdfunding tooltip

### DIFF
--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -270,7 +270,7 @@ var callbacks = {
       const tokenValue = normalizeAmount(1.0 * ratio, dollarDecimals);
       const timestamp = new Date(obj['timestamp']);
       const timePeg = timeDifference(dateNow, timestamp > dateNow ? dateNow : timestamp, false, 60 * 60);
-      const tooltip = '$' + normalizeAmount(usd, dollarDecimals) + ' ' + tokenName + ' in crowdfunding';
+      const tooltip = `$ ${normalizeAmount(usd, dollarDecimals)} USD in crowdfunding`;
 
       leftHtml += '<p class="m-0">+ ' + funding + ' ' + tokenName + '</p>';
       rightHtml += '<p class="m-0">@ $' + tokenValue + ' ' + tokenName + ' as of ' + timePeg + '</p>';


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://docs.gitcoin.co/mk_contributors/
-->

##### Description

<!-- A description of what this PR aims to solve -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] linter status: 100% pass
- [x] changes don't break existing behavior
- [x] commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, ui, crypto, etc). -->
UI: Chnaged the crowdfunding tooltip to say USD instead of the tokenName.

![image](https://user-images.githubusercontent.com/21009455/49496496-25516000-f88c-11e8-9278-11d0d74f66ec.png)


##### Testing

<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
Quick change, doesn't break the linting or anything.

##### Refers/Fixes

Fixes: #3062 

