### PR TITLE
#4484 - remove waffle.io references

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Issues in `gitcoin/web` are the primary means by which bug reports and
 general discussions are made. A contributor is allowed to create an issue,
 discuss, and provide a fix if needed.
 
-Before opening an issue, https://waffle.io/gitcoinco/web is a good place to go to see if there are any current issues with similar key words. This helps us cut down on duplicate tickets.
+Before opening an issue, check to see if there are any current issues with similar key words. This helps us cut down on duplicate tickets.
 
 When you [open an issue](https://github.com/gitcoinco/web), you'll notice four templates (bug, custom, discussion, feature) with the user-story format we like for our issue reports. When starting a new issue, please do your best to be as detailed and specific as possible.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,6 @@ Gitcoin Grows Open Source. Learn more at [https://gitcoin.co](https://gitcoin.co
 
 [![Build Status](https://travis-ci.org/gitcoinco/web.svg?branch=master)](https://travis-ci.org/gitcoinco/web)
 [![codecov](https://codecov.io/gh/gitcoinco/web/branch/master/graph/badge.svg)](https://codecov.io/gh/gitcoinco/web)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/gitcoinco/web.svg?columns=all)](https://waffle.io/gitcoinco/web)
 
 This is the website that is live at [gitcoin.co](https://gitcoin.co)
 ```master``` branch - staging


### PR DESCRIPTION
##### Description
Waffle.io has shut down. There are references. References to dead links are bad.

##### Refers/Fixes
Fixes #4484 

##### Testing
Check Github README