### PR TITLE
Subscription email fix

### DIFF
--- a/app/assets/v2/js/grants/fund.js
+++ b/app/assets/v2/js/grants/fund.js
@@ -198,6 +198,7 @@ $(document).ready(function() {
             console.log('1', error);
             _alert({ message: gettext('Your approval transaction failed. Please try again.')}, 'error');
           }).on('transactionHash', function(transactionHash) {
+            $('#sub_new_approve_tx_id').val(transactionHash);
             if (data.num_periods == 1) {
               // call splitter after approval
               splitPayment(accounts[0], data.admin_address, gitcoinDonationAddress, Number(grant_amount * Math.pow(10, decimals)).toLocaleString('fullwide', {useGrouping: false}), Number(gitcoin_grant_amount * Math.pow(10, decimals)).toLocaleString('fullwide', {useGrouping: false}));
@@ -243,7 +244,6 @@ $(document).ready(function() {
 const subscribeToGrant = (transactionHash) => {
   web3.eth.getAccounts(function(err, accounts) {
     deployedToken.methods.decimals().call(function(err, decimals) {
-      $('#sub_new_approve_tx_id').val(transactionHash);
       const linkURL = etherscan_tx_url(transactionHash);
       let token_address = $('#js-token').length ? $('#js-token').val() : $('#sub_token_address').val();
       let data = {

--- a/app/grants/management/commands/subminer.py
+++ b/app/grants/management/commands/subminer.py
@@ -65,6 +65,12 @@ def process_subscription(subscription, live):
         elif not has_approve_tx_mined:
             logger.info(f"   -- ( NOT ready via approve tx, will be ready when {subscription.new_approve_tx_id} mines) ")
         else:
+            if subscription.contributor_signature == "onetime":
+                subscription.error = True
+                subscription.subminer_comments = "One time subscription"
+                subscription.save()
+                logger.info('skipping one time subscription: %s' % subscription.id)
+                return
             web3_hash_arguments = subscription.get_subscription_hash_arguments()
             if web3_hash_arguments['periodSeconds'] < METATX_FREE_INTERVAL_SECONDS and web3_hash_arguments['gasPrice'] <= METATX_GAS_PRICE_THRESHOLD:
                 subscription.error = True


### PR DESCRIPTION
##### Description

This PR properly sets the approval transaction hash for grant subscriptions. When this field is missing, the finalization of a subscription or one-time donation in our database fails and defaults to the first subscription made after the updated grants code was deployed. This subscription was mine since it has an empty value, and each donation made afterwards synced with my donation, hence the emails going out saying I contributed 1 DAI.

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/4577

##### Testing

Tested locally