### PR TITLE
fix spoofing email sender on bounty invite

### DIFF
--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -592,7 +592,7 @@ def funder_payout_reminder(to_email, bounty, github_username, live):
 def share_bounty(emails, msg, profile, invite_url=None, kudos_invite=False):
     for email in emails:
         to_email = email
-        from_email = profile.email
+        from_email = settings.CONTACT_EMAIL
         subject = "You have been invited to work on a bounty."
         html, text = render_share_bounty(to_email, msg, profile, invite_url, kudos_invite)
         send_mail(


### PR DESCRIPTION

##### Description

Share bounty/invite user to bounty emails currently put the user who invited's email address as the sender, which is basically spoofing as them. This is bad for many reasons, but mostly it lowers our email reputation.

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/4545

##### Testing

Untested