### PR TITLE
prevent back button github reconnect

### DIFF
--- a/app/marketing/views.py
+++ b/app/marketing/views.py
@@ -530,6 +530,7 @@ def account_settings(request):
             create_user_action(profile.user, 'account_disconnected', request)
             messages.success(request, _('Your account has been disconnected from Github'))
             logout_redirect = redirect(reverse('logout') + '?next=/')
+            logout_redirect['Cache-Control'] = 'max-age=0 no-cache no-store must-revalidate'
             return logout_redirect
         elif request.POST.get('delete', False):
 


### PR DESCRIPTION

##### Description

This change adds response headers after disconnecting your account from Github to prevent accidental reconnection if the user presses the back button.

##### Refers/Fixes

n/a

##### Testing

Tested locally

![Screen Shot 2019-08-20 at 9 50 56 PM](https://user-images.githubusercontent.com/869266/63348741-e0774600-c394-11e9-95cc-40fa0c2e1709.png)
