### PR TITLE
Updated URL for CodeFund to use .app

### DIFF
--- a/app/retail/templates/shared/top_nav.html
+++ b/app/retail/templates/shared/top_nav.html
@@ -22,7 +22,7 @@
     <img src="{% static "v2/images/top-bar/gitcoin-logo.svg" %}" height="22" alt="" class="d-md-block d-none" style="margin-bottom: 5px;">
     <img src="{% static "v2/images/top-bar/gitcoin-symbol.svg" %}" height="22" alt="" class="d-md-none">
   </a>
-  <a class="{% if request.path|matches:'^\/((codefund.*))$' %}selected{% endif %}" href="https://codefund.io/">
+  <a class="{% if request.path|matches:'^\/((codefund.*))$' %}selected{% endif %}" href="https://codefund.app/">
     <img src="{% static "v2/images/top-bar/codefund-logo.svg" %}" height="20" alt="" class="d-md-block d-none">
     <img src="{% static "v2/images/top-bar/codefund-symbol.svg" %}" height="20" alt="" class="d-md-none">
   </a>


### PR DESCRIPTION
The tophat currently shows the CodeFund URL as `.io` but should be `.app`