### PR TITLE
api results speed down from 1.5s to 0.4s

### DIFF
--- a/app/assets/v2/js/pages/dashboard.js
+++ b/app/assets/v2/js/pages/dashboard.js
@@ -291,7 +291,7 @@ var removeFilter = function(key, value) {
 };
 
 var get_search_URI = function(offset, order) {
-  var uri = '/api/v0.1/bounties/?';
+  var uri = '/api/v0.1/bounties/slim/?';
   var keywords = '';
   var org = '';
 

--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -1229,7 +1229,7 @@ function renderBountyRowsFromResults(results, renderForExplorer) {
     } else {
       result['hidden'] = (i > 4);
     }
-
+    
     html += tmpl.render(result);
   }
   return html;

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -329,6 +329,14 @@ class Bounty(SuperModel):
         super().save(*args, **kwargs)
 
     @property
+    def latest_activity(self):
+        activity = Activity.objects.filter(bounty=self.pk).order_by('-pk')
+        if activity.exists():
+            from dashboard.router import ActivitySerializer
+            return ActivitySerializer(activity.first()).data
+        return None
+
+    @property
     def profile_pairs(self):
         profile_handles = []
 

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -176,6 +176,19 @@ class BountySerializer(serializers.HyperlinkedModelSerializer):
         return bounty
 
 
+class BountySerializerSlim(BountySerializer):
+
+
+    class Meta:
+        """Define the bounty serializer metadata."""
+        model = Bounty
+        fields = (
+            'url', 'title', 'experience_level', 'status', 'fulfillment_accepted_on',
+            'fulfillment_started_on', 'fulfillment_submitted_on', 'canceled_on', 'web3_created', 'bounty_owner_address',
+            'avatar_url', 'network', 'standard_bounties_id', 'github_org_name', 'interested', 'token_name', 'value_in_usdt',
+            'keywords', 'value_in_token', 'project_type', 'is_open', 'expires_date'
+        )
+
 class BountyViewSet(viewsets.ModelViewSet):
     """Handle the Bounty view behavior."""
     queryset = Bounty.objects.prefetch_related('fulfillments', 'interested', 'interested__profile', 'activities', 'unsigned_nda') \
@@ -379,6 +392,12 @@ class BountyViewSet(viewsets.ModelViewSet):
         return queryset
 
 
+class BountyViewSetSlim(BountyViewSet):
+    queryset = Bounty.objects.all().order_by('-web3_created')
+    serializer_class = BountySerializerSlim
+
+
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
+router.register(r'bounties/slim', BountyViewSetSlim)
 router.register(r'bounties', BountyViewSet)

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -186,7 +186,7 @@ class BountySerializerSlim(BountySerializer):
             'url', 'title', 'experience_level', 'status', 'fulfillment_accepted_on',
             'fulfillment_started_on', 'fulfillment_submitted_on', 'canceled_on', 'web3_created', 'bounty_owner_address',
             'avatar_url', 'network', 'standard_bounties_id', 'github_org_name', 'interested', 'token_name', 'value_in_usdt',
-            'keywords', 'value_in_token', 'project_type', 'is_open', 'expires_date'
+            'keywords', 'value_in_token', 'project_type', 'is_open', 'expires_date', 'latest_activity'
         )
 
 class BountyViewSet(viewsets.ModelViewSet):

--- a/app/dashboard/templates/shared/bounty-popover.html
+++ b/app/dashboard/templates/shared/bounty-popover.html
@@ -48,15 +48,4 @@
       [[if expired !== ""]]<i class="far fa-clock expired-icon"></i>[[/if]][[:expired]]
     </div>
   </div>
-  [[if activities.length]]
-    <div class="popover-bounty__footer">
-      <span class="title">{% trans "Latest Activity" %}</span>
-      [[for activities.slice(-1)  ]]
-        <div class="d-flex justify-content-between">
-          <span>[[activitytext:activity_type]] {% trans "by" %} <b>[[:profile.handle]]</b></span>
-          <span>[[timedifference:created]]</span>
-        </div>
-      [[/for]]
-    </div>
-  [[/if]]
 </div>

--- a/app/dashboard/templates/shared/bounty-popover.html
+++ b/app/dashboard/templates/shared/bounty-popover.html
@@ -48,4 +48,13 @@
       [[if expired !== ""]]<i class="far fa-clock expired-icon"></i>[[/if]][[:expired]]
     </div>
   </div>
+  [[if latest_activity]]
+    <div class="popover-bounty__footer">
+      <span class="title">{% trans "Latest Activity" %}</span>
+        <div class="d-flex justify-content-between">
+          <span>[[activitytext:latest_activity.activity_type]] {% trans "by" %} <b>[[:latest_activity.profile.handle]]</b></span>
+          <span>[[timedifference:latest_activity.created]]</span>
+        </div>
+    </div>
+  [[/if]]
 </div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR takes the explorer lazy load time from

```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % time curl "http://localhost:8000/api/v0.1/bounties/?bounty_owner_github_username=owocki&network=mainnet&idx_status=open&order_by=-featuring_date&offset=10&limit=5" > /dev/null
curl  > /dev/null  0.01s user 0.01s system 0% cpu 1.747 total
```
```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % time curl "http://localhost:8000/api/v0.1/bounties/slim/?bounty_owner_github_username=owocki&network=mainnet&idx_status=open&order_by=-featuring_date&offset=10&limit=5" > /dev/null
curl  > /dev/null  0.01s user 0.01s system 4% cpu 0.459 total
```

by creating a new route at `http://localhost:8000/api/v0.1/bounties/slim/` that loads ONLY what is needed to load the /explorer results in a performant way.

(EDIT - re-added this) note that i had to cut the `activities` from the response because those were making the results way slow.  luckily the `activities` were not really needed to render the result in the explorer.  a further PR down the line could re-enable this by calling an API when the popover is triggered.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://github.com/gitcoinco/web/issues/4538
https://github.com/gitcoinco/web/issues/3628

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally