### PR TITLE
catch infura/metamask errors before they alert sentry

### DIFF
--- a/app/assets/v2/js/shared.js
+++ b/app/assets/v2/js/shared.js
@@ -928,6 +928,7 @@ var listen_for_web3_changes = async function() {
       trigger_form_hooks();
     } else {
       var cb;
+
       try {
         // invoke infura synchronous call, if it fails metamask is locked
         cb = web3.eth.coinbase;
@@ -936,8 +937,8 @@ var listen_for_web3_changes = async function() {
         console.log('web3.eth.coinbase could not be loaded');
       }
       if (typeof cb == 'undefined' || !cb) {
-         currentNetwork('locked');
-         trigger_form_hooks();
+        currentNetwork('locked');
+        trigger_form_hooks();
       } else {
         is_metamask_unlocked = true;
         web3.eth.getBalance(web3.eth.coinbase, function(errors, result) {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

We use a variety of techniques in our shared.js to determine whether the user has web3 access. One of the ways we do it is to attempt to access the coinbase of the connected ETH node - if the coinbase comes back as something other than undefined, then we assume we have a working blockchain connection. However, when calling this synchronous method in browsers that do not have metamask unlocked, we get an error trying to access the coinbase, and use this to show the user the "unlock metamask" alert. Each time this happens however, an alert is sent to sentry.

##### Refers/Fixes

This PR catches the error.

##### Testing

Untested