### PR TITLE
Load codefund weekly roundup sponsor context via API

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -487,6 +487,7 @@ EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')  # TODO
 EMAIL_PORT = env.int('EMAIL_PORT', default=587)
 EMAIL_USE_TLS = env.bool('EMAIL_USE_TLS', default=True)
 SERVER_EMAIL = env('SERVER_EMAIL', default='server@TODO.co')
+CODEFUND_NEWSLETTER_URL = env('CODEFUND_NEWSLETTER_URL', default=None)
 
 # ENS Subdomain Settings
 # The value of ENS_LIMIT_RESET_DAYS should be higher since only one transaction is allowed per user.

--- a/app/marketing/tests/management/commands/test_roundup.py
+++ b/app/marketing/tests/management/commands/test_roundup.py
@@ -66,3 +66,18 @@ class TestRoundup(TestCase):
         assert mock_weekly_roundup.call_count == 1
 
         mock_weekly_roundup.assert_called_once_with(['jackson@bar.com'])
+
+    @patch('time.sleep')
+    @patch('retail.emails.requests')
+    @patch('marketing.management.commands.roundup.weekly_roundup')
+    def test_codefund_sponsor_local_context(self, mock_weekly_roundup, requests, *args):
+        Command().handle(exclude_startswith=None, filter_startswith=None, start_counter=0, live=False)
+        assert requests.call_count == 0
+
+    @patch('time.sleep')
+    @patch('retail.emails.requests')
+    @patch('marketing.management.commands.roundup.weekly_roundup')
+    def test_codefund_sponsor_api_context(self, mock_weekly_roundup, requests, *args):
+        with self.settings(CODEFUND_NEWSLETTER_URL='http://www.example.com'):
+            Command().handle(exclude_startswith=None, filter_startswith=None, start_counter=0, live=False)
+            assert requests.call_count == 1

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -993,16 +993,24 @@ Back to shipping,
         'link_copy': 'View more',
     }, ]
 
-    sponsor = {
-        'name': 'Blockchain Job Kit',
-        'title': 'Blockchain Developer Job Kit',
-        'image_url': 'https://s3.us-west-2.amazonaws.com/gitcoin-static/jDSk7ZTfpY19PWdwwsk8puNd.png',
-        'link': 'http://bit.ly/EthDevKit',
-        'cta': 'View now',
-        'body': [
-            'Blockchain Developer Job Kit - See who’s hiring, salary info, and dev skills required'
-        ]
-    }
+    sponsor_response = (requests.get(settings.CODEFUND_NEWSLETTER_URL)
+                        if settings.CODEFUND_NEWSLETTER_URL
+                        else None)
+    if sponsor_response and sponsor_response.status_code = 200:
+        print('loading newsletter sponsor data from codefund servers')
+        sponsor = sponsor_response.json()
+    else:
+        print('using local sponsor data')
+        sponsor = {
+            'name': 'Blockchain Job Kit',
+            'title': 'Blockchain Developer Job Kit',
+            'image_url': 'https://s3.us-west-2.amazonaws.com/gitcoin-static/jDSk7ZTfpY19PWdwwsk8puNd.png',
+            'link': 'http://bit.ly/EthDevKit',
+            'cta': 'View now',
+            'body': [
+                'Blockchain Developer Job Kit - See who’s hiring, salary info, and dev skills required'
+            ]
+        }
 
     bounties_spec = [{
         'url': 'https://github.com/knocte/udtRs/issues/1',

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -32,6 +32,7 @@ from django.utils.translation import gettext as _
 
 import cssutils
 import premailer
+import requests
 from grants.models import Contribution, Grant, Subscription
 from marketing.models import LeaderboardRank
 from marketing.utils import get_or_save_email_subscriber
@@ -996,7 +997,7 @@ Back to shipping,
     sponsor_response = (requests.get(settings.CODEFUND_NEWSLETTER_URL)
                         if settings.CODEFUND_NEWSLETTER_URL
                         else None)
-    if sponsor_response and sponsor_response.status_code = 200:
+    if sponsor_response and sponsor_response.status_code == 200:
         print('loading newsletter sponsor data from codefund servers')
         sponsor = sponsor_response.json()
     else:


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This change to the rendering of the weekly roundup allows for an optional settings entry for a URL that will return the appropriate context data for the codefund sponsor in the weekly roundup email. This will make it easier for the newsletter data to be incorporated.

##### Refers/Fixes

Discussed with @coderberry as a result of our weekly sync discussions

##### Testing

Not yet tested