### PR TITLE
chore: show supported by only if sponsors are present

### DIFF
--- a/app/dashboard/templates/shared/hackathon_sponsors.html
+++ b/app/dashboard/templates/shared/hackathon_sponsors.html
@@ -15,10 +15,10 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static %}
-<div class="col-12 sponsors text-white mt-5 mb-3">
-  <p class="font-weight-semibold font-subheader mb-4">SUPPORTED BY</p>
 
+<div class="col-12 sponsors text-white mt-5 mb-3">
   {% if sponsors %}
+    <p class="font-weight-semibold font-subheader mb-4">SUPPORTED BY</p>
     {% if sponsors.sponsors_gold %}
       <div class="d-flex flex-wrap justify-content-center mb-4">
         {% for sponsor in sponsors.sponsors_gold %}


### PR DESCRIPTION
##### Before

<img width="1920" alt="Screenshot 2019-07-25 at 2 29 00 PM" src="https://user-images.githubusercontent.com/5358146/61861068-b68f4880-aee8-11e9-8e40-6098da6f834b.png">


##### After

<img width="1920" alt="Screenshot 2019-07-25 at 2 23 41 PM" src="https://user-images.githubusercontent.com/5358146/61861078-bbec9300-aee8-11e9-9d85-db911fc841ab.png">
