### PR TITLE
sentry: Quill not defined

### DIFF
--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
     );
   }, 1000);
 
-  let _text = grant_description.getContents();
+  let _text = grant_description ? grant_description.getContents() : null;
 
   userSearch('#grant-admin', false, undefined, false, false, true);
   userSearch('#grant-members', false, undefined, false, false, true);
@@ -64,8 +64,8 @@ $(document).ready(function() {
     let edit_title = $('#form--input__title').val();
     let edit_reference_url = $('#form--input__reference-url').val();
     let edit_admin_profile = $('#grant-admin option').last().text();
-    let edit_description = grant_description.getText();
-    let edit_description_rich = JSON.stringify(grant_description.getContents());
+    let edit_description = grant_description ? grant_description.getText() : null;
+    let edit_description_rich = grant_description ? JSON.stringify(grant_description.getContents()) : null;
     let edit_amount_goal = $('#amount_goal').val();
     let edit_grant_members = $('#grant-members').val();
 

--- a/app/grants/templates/grants/detail/index.html
+++ b/app/grants/templates/grants/detail/index.html
@@ -85,6 +85,26 @@
       $.fn.runTooltip = bootstrapTooltip;
       $('[data-toggle="tooltip"]').runTooltip();
       $.fn.modal.noConflict();
+
+    let grant_description;
+    if($('#editor').length) {
+      {% if is_admin and not grant_is_inactive %}
+          grant_description = new Quill('#editor', {
+          theme: 'snow',
+        });
+        grant_description.enable(false);
+      {% else %}
+        grant_description = new Quill('#editor', {
+          theme: 'bubble',
+          readOnly: true,
+        });
+      {% endif %}
+
+      let desc = JSON.parse(grant_description.getContents().ops[0].insert);
+      if (desc.ops) {
+        grant_description.setContents(desc);
+      }
+    }
   </script>
   <script src="{% static "v2/js/user-search.js" %}"></script>
   <script src="{% static "v2/js/grants/shared.js" %}"></script>

--- a/app/grants/templates/grants/detail/tabs.html
+++ b/app/grants/templates/grants/detail/tabs.html
@@ -94,23 +94,3 @@
     
   </div>
 </div>
-
-<script>
-  let grant_description;
-  {% if is_admin and not grant_is_inactive %}
-      grant_description = new Quill('#editor', {
-      theme: 'snow',
-    });
-    grant_description.enable(false);
-  {% else %}
-    grant_description = new Quill('#editor', {
-      theme: 'bubble',
-      readOnly: true,
-    });
-  {% endif %}
-
-  let desc = JSON.parse(grant_description.getContents().ops[0].insert);
-  if (desc.ops) {
-    grant_description.setContents(desc);
-  }
-</script>


### PR DESCRIPTION
##### Description

so when you switch tabs on grants  -> owocki added a change where page gets reloaded and only that particular tab content would get rendered in the HTML

So when you go to any other tab except description -> Quill tries to find the root element to which is gets instantiated with ->  which is never found in the generated HTML

##### Testing

Tested locally 
- still can update the description 
- the error disappears from the console
