### PR TITLE
Check for auth on importing linkedin data

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1735,6 +1735,10 @@ def profile_job_opportunity(request, handle):
             status=401)
     try:
         profile = profile_helper(handle, True)
+        if request.user.profile.id != profile.id:
+            return JsonResponse(
+                {'error': 'Bad request'},
+                status=401)
         profile.job_search_status = request.POST.get('job_search_status', None)
         profile.show_job_status = request.POST.get('show_job_status', None) == 'true'
         profile.job_type = request.POST.get('job_type', None)

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1729,6 +1729,10 @@ def profile_job_opportunity(request, handle):
     Args:
         handle (str): The profile handle.
     """
+    if not request.user.is_authenticated:
+        return JsonResponse(
+            {'error': 'You must be authenticated via github to use this feature!'},
+            status=401)
     try:
         profile = profile_helper(handle, True)
         profile.job_search_status = request.POST.get('job_search_status', None)


### PR DESCRIPTION

##### Description

This PR checks if the user is authenticated before accepting the updated LinkedIn data for their job opportunity profile.

##### Refers/Fixes

This issue was referred to us by a security researcher.

##### Testing

After this change I am still able to update my own profile. If I change to change the profile handle in the URL I now receive a bad request error