### PR TITLE
Don't expose ports unless neccessary

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   db:
     image: postgres:10.1-alpine
     restart: unless-stopped
-    ports:
-      - "5432:5432"
+#    ports:
+#      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     deploy:
@@ -22,11 +22,11 @@ services:
     volumes:
       - 'ipfsexport:/export'
       - 'ipfsdata:/data/ipfs'
-    ports:
-      - "4001:4001"
-      - "4002:4002"
-      - "5001:5001"
-      - "8080:8080"
+#    ports:
+#      - "4001:4001"
+#      - "4002:4002"
+#      - "5001:5001"
+#      - "8080:8080"
     deploy:
       replicas: 1
       resources:
@@ -50,7 +50,7 @@ services:
       - .:/code
     ports:
       - "8000:8000"
-      - "3030:3030"
+ #     - "3030:3030"
     depends_on:
       - db
     stdin_open: true
@@ -65,8 +65,8 @@ services:
 
   testrpc:
     image: trufflesuite/ganache-cli
-    ports:
-      - "8545:8545"
+ #   ports:
+ #     - "8545:8545"
     command: '-a 1 --seed 2 --host 0.0.0.0 --mnemonic "${TEST_MNEMONIC}"'
     deploy:
       replicas: 1
@@ -83,8 +83,8 @@ services:
       - app/app/.env
     volumes:
       - redis:/data
-    ports:
-      - "6379:6379"
+#    ports:
+#      - "6379:6379"
     deploy:
       replicas: 1
       resources:


### PR DESCRIPTION
##### Description
Since I keep getting CERT ABUSE messages regarding open Redis servers (as seen in this image) we should only expose ports that are neccessary for operation(s). The normal developer probabbly won't ever use much besides the web server anyways (at least I haven't had to check postgres, redis or IPFS in the last months I worked on the project).
