### PR TITLE
web3 wallet callout proof of concept

### DIFF
--- a/app/assets/onepager/js/send.js
+++ b/app/assets/onepager/js/send.js
@@ -281,6 +281,7 @@ function sendTip(email, github_url, from_name, username, amountInEth, comments_p
         };
 
         if (isSendingETH) {
+          prompt_for_web3_wallet_action();
           web3.eth.sendTransaction({
             to: destinationAccount,
             value: amountInWei,
@@ -290,10 +291,12 @@ function sendTip(email, github_url, from_name, username, amountInEth, comments_p
           var send_erc20 = function() {
             var token_contract = web3.eth.contract(token_abi).at(tokenAddress);
 
+            prompt_for_web3_wallet_action();
             token_contract.transfer(destinationAccount, amountInWei, {gasPrice: web3.toHex(get_gas_price())}, post_send_callback);
           };
           var send_gas_money_and_erc20 = function() {
             _alert({ message: gettext('You will now be asked to confirm two transactions.  The first is gas money, so your receipient doesnt have to pay it.  The second is the actual token transfer. (note: check Metamask extension, sometimes the 2nd confirmation window doesnt popup)') }, 'info');
+            prompt_for_web3_wallet_action();
             web3.eth.sendTransaction({
               to: destinationAccount,
               value: gas_money,

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -413,6 +413,7 @@ $(document).ready(function() {
 
         var eth_amount = isETH ? amount : 0;
         var _paysTokens = !isETH;
+        prompt_for_web3_wallet_action();
         var bountyIndex = bounty.issueAndActivateBounty(
           account, // _issuer
           mock_expire_date, // _deadline

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -413,6 +413,7 @@ $(document).ready(function() {
 
         var eth_amount = isETH ? amount : 0;
         var _paysTokens = !isETH;
+
         prompt_for_web3_wallet_action();
         var bountyIndex = bounty.issueAndActivateBounty(
           account, // _issuer

--- a/app/assets/v2/js/pages/tokens_settings.js
+++ b/app/assets/v2/js/pages/tokens_settings.js
@@ -45,6 +45,7 @@ $(document).ready(function() {
       if (error || result.toNumber() == 0) {
         var amount = 10 * 18 * 9999999999999999999999999999999999999999999999999999; // uint256
 
+        prompt_for_web3_wallet_action();
         token_contract.approve(
           to,
           amount,

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -34,7 +34,7 @@ var callFunctionWhenTransactionMined = function(txHash, f) {
  * Injects an element into the DOM which tells the user that there is a web3 action which requires their attention
  * Helps with UX of https://github.com/MetaMask/metamask-extension/issues/3759#issuecomment-456908970
  */
-var prompt_for_web3_wallet_action = function(){
+var prompt_for_web3_wallet_action = function() {
   var html = `
   <div id="metamask_arrow" style="position: fixed; top: 0px; right: 100px; width: 100px; color: #ff3232;">
     <svg width="10px" height="45px" viewBox="0 0 29 133" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -46,15 +46,16 @@ var prompt_for_web3_wallet_action = function(){
         Web3 action is pending.  Please check your web3 wallet ^
     </p>
   </div>
-  `;  
-  $("body").append(html);
-  setInterval(function(){
-    $( "#metamask_arrow" ).animate({'right': "105"}, 100).animate({'right': "100"}, 100)
+  `;
+
+  $('body').append(html);
+  setInterval(function() {
+    $('#metamask_arrow').animate({'right': '105'}, 100).animate({'right': '100'}, 100);
   }, 210);
-  setTimeout(function(){
-    $("#metamask_arrow").remove();
+  setTimeout(function() {
+    $('#metamask_arrow').remove();
   }, 4 * 1000);
-}
+};
 
 
 /**

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -30,6 +30,32 @@ var callFunctionWhenTransactionMined = function(txHash, f) {
   });
 };
 
+/**
+ * Injects an element into the DOM which tells the user that there is a web3 action which requires their attention
+ * Helps with UX of https://github.com/MetaMask/metamask-extension/issues/3759#issuecomment-456908970
+ */
+var prompt_for_web3_wallet_action = function(){
+  var html = `
+  <div id="metamask_arrow" style="position: fixed; top: 0px; right: 100px; width: 100px; color: #ff3232;">
+    <svg width="10px" height="45px" viewBox="0 0 29 133" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <path id="Line" d="M14.5,5.55111512e-17 L-1.77635684e-15,29 L29,29 L14.5,5.55111512e-17 Z M17,130.5 L17,26.5 L17,24 L12,24 L12,26.5 L12,130.5 L12,133 L17,133 L17,130.5 Z" fill="#ff3232" fill-rule="nonzero"></path>
+        </g>
+    </svg>
+    <p>
+        Web3 action is pending.  Please check your web3 wallet ^
+    </p>
+  </div>
+  `;  
+  $("body").append(html);
+  setInterval(function(){
+    $( "#metamask_arrow" ).animate({'right': "105"}, 100).animate({'right': "100"}, 100)
+  }, 210);
+  setTimeout(function(){
+    $("#metamask_arrow").remove();
+  }, 4 * 1000);
+}
+
 
 /**
  * Looks for web3.  Won't call the fucntion until its there


### PR DESCRIPTION
#  Why

Sometimes the metamask popup does not show up ( https://github.com/MetaMask/metamask-extension/issues/3759#issuecomment-456908970 )..  In this scenario, the user may click a button expecting a web3 action then think "WTF" when nothing happens.  After a little thinking and hunting around, they will see a little icon in their top right.  
<img width="74" alt="screen shot 2019-01-23 at 11 34 19 am" src="https://user-images.githubusercontent.com/513929/51628669-dd9d9b00-1f02-11e9-944c-03117070bb0f.png">
  But only after looking and even then its small

# Solution

I propose that any web3 action on our site create a callout in the top right asking the user to check their web3 wallet.

Here is a demo (make sure you keep your eye on the top right).

![screen recording 2019-01-23 at 11 32 am](https://user-images.githubusercontent.com/513929/51628636-c78fda80-1f02-11e9-8ac5-60c6a731fda6.gif)

# Testing

I have tested this on the tip flow, but still need to integrate it with all web3 actions on our site.  At that point, I can test it site wide.

# TODOS

* [ ] Achieve consensus on this being something we actually want to do.
* [ ] Make sure the design is 👍 
* [ ] Make sure the design on mobile is 👍 
* [ ] Integrate it everywher.
* [ ] Merge and ship.



