### PR TITLE
grant/new: add gas-setting

### DIFF
--- a/app/assets/v2/css/base.css
+++ b/app/assets/v2/css/base.css
@@ -798,6 +798,11 @@ input[type=text].loading {
   display: inline-block;
 }
 
+#metamask_label img {
+  position: relative;
+  top: -2px;
+}
+
 #metamask_context .red_warning {
   background-color: #fbe0d6;
   color: #fb9470;
@@ -813,9 +818,14 @@ input[type=text].loading {
   text-decoration: underline;
 }
 
-#metamask_context {
-  background-color: #fafafa;
-  border-radius: 5px;
+#metamask_context ul {
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+}
+
+#metamask_context li a {
+  color: #0D0764;
 }
 
 #metamask_context .warning {

--- a/app/assets/v2/css/grants/fund.css
+++ b/app/assets/v2/css/grants/fund.css
@@ -45,6 +45,10 @@
   bottom: 2px;
 }
 
+#accordion-set-own-limit {
+  font-size: 12px;
+}
+
 @media (max-width: 767.98px) {
 
   .banner-img {

--- a/app/assets/v2/js/grants/cancel_subscription.js
+++ b/app/assets/v2/js/grants/cancel_subscription.js
@@ -27,10 +27,7 @@ $(document).ready(() => {
 
         console.log('realTokenAmount', realTokenAmount);
 
-        // gas price in gwei
-        let realGasPrice = Number(data.gas_price * 10 ** 9);
-
-        console.log('realGasPrice', realGasPrice);
+        let realGasPrice = $('#gasPrice').val() * Math.pow(10, 9);
 
         web3.eth.getAccounts(function(err, accounts) {
 
@@ -59,7 +56,7 @@ $(document).ready(() => {
 
                 deployedSubscription.methods.cancelSubscription(
                   ...parts
-                ).send({from: accounts[0], gasPrice: 4000000000})
+                ).send({from: accounts[0], gasPrice: realGasPrice})
                   .on('transactionHash', function(transactionHash) {
                     $('#sub_cancel_tx_id').val(transactionHash);
                   }).on('confirmation', function(confirmationNumber, receipt) {

--- a/app/assets/v2/js/grants/fund.js
+++ b/app/assets/v2/js/grants/fund.js
@@ -56,10 +56,9 @@ $(document).ready(function() {
 
       deployedToken.methods.decimals().call(function(err, decimals) {
 
-        // gas price in gwei
-        let realGasPrice = Number(4 * 10 ** 9);
+        let realGasPrice = $('#gasPrice').val() * Math.pow(10, 9);
 
-        $('#gas_price').val(4);
+        $('#gas_price').val(realGasPrice);
 
         let realApproval = Number(((data.approve * 10 ** decimals) + realGasPrice) * data.amount_per_period);
 
@@ -74,7 +73,7 @@ $(document).ready(function() {
             web3.utils.toTwosComplement(realApproval)
           ).send({
             from: accounts[0],
-            gasPrice: 4000000000
+            gasPrice: realGasPrice
           }).on('error', function(error) {
             console.log('1', error);
             alert('Your approval transaction failed. Please try again.');

--- a/app/assets/v2/js/grants/new.js
+++ b/app/assets/v2/js/grants/new.js
@@ -80,7 +80,7 @@ $(document).ready(function() {
           }).send({
             from: accounts[0],
             gas: 3000000,
-            gasPrice: 4000000000
+            gasPrice: web3.utils.toHex($('#gasPrice').val() * Math.pow(10, 9))
           }).on('error', function(error) {
             console.log('1', error);
           }).on('transactionHash', function(transactionHash) {

--- a/app/assets/v2/js/pages/shared_bounty_mutation_estimate_gas.js
+++ b/app/assets/v2/js/pages/shared_bounty_mutation_estimate_gas.js
@@ -22,6 +22,10 @@ var gas_amount = function(page_url) {
     gasLimitEstimate = 21000;
   } else if (page_url.indexOf('tip/receive') != -1) { // tip
     gasLimitEstimate = 21000;
+  } else if (page_url.indexOf('/fund') != -1) { // grant contribution
+    gasLimitEstimate = 318730;
+  } else if (page_url.indexOf('/subscription') != -1) { // canacel grant contribution
+    gasLimitEstimate = 318730;
   }
   return gasLimitEstimate;
 };

--- a/app/assets/v2/js/pages/wallet_estimate.js
+++ b/app/assets/v2/js/pages/wallet_estimate.js
@@ -127,4 +127,3 @@ function prefill_recommended_prices() {
   $('#fast-recommended-gas').html('Fast $' + parseFloat(fast_data['usd']).toFixed(2) + ' ~' + fast_data['time'] + ' minutes');
   $('#fast-recommended-gas').data('amount-usd', parseFloat(fast_data['usd']).toFixed(2));
 }
-

--- a/app/dashboard/templates/bounty/new.html
+++ b/app/dashboard/templates/bounty/new.html
@@ -125,7 +125,7 @@
                   <input name='jobDescription' id='jobDescription' type="url" class="form__input hidden" type="text" placeholder="https://link.to/job/description" value="" />
                 </div>
                 <div id="gas-section" class="pt-2">
-                  <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h4>
+                  <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h5>
                   <div>
                     {% include 'shared/bounty_actions_hidden_vars.html' %}
                     {% include 'shared/wallet_estimate.html' %}

--- a/app/dashboard/templates/shared/wallet_estimate.html
+++ b/app/dashboard/templates/shared/wallet_estimate.html
@@ -45,9 +45,9 @@
     <div class="warning mb-2">{% trans "Warning: the ethereum network is quite congested at the moment." %} <a href="{% url "gas" %}" target="_blank" rel="noopener noreferrer">[{% trans "Stats" %}]</a></div>
   {% endif %}
   {% include 'shared/gas_advisories.html' %}
-  <label id="metamask_label" style="display:none"><img src="{% url "avatar" %}?repo=https://github.com/MetaMask&v=3" width="20px" height="20px">{% blocktrans %}The following MetaMask settings should give a <span id="confTime">5</span> min confirmation for <span id="ethAmount">unknown</span> ETH (<span id="usdAmount">unknown</span> USD){% endblocktrans %}:
+  <label id="metamask_label" style="display:none"><img class="mr-2" src="{% url "avatar" %}?repo=https://github.com/MetaMask&v=3" width="18px" height="18px">{% blocktrans %}The following MetaMask settings should give a <span id="confTime">5</span> min confirmation for <span id="ethAmount">unknown</span> ETH (<span id="usdAmount">unknown</span> USD){% endblocktrans %}:
   </label>
-  <label id="trust_label" style="display:none"><img src="{% url "avatar" %}?repo=https://github.com/TrustWallet&v=3" width="20px" height="20px">{% blocktrans %}The following Trust settings should give a <span id="confTime">5</span> min confirmation for <span id="ethAmount">unknown</span> ETH (<span id="usdAmount">unknown</span> USD){% endblocktrans %} :
+  <label id="trust_label" style="display:none"><img class="mr-2" src="{% url "avatar" %}?repo=https://github.com/TrustWallet&v=3" width="18px" height="18px">{% blocktrans %}The following Trust settings should give a <span id="confTime">5</span> min confirmation for <span id="ethAmount">unknown</span> ETH (<span id="usdAmount">unknown</span> USD){% endblocktrans %} :
   </label>
   <br>
   <div class="metamask_recc">

--- a/app/grants/templates/grants/cancel.html
+++ b/app/grants/templates/grants/cancel.html
@@ -73,6 +73,12 @@
         <div class="col-12 my-4">
           <form method="POST" id="js-cancelSubscription">
             {% csrf_token %}
+            <div id="gas-section" class="form__group-horizontal">
+              <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h5>
+              <div>
+                {% include 'shared/wallet_estimate.html' %}
+              </div>
+            </div>
             <button class="button button--primary button--warning button--full">{% trans "Cancel Contribution" %}
             </button>
             <input type="hidden" id="contract_address" name="contract_address" value="{{ grant.contract_address }}">
@@ -84,7 +90,6 @@
             <input type="hidden" id="amount_per_period" name="amount_per_period" value="{{ subscription.amount_per_period }}">
             <input type="hidden" id="real_period_seconds" name="real_period_seconds" value="{{ subscription.real_period_seconds }}">
             <input type="hidden" id="signature" name="signature" value="{{ subscription.contributor_signature }}">
-            <input type="hidden" id="gas_price" name="gas_price" value="{{ subscription.gas_price }}">
           </form>
         </div>
 

--- a/app/grants/templates/grants/fund.html
+++ b/app/grants/templates/grants/fund.html
@@ -117,6 +117,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                   </div>
                 </div>
 
+                <div id="gas-section" class="form__group-horizontal">
+                  <div class="row">
+                    <div class="col-12">
+                      <h5 class="form__label">{% trans "Gas Settings" %}</h5>
+                      <div>
+                        {% include 'shared/wallet_estimate.html' %}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="summary font-body mt-4">
                   <p class="mb-2 font-weight-semibold">Summary</p>
                   <p>
@@ -171,7 +182,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               <input type="hidden" id="signature" name="signature" value="">
               <input type="hidden" id="contributor_address" name="contributor_address" value="">
               <input type="hidden" id="sub_new_approve_tx_id" name="sub_new_approve_tx_id" value="">
-              <input type="hidden" id="gas_price" name="gas_price" value="">
               <input type="hidden" id="token_symbol" name="token_symbol" value="{{ grant.token_symbol }}">
               <input type="hidden" id="real_period_seconds" name="real_period_seconds" value="">
               <input type="hidden" id="grant-link" value="{% url 'grants:details' grant.id grant.slug %}">

--- a/app/grants/templates/grants/new.html
+++ b/app/grants/templates/grants/new.html
@@ -103,6 +103,13 @@
                   <input type="text" class="form__input form__input-lg " id="input-admin_address" value="" name="admin_address" required/>
                 </div>
 
+                <div id="gas-section" class="pb-2">
+                  <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h4>
+                  <div>
+                    {% include 'shared/wallet_estimate.html' %}
+                  </div>
+                </div>
+
                 <div class="form__group-horizontal pb-3">
                   <label class="font-body">{% trans "Project Logo" %}</label>
                   <div class="form__drop" id="js-drop">
@@ -147,6 +154,7 @@
   <script src="{% static "v2/js/user-search.js" %}"></script>
   <script src="{% static "v2/js/grants/compiledSubscriptionContract.js" %}"></script>
   <script src="{% static "v2/js/waiting_room_entertainment.js" %}"></script>
+  <script src="{% static "v2/js/pages/shared_bounty_mutation_estimate_gas.js" %}"></script>
   <script src="{% static "v2/js/grants/shared.js" %}"></script>
   <script src="{% static "v2/js/grants/new.js" %}"></script>
 </html>

--- a/app/grants/templates/grants/new.html
+++ b/app/grants/templates/grants/new.html
@@ -104,7 +104,7 @@
                 </div>
 
                 <div id="gas-section" class="pb-2">
-                  <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h4>
+                  <h5 class="font-subheader pb-2">{% trans "Gas Settings" %}</h5>
                   <div>
                     {% include 'shared/wallet_estimate.html' %}
                   </div>

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -301,7 +301,6 @@ def grant_fund(request, grant_id,  grant_slug):
         }
         return TemplateResponse(request, 'grants/shared/error.html', params)
 
-    # make sure a user can only create one subscription per grant
     if request.method == 'POST':
         subscription = Subscription()
 
@@ -332,6 +331,13 @@ def grant_fund(request, grant_id,  grant_slug):
         'grant_has_no_token': True if grant.token_address == '0x0000000000000000000000000000000000000000' else False,
         'grant': grant,
         'keywords': get_keywords(),
+        'recommend_gas_price': recommend_min_gas_price_to_confirm_in_time(4),
+        'recommend_gas_price_slow': recommend_min_gas_price_to_confirm_in_time(120),
+        'recommend_gas_price_avg': recommend_min_gas_price_to_confirm_in_time(15),
+        'recommend_gas_price_fast': recommend_min_gas_price_to_confirm_in_time(1),
+        'eth_usd_conv_rate': eth_usd_conv_rate(),
+        'conf_time_spread': conf_time_spread(),
+        'gas_advisories': gas_advisories(),
     }
     return TemplateResponse(request, 'grants/fund.html', params)
 
@@ -377,6 +383,13 @@ def subscription_cancel(request, grant_id, grant_slug, subscription_id):
         'grant': grant,
         'now': now,
         'keywords': get_keywords(),
+        'recommend_gas_price': recommend_min_gas_price_to_confirm_in_time(4),
+        'recommend_gas_price_slow': recommend_min_gas_price_to_confirm_in_time(120),
+        'recommend_gas_price_avg': recommend_min_gas_price_to_confirm_in_time(15),
+        'recommend_gas_price_fast': recommend_min_gas_price_to_confirm_in_time(1),
+        'eth_usd_conv_rate': eth_usd_conv_rate(),
+        'conf_time_spread': conf_time_spread(),
+        'gas_advisories': gas_advisories(),
     }
 
     return TemplateResponse(request, 'grants/cancel.html', params)

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -34,6 +34,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from dashboard.models import Profile
+from gas.utils import conf_time_spread, eth_usd_conv_rate, gas_advisories, recommend_min_gas_price_to_confirm_in_time
 from grants.forms import MilestoneForm
 from grants.models import Grant, Milestone, Subscription, Update
 from marketing.mails import (
@@ -201,7 +202,14 @@ def grant_new(request):
         'card_desc': _('Provide sustainable funding for Open Source with Gitcoin Grants'),
         'profile': profile,
         'grant': {},
-        'keywords': get_keywords()
+        'keywords': get_keywords(),
+        'recommend_gas_price': recommend_min_gas_price_to_confirm_in_time(4),
+        'recommend_gas_price_slow': recommend_min_gas_price_to_confirm_in_time(120),
+        'recommend_gas_price_avg': recommend_min_gas_price_to_confirm_in_time(15),
+        'recommend_gas_price_fast': recommend_min_gas_price_to_confirm_in_time(1),
+        'eth_usd_conv_rate': eth_usd_conv_rate(),
+        'conf_time_spread': conf_time_spread(),
+        'gas_advisories': gas_advisories(),
     }
 
     return TemplateResponse(request, 'grants/new.html', params)

--- a/app/retail/templates/emails/grants/support_cancellation.html
+++ b/app/retail/templates/emails/grants/support_cancellation.html
@@ -16,7 +16,7 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 {% endcomment %}
-{% load i18n static %}
+{% load i18n static grants_extra %}
 
 {% block content %}
 

--- a/app/retail/templates/emails/grants/support_cancellation.txt
+++ b/app/retail/templates/emails/grants/support_cancellation.txt
@@ -6,8 +6,6 @@
 
 {% trans "Thank you for everything you have contributed!" %}
 
-{{ grant.logo.url }}
-
 {{ grant.description }}
 
 {{ grant.percentage_done }}


### PR DESCRIPTION
This PR adds dynamic gas pricing to

- grants/new
- grants/fund
- grant/fund/cancel

Refs: https://github.com/gitcoinco/web/issues/3067

![untitled](https://user-images.githubusercontent.com/5358146/49702726-bffdc600-fc21-11e8-9dbf-f61b73e06862.gif)

Questions ( @owocki / @captnseagraves  ):
- where else does this need be added ? 
  (If yes for subscription -> we have 2 contract deployment, so we use the same gas price for both ?)
- should we be converting `gas` in [grantz](https://github.com/thelostone-mc/web/blob/gas_setting/app/assets/v2/js/grants/new.js#L82) to hex like in [bounties](https://github.com/gitcoinco/web/blob/master/app/assets/v2/js/pages/new_bounty.js#L424-L426)