### PR TITLE
 Fix tests failing in master

### DIFF
--- a/app/marketing/tests/management/commands/test_assemble_leaderboards.py
+++ b/app/marketing/tests/management/commands/test_assemble_leaderboards.py
@@ -155,11 +155,10 @@ class TestAssembleLeaderboards(TestCase):
     def test_bounty_index_terms(self):
         """Test bounty index terms list."""
         index_terms = bounty_index_terms(self.bounty)
-        print(index_terms)
         assert len(index_terms) == 15
         assert 'USDT' in index_terms
         assert set({self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco'}).issubset(set(index_terms))
-        assert set({'Cuyahoga Falls', 'United States', 'North America'}).issubset(set(index_terms))
+        assert set({'Tallmadge', 'United States', 'North America'}).issubset(set(index_terms))
         assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
         assert set({'Australia', 'Oceania'}).issubset(set(index_terms))
         assert set({'python', 'shell'}).issubset(set(index_terms))
@@ -171,7 +170,7 @@ class TestAssembleLeaderboards(TestCase):
         assert len(index_terms) == 10
         assert 'USDT' in index_terms
         assert set([self.tip_payer_handle, self.tip_earner_handle, 'gitcoinco']).issubset(set(index_terms))
-        assert set({'Cuyahoga Falls', 'United States', 'North America'}).issubset(set(index_terms))
+        assert set({'Tallmadge', 'United States', 'North America'}).issubset(set(index_terms))
         assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
 
     def test_sum_bounties_payer(self):

--- a/app/marketing/tests/management/commands/test_assemble_leaderboards.py
+++ b/app/marketing/tests/management/commands/test_assemble_leaderboards.py
@@ -157,11 +157,11 @@ class TestAssembleLeaderboards(TestCase):
         index_terms = bounty_index_terms(self.bounty)
         assert len(index_terms) == 15
         assert 'USDT' in index_terms
-        assert set({self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco'}).issubset(set(index_terms))
-        assert set({'Tallmadge', 'United States', 'North America'}).issubset(set(index_terms))
-        assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
-        assert set({'Australia', 'Oceania'}).issubset(set(index_terms))
-        assert set({'python', 'shell'}).issubset(set(index_terms))
+        assert {self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco'}.issubset(set(index_terms))
+        assert {'Tallmadge', 'United States', 'North America'}.issubset(set(index_terms))
+        assert {'London', 'United Kingdom', 'Europe'}.issubset(set(index_terms))
+        assert {'Australia', 'Oceania'}.issubset(set(index_terms))
+        assert {'python', 'shell'}.issubset(set(index_terms))
 
     def test_tip_index_terms(self):
         """Test tip index terms list."""
@@ -169,9 +169,9 @@ class TestAssembleLeaderboards(TestCase):
 
         assert len(index_terms) == 10
         assert 'USDT' in index_terms
-        assert set([self.tip_payer_handle, self.tip_earner_handle, 'gitcoinco']).issubset(set(index_terms))
-        assert set({'Tallmadge', 'United States', 'North America'}).issubset(set(index_terms))
-        assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
+        assert {self.tip_payer_handle, self.tip_earner_handle, 'gitcoinco'}.issubset(set(index_terms))
+        assert {'Tallmadge', 'United States', 'North America'}.issubset(set(index_terms))
+        assert {'London', 'United Kingdom', 'Europe'}.issubset(set(index_terms))
 
     def test_sum_bounties_payer(self):
         """Test sum bounties leaderboards."""

--- a/app/marketing/tests/management/commands/test_assemble_leaderboards.py
+++ b/app/marketing/tests/management/commands/test_assemble_leaderboards.py
@@ -155,6 +155,7 @@ class TestAssembleLeaderboards(TestCase):
     def test_bounty_index_terms(self):
         """Test bounty index terms list."""
         index_terms = bounty_index_terms(self.bounty)
+        print(index_terms)
         assert len(index_terms) == 15
         assert 'USDT' in index_terms
         assert set({self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco'}).issubset(set(index_terms))

--- a/app/marketing/tests/management/commands/test_assemble_leaderboards.py
+++ b/app/marketing/tests/management/commands/test_assemble_leaderboards.py
@@ -157,11 +157,11 @@ class TestAssembleLeaderboards(TestCase):
         index_terms = bounty_index_terms(self.bounty)
         assert len(index_terms) == 15
         assert 'USDT' in index_terms
-        assert set([self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco']).issubset(set(index_terms))
-        assert set(['Cuyahoga Falls', 'United States', 'North America']).issubset(set(index_terms))
-        assert set(['London', 'United Kingdom', 'Europe']).issubset(set(index_terms))
-        assert set(['Australia', 'Oceania']).issubset(set(index_terms))
-        assert set(['python', 'shell']).issubset(set(index_terms))
+        assert set({self.bounty_payer_handle, self.bounty_earner_handle, 'gitcoinco'}).issubset(set(index_terms))
+        assert set({'Cuyahoga Falls', 'United States', 'North America'}).issubset(set(index_terms))
+        assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
+        assert set({'Australia', 'Oceania'}).issubset(set(index_terms))
+        assert set({'python', 'shell'}).issubset(set(index_terms))
 
     def test_tip_index_terms(self):
         """Test tip index terms list."""
@@ -170,8 +170,8 @@ class TestAssembleLeaderboards(TestCase):
         assert len(index_terms) == 10
         assert 'USDT' in index_terms
         assert set([self.tip_payer_handle, self.tip_earner_handle, 'gitcoinco']).issubset(set(index_terms))
-        assert set(['Cuyahoga Falls', 'United States', 'North America']).issubset(set(index_terms))
-        assert set(['London', 'United Kingdom', 'Europe']).issubset(set(index_terms))
+        assert set({'Cuyahoga Falls', 'United States', 'North America'}).issubset(set(index_terms))
+        assert set({'London', 'United Kingdom', 'Europe'}).issubset(set(index_terms))
 
     def test_sum_bounties_payer(self):
         """Test sum bounties leaderboards."""

--- a/app/marketing/tests/test_marketing_utils.py
+++ b/app/marketing/tests/test_marketing_utils.py
@@ -50,6 +50,8 @@ class MarketingEmailUtilsTest(TestCase):
 
     def setUp(self):
         """Perform setup for the testcase."""
+        test_es = EmailSubscriber.objects.all().delete()
+
         EmailSubscriber.objects.create(
             email='emailSubscriber1@gitcoin.co',
             source='mysource',


### PR DESCRIPTION
##### Description

Fixes tests failures in master

##### Refers/Fixes

Fixes 2 issues - 1) the old grants test left EmailSubscriber objects in the database, breaking a later test. 2) The GeoIP database we use updated the entry for one of the IP addresses in our tests from Cuyahoga Falls to Tallmadge, another city 5 km away. Great. ;P

##### Testing

The tests now pass