### PR TITLE
Preload fonts from the static domain

### DIFF
--- a/app/retail/templates/shared/head.html
+++ b/app/retail/templates/shared/head.html
@@ -24,10 +24,10 @@
 <link rel="preload" href="{% static "v2/css/fontawesome-all.min.css" %}" as="style">
 <link rel="preload" href="{% static "v2/css/lib/typography.css" %}" as="style">
 <link rel="preload" href="{% static "v2/css/jquery.select2.min.css" %}" as="style">
-<link rel="preload" href="/static/v2/fonts/muli/muli-v12-latin-200.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="/static/v2/fonts/muli/muli-v12-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="/static/v2/fonts/muli/muli-v12-latin-600.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="/static/v2/fonts/muli/muli-v12-latin-700.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{% static "v2/fonts/muli/muli-v12-latin-200.woff2" %}" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{% static "v2/fonts/muli/muli-v12-latin-regular.woff2" %}" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{% static "v2/fonts/muli/muli-v12-latin-600.woff2" %}" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{% static "v2/fonts/muli/muli-v12-latin-700.woff2" %}" as="font" type="font/woff2" crossorigin>
 
 <link rel="preload" href="{% static "v2/js/lib/bootstrap.min.js" %}" as="script" crossorigin="anonymous">
 


### PR DESCRIPTION
##### Description
Currently all fonts are loaded from the CDN subdomain https://s.gitcoin.co, but the preloader gets the fonts from the main domain https://gitcoin.co. In order to benefit from the browser preloader, the domain should be adapted.

##### Testing
Sorry, no tests.