### PR TITLE
dont check for sufficient funds on tips with ETH

### DIFF
--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -1556,6 +1556,10 @@ function check_balance_and_alert_user_if_not_enough(
   amount,
   msg = 'You do not have enough tokens to perform this action.') {
 
+  if (tokenAddress == "0x0" || tokenAddress == "0x0000000000000000000000000000000000000000") {
+    return;
+  }
+
   let token_contract = web3.eth.contract(token_abi).at(tokenAddress);
   let from = web3.eth.coinbase;
   let token_details = tokenAddressToDetails(tokenAddress);


### PR DESCRIPTION
Fix bug where ETH tips always returned insufficient funds