### PR TITLE
tags exceeding profile page

### DIFF
--- a/app/assets/v2/css/dashboard.css
+++ b/app/assets/v2/css/dashboard.css
@@ -166,6 +166,7 @@ body {
 
 .tags {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .tags.fixed {


### PR DESCRIPTION
##### Description

without wrap tags are exceeding screen in certain situations making profile page not fully responsive

before:
![tags_before](https://user-images.githubusercontent.com/1838338/49751733-8030f000-fcae-11e8-955b-8fe8aea20087.png)

after:
![tags_after](https://user-images.githubusercontent.com/1838338/49751741-845d0d80-fcae-11e8-8ca1-9ff9c99f7352.png)

##### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] Read and conforms to the [contributor guidelines](https://docs.gitcoin.co/mk_contributors/)
- [x] Read and conforms to the [style guidelines](https://docs.gitcoin.co/mk_styleguide/)
- [x] Linter status: 100% pass
- [ ] Added relevant tests
- [ ] Tests pass and code coverage has not decreased
- [ ] Changes don't break existing behavior
- [x] Commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)
- [x] [Code documentation](https://docs.gitcoin.co/mk_contributors/#docstrings)
- [ ] Completed: Code review by core team and any requested changes

##### Affected core subsystem(s)

ui

###### Contributor

- [x] Read and followed the [Contributor Guidelines](https://docs.gitcoin.co/mk_contributors/)
- [x] Tested all changes **locally**
- [x] Verified existing functionality
- [] Ran `make test` and everything passed!

###### Reviewer

- [ ] Affirm contributor guidelines have been followed and requested changes made
- [ ] CI tests and linting pass
- [ ] No conflicts (migrations, files, etc)
- [ ] Regression tested against staging

###### Funder

- [ ] Validated requested changes were made to specification
- [ ] Bounty payout released to the contributor
