### PR TITLE
Remove redundant/secondary import of Profile and fix operator space in cleanup_dupe

### DIFF
--- a/app/dashboard/management/commands/cleanup_dupe_profiles.py
+++ b/app/dashboard/management/commands/cleanup_dupe_profiles.py
@@ -26,7 +26,7 @@ from dashboard.models import Profile
 def combine_profiles(p1, p2):
     # p2 is the delete profile, p1 is the save profile
     # switch if p2 has the user
-    # TODO: refactor to use https://github.com/mighty-justice/django-super-deduper 
+    # TODO: refactor to use https://github.com/mighty-justice/django-super-deduper
     # instead
     if p2.user:
         p1, p2 = p2, p1
@@ -103,7 +103,9 @@ class Command(BaseCommand):
             profile.handle = profile.handle.replace('@', '')
             profile.save()
 
-        dupes = Profile.objects.exclude(handle=None).annotate(handle_lower=Lower("handle")).values('handle_lower').annotate(handle_lower_count=Count('handle_lower')).filter(handle_lower_count__gt=1)
+        dupes = Profile.objects.exclude(handle=None).annotate(handle_lower=Lower("handle")) \
+            .values('handle_lower').annotate(handle_lower_count=Count('handle_lower')) \
+            .filter(handle_lower_count__gt=1)
         print(f" - {dupes.count()} dupes")
 
         for dupe in dupes:
@@ -116,9 +118,8 @@ class Command(BaseCommand):
         # For some reason, profiles keep getting set to hide_profile=True, even
         # when there's no form submissions on record for them.
         # this is a stopgap until we can figure out the root cause
-        from dashboard.models import Profile
         profiles = Profile.objects.filter(hide_profile=True, form_submission_records=[])
         for profile in profiles:
-            profile.hide_profile=False
+            profile.hide_profile = False
             profile.save()
             print(profile.handle)


### PR DESCRIPTION
##### Description

The goal of this PR is to remove a redundant import (while resolving the associated sentry error) and fix whitespace around an operator.

##### Checklist

- [x] Read and conforms to the [contributor guidelines](https://docs.gitcoin.co/mk_contributors/)
- [x] Read and conforms to the [style guidelines](https://docs.gitcoin.co/mk_styleguide/)
- [x] Linter status: 100% pass
- [x] Added relevant tests
- [x] Tests pass and code coverage has not decreased
- [x] Changes don't break existing behavior
- [x] Commit message follows [commit guidelines](https://docs.gitcoin.co/mk_contributors/#step-4-commit)
- [x] [Code documentation](https://docs.gitcoin.co/mk_contributors/#docstrings)
- [x] Completed: Code review by core team and any requested changes

##### Affected core subsystem(s)

management commands, profile

##### Refers/Fixes

Fix #3186 

##### Testing and Sign-off

###### Contributor

- [x] Read and followed the [Contributor Guidelines](https://docs.gitcoin.co/mk_contributors/)
- [x] Tested all changes **locally**
- [x] Verified existing functionality
- [x] Ran `make test` and everything passed!

###### Reviewer

- [x] Affirm contributor guidelines have been followed and requested changes made
- [x] CI tests and linting pass
- [x] No conflicts (migrations, files, etc)
- [ ] Regression tested against staging

