### PR TITLE
bug: fix grant owner address etherscan link

### DIFF
--- a/app/assets/v2/js/abi.js
+++ b/app/assets/v2/js/abi.js
@@ -46,21 +46,27 @@ var kudos_address = function() {
   }
 };
 
-var etherscan_tx_url = function(txid, network) {
+/**
+ * Returns etherscan link of transaction /
+ * @param {string} id
+ * @param {string} network
+ * @param {enum} type tx | address
+ */
+var get_etherscan_url = function(id, network, type = 'tx') {
   let _network = network ? network : document.web3network;
   switch (_network) {
     case 'mainnet':
-      return 'https://etherscan.io/tx/' + txid;
+      return 'https://etherscan.io/' + type + '/' + id;
     case 'ropsten':
-      return 'https://ropsten.etherscan.io/tx/' + txid;
+      return 'https://ropsten.etherscan.io/' + type + '/' + id;
     case 'kovan':
-      return 'https://kovan.etherscan.io/tx/' + txid;
+      return 'https://kovan.etherscan.io/'  + type + '/' + id;
     case 'rinkeby':
-      return 'https://rinkeby.etherscan.io/tx/' + txid;
+      return 'https://rinkeby.etherscan.io/' + type + '/' + id;
     case 'custom network':
-      return 'https://localhost/tx/' + txid;
+      return 'https://localhost/' + type + '/' + id;
     default:
-      return 'https://etherscan.io/tx/' + txid;
+      return 'https://etherscan.io/' + type + '/' + id;
   }
 };
 

--- a/app/assets/v2/js/grants/cancel_subscription.js
+++ b/app/assets/v2/js/grants/cancel_subscription.js
@@ -40,7 +40,7 @@ $(document).ready(() => {
           deployedToken.methods.approve(data.contract_address, web3.utils.toTwosComplement(0)).send({from: accounts[0], gasPrice: realGasPrice})
             .on('transactionHash', function(transactionHash) {
               $('#sub_end_approve_tx_id').val(transactionHash);
-              const linkURL = etherscan_tx_url(transactionHash);
+              const linkURL = get_etherscan_url(transactionHash);
 
               document.issueURL = linkURL;
               $('#transaction_url').attr('href', linkURL);

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -143,7 +143,7 @@ $(document).ready(function() {
             gasPrice: web3.utils.toHex($('#gasPrice').val() * Math.pow(10, 9))
           }).on('transactionHash', function(transactionHash) {
             grant_cancel_tx_id = $('#grant_cancel_tx_id').val();
-            const linkURL = etherscan_tx_url(transactionHash);
+            const linkURL = get_etherscan_url(transactionHash);
 
             document.issueURL = linkURL;
             $('#transaction_url').attr('href', linkURL);
@@ -182,7 +182,7 @@ $(document).ready(function() {
         from: accounts[0],
         gasPrice: 8000000000
       }).on('transactionHash', function(transactionHash) {
-        const linkURL = etherscan_tx_url(transactionHash);
+        const linkURL = get_etherscan_url(transactionHash);
 
         document.issueURL = linkURL;
         $('#transaction_url').attr('href', linkURL);

--- a/app/assets/v2/js/grants/fund.js
+++ b/app/assets/v2/js/grants/fund.js
@@ -262,7 +262,7 @@ const donationPayment = (token, account, donationAmountString) => {
 const subscribeToGrant = (transactionHash) => {
   web3.eth.getAccounts(function(err, accounts) {
     deployedToken.methods.decimals().call(function(err, decimals) {
-      const linkURL = etherscan_tx_url(transactionHash);
+      const linkURL = get_etherscan_url(transactionHash);
       let token_address = $('#js-token').length ? $('#js-token').val() : $('#sub_token_address').val();
       let data = {
         'contributor_address': $('#contributor_address').val(),
@@ -393,7 +393,7 @@ const splitPayment = (account, toFirst, toSecond, valueFirst, valueSecond) => {
       window.location = redirectURL;
     });
 
-    const linkURL = etherscan_tx_url(transactionHash);
+    const linkURL = get_etherscan_url(transactionHash);
 
     document.issueURL = linkURL;
 

--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -39,7 +39,7 @@ $(document).ready(() => {
 
 const etherscanUrlConvert = (elem, network) => {
   elem.each(function() {
-    $(this).attr('href', etherscan_tx_url($(this).attr('href'), network));
+    $(this).attr('href', get_etherscan_url($(this).attr('href'), network));
   });
 };
 

--- a/app/assets/v2/js/grants/new.js
+++ b/app/assets/v2/js/grants/new.js
@@ -149,7 +149,7 @@ const init = () => {
           }).on('transactionHash', function(transactionHash) {
             console.log('2', transactionHash);
             $('#transaction_hash').val(transactionHash);
-            const linkURL = etherscan_tx_url(transactionHash);
+            const linkURL = get_etherscan_url(transactionHash);
             let file = $('#img-project')[0].files[0];
             let formData = new FormData();
 

--- a/app/assets/v2/js/pages/bounty_details.js
+++ b/app/assets/v2/js/pages/bounty_details.js
@@ -512,7 +512,7 @@ var showWarningMessage = function(txid) {
   if (typeof txid != 'undefined' && txid.indexOf('0x') != -1) {
     waitforWeb3(function() {
       clearInterval(interval);
-      var link_url = etherscan_tx_url(txid);
+      var link_url = get_etherscan_url(txid);
 
       $('#transaction_url').attr('href', link_url);
     });

--- a/app/grants/templates/grants/detail/index.html
+++ b/app/grants/templates/grants/detail/index.html
@@ -87,7 +87,12 @@
   <script src="{% static "v2/js/waiting_room_entertainment.js" %}"></script>
   <script>
     $('#wallet-address').attr(
-      'href', etherscan_tx_url($('#wallet-address').text().trim(), '{{ grant.network }}')
+      'href',
+      get_etherscan_url(
+        $('#wallet-address').text().trim(),
+        '{{ grant.network }}',
+        'address'
+      )
     );
 
     {% if change_ownership == 'Y' %}


### PR DESCRIPTION
##### Description

```
Scott Moore [Today at 2:31 AM]
:large_blue_circle: clicking on gitcoin grant recipient address leads to an invalid etherscan page as spaces aren’t trimmed https://gitcoin.co/grants/22/fuzz-geth-and-parity-for-evm-consensus-bugs-2

thelostone-mc  [2 hours ago]
Do you mean it should point to
https://etherscan.io/address/0x7056E70A5CA249Ba88e9550EB22CAEc4C985bb8E

as opposed to

https://etherscan.io/tx/0x7056E70A5CA249Ba88e9550EB22CAEc4C985bb8E
?
```



##### Testing

https://embed.vidyard.com/share/ApLoYYB5oznWx44NkTL8VQ?
