### PR TITLE
CVE-2019-6975 - Vulnerability of django < 2.1.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ bs4
 ccxt
 cryptocompare==0.6
 cryptography==2.3
-django==2.1.5
+django==2.1.6
 django-cors-headers==2.4.0
 django-filter==2.0.0
 django-ratelimit==1.1.0


### PR DESCRIPTION
### Why

As a user I want to use a secure tool that does not compromise any data it handles. (especially if we look forward to integrate private repositories).

### additional (github) info:
CVE-2019-6975 More information
moderate severity
Vulnerable versions: >= 2.1.0, < 2.1.6
Patched version: 2.1.6
Django 1.11.x before 1.11.19, 2.0.x before 2.0.11, and 2.1.x before 2.1.6 allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the django.utils.numberformat.format() function.

### Notes:
I do know we do not actively use django.utils.numberformat, but we cannot exclude the possibility anything else (like wagtail or a django extension) uses this function.
Better safe than sorry, right?

### Alerting staff:
@owocki  @PixelantDesign  @frankchen07  @vs77bb 
Please check @willsputra or @danlipert to ensure nothing breaks!

Thanks
Chris