### PR TITLE
fix wording for one-time contribution

### DIFF
--- a/app/grants/templates/grants/fund.html
+++ b/app/grants/templates/grants/fund.html
@@ -230,7 +230,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     {% trans "You are additionally contributing" %}
                     <span class="summary-gitcoin-amount font-weight-bold">-</span>
                     <span class="summary-token font-weight-bold"></span>
-                    {% trans "to the gitcoin grant." %}
+                    {% trans "to the gitcoin maintainer grant." %}
                   </p>
 
                   <p class="hide_if_recurring hidden">


### PR DESCRIPTION
adds "maintainer" language describing optional gitcoin grant donation