### PR TITLE
bug: supress multiple alert when owner is logged out

### DIFF
--- a/app/assets/v2/js/grants/shared.js
+++ b/app/assets/v2/js/grants/shared.js
@@ -43,11 +43,16 @@ var waitingStateActive = function() {
  * @param {string} message
  */
 const notifyOwnerAddressMismatch = (username, address, button, message) => {
-  if (!web3 || !web3.eth)
+
+  if (!web3 || !web3.eth || !username || !document.contxt.github_handle) {
     return;
+  }
+
   web3.eth.getAccounts((error, accounts) => {
-    if (document.contxt.github_handle == username && accounts[0] &&
-        accounts[0] != address) {
+    if (
+      document.contxt.github_handle == username &&
+      accounts[0] && accounts[0] != address
+    ) {
       if ($(button).attr('disabled') != 'disabled') {
         $(button).attr('disabled', 'disabled');
         _alert({


### PR DESCRIPTION
#### Description

When you are logged in as the grant owner as wrong address the alert shows up as usual.
When you logout -> we add a null check to ensure to show the alert only if the user is logged in

Demo: https://embed.vidyard.com/share/CY7m7HX19YngBqzs6wfd6W?

closes https://github.com/gitcoinco/web/issues/5026



