### PR TITLE
sync mail every 2 hours to match script

### DIFF
--- a/scripts/crontab
+++ b/scripts/crontab
@@ -43,7 +43,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 
 
 ## GITCOIN MARKETING
-30 */6 * * * cd gitcoin/coin; bash scripts/run_management_command.bash sync_mail  >> /var/log/gitcoin/sync_mail.log  2>&1
+30 */2 * * * cd gitcoin/coin; bash scripts/run_management_command.bash sync_mail  >> /var/log/gitcoin/sync_mail.log  2>&1
 35 14 * * 1,6 cd gitcoin/coin; bash scripts/run_management_command.bash remarket_bounties  >> /var/log/gitcoin/remarket_bounties.log  2>&1
 35 11 * * 0,4 cd gitcoin/coin; bash scripts/run_management_command.bash remarket_bounties  >> /var/log/gitcoin/remarket_bounties.log  2>&1
 45 10 * * * cd gitcoin/coin; bash scripts/run_management_command.bash expiration  >> /var/log/gitcoin/expiration_bounty.log  2>&1


### PR DESCRIPTION
##### Description

This change to the cron schedule matches the sync_mail job timing to the timing in the script itself (syncing new users from the last 2 hours here: https://github.com/gitcoinco/web/blob/master/app/marketing/management/commands/sync_mail.py#L121)

This issue was discovered when we noted our mailchimp audience list contains about half the actual user count from our platform - since the cronjob syncs new users from the database every 6 hours, and script only looks at users from the last 2 hours, we were missing 2/3 new users. The remaining 1/6 likely came from Sumo

##### Testing

Will monitor production infrastructure metrics one deployed