### PR TITLE
improves profile speed by moving the activity tab into lazy load

### DIFF
--- a/app/assets/v2/js/pages/profile.js
+++ b/app/assets/v2/js/pages/profile.js
@@ -34,12 +34,12 @@ $(document).ready(function() {
 
     if (ignoreScrollOffset || window.scrollY >= tabSection.scrollHeight) {
       const activityName = activityContainer.id;
-      let page = parseInt(activityContainer.getAttribute('page')) || 1;
+      let page = parseInt(activityContainer.getAttribute('page')) || 0;
 
       fetchInProgress = true;
       loadingImg.className = loadingImg.className.replace('hidden', 'visible');
 
-      fetch(location.href.replace(location.hash, '') + '?p=' + (++page) + '&a=' + activityName).then(
+      fetch(location.href.replace(location.hash, '') + '?p=' + (page++) + '&a=' + activityName).then(
         function(response) {
           if (response.status === 200) {
             response.text().then(

--- a/app/assets/v2/js/pages/profile.js
+++ b/app/assets/v2/js/pages/profile.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
       fetchInProgress = true;
       loadingImg.className = loadingImg.className.replace('hidden', 'visible');
 
-      fetch(location.href.replace(location.hash, '') + '?p=' + (page++) + '&a=' + activityName).then(
+      fetch(location.href.replace(location.hash, '') + '?p=' + (++page) + '&a=' + activityName).then(
         function(response) {
           if (response.status === 200) {
             response.text().then(

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -262,10 +262,12 @@
                     <div class="container">
                       <div class="row mb-3 p-2">
                         <div id="{{ tab.id }}" class="col-12 activities" count="{{ tab.count }}">
-                          {% if tab.type == 'activity' %}
-                            {% include 'profiles/profile_activities.html' with activities=tab.objects %}
-                          {% else %}
-                            {% include 'profiles/profile_bounties.html' with bounties=tab.objects %}
+                          {% if show_activity %}
+                            {% if tab.type == 'activity' %}
+                              {% include 'profiles/profile_activities.html' with activities=tab.objects %}
+                            {% else %}
+                              {% include 'profiles/profile_bounties.html' with bounties=tab.objects %}
+                            {% endif %}
                           {% endif %}
                         </div>
                       </div>

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2074,6 +2074,7 @@ def profile(request, handle):
             }
 
             return JsonResponse(msg, status=msg.get('status', 200))
+    context['show_activity'] = request.GET.get('p', None)
     return TemplateResponse(request, 'profiles/profile.html', context, status=status)
 
 

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2074,7 +2074,7 @@ def profile(request, handle):
             }
 
             return JsonResponse(msg, status=msg.get('status', 200))
-    context['show_activity'] = request.GET.get('p', None)
+    context['show_activity'] = request.GET.get('p', False) != False
     return TemplateResponse(request, 'profiles/profile.html', context, status=status)
 
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
improves profile speed by moving the activity tab into lazy load

this is driven by an analysis on my local that shows that for profile/owocki , the activity tab is the slowest thing to load on the page (currently takes 5s to load, 2.2s is from activity tab)

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://github.com/gitcoinco/web/issues/4620

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
tested locally

### with a warmed cache:

BEFORE THIS CHANGE:
```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % time curl "http://localhost:8000/profile/owocki" > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  122k  100  122k    0     0   100k      0  0:00:01  0:00:01 --:--:--  100k
curl "http://localhost:8000/profile/owocki" > /dev/null  0.01s user 0.01s system 1% cpu 1.242 total
```

AFTER THIS CHANGE:
```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % !time      (git)-[kevin/profile_speed_2] :
time curl "http://localhost:8000/profile/owocki" > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 69145  100 69145    0     0   103k      0 --:--:-- --:--:-- --:--:--  103k
curl "http://localhost:8000/profile/owocki" > /dev/null  0.01s user 0.01s system 2% cpu 0.666 total
```


### with a cold cache:

BEFORE THIS CHANGE:
```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % time curl "http://localhost:8000/profile/owocki" > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 69145  100 69145    0     0  10760      0  0:00:06  0:00:06 --:--:-- 16423
curl "http://localhost:8000/profile/owocki" > /dev/null  0.01s user 0.02s system 0% cpu 6.459 total
```

AFTER THIS CHANGE:
```
kevinowocki@local /Users/kevinowocki/Sites/gitcoin/web~ % time curl "http://localhost:8000/profile/owocki" > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 69145  100 69145    0     0  20877      0  0:00:03  0:00:03 --:--:-- 20883
curl "http://localhost:8000/profile/owocki" > /dev/null  0.01s user 0.02s system 0% cpu 3.342 total
```
