### PR TITLE
Fix ENS onepager layout

### DIFF
--- a/app/dashboard/templates/ens/base.html
+++ b/app/dashboard/templates/ens/base.html
@@ -5,24 +5,10 @@
     <title>{% trans "ENS Subdomains | Gitcoin" %}</title>
     {% include 'shared/cards_pic.html' with title='Gitcoin | _you_.gitcoin.eth ENS Subdomains'  card_desc='*NEW* Register `_you_.gitcoin.eth` with one click for free' avatar_url="https://s.gitcoin.co/static/v2/images/ens_gitcoin.png"  %}
     {% include 'shared/head.html' %}
-    <meta charset="utf-8" />
-    <meta name="title" content="ENS Subdomains | Gitcoin">
-    <meta name="description" content="Create and manage your ENS subdomain">
-    <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
-    <meta name="theme-color" content="#ffffff">
-    <!--[if lte IE 8]><script src="{% static "onepager/js/html5shiv.js" %}"></script><![endif]-->
-    <link rel="stylesheet" href="{% static "v2/css/bootstrap.min.css" %}" crossorigin="anonymous">
+
     <link rel="stylesheet" href="{% static "v2/css/kudos/styles.css" %}" />
     <link rel="stylesheet" href="{% static "onepager/css/main.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/lib/typography.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/gitcoin.css" %}">
-    <link rel="stylesheet" href="{% static "onepager/css/main.css" %}">
     <link rel="stylesheet" href="{% static "v2/css/box_redeem.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/rain.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/forms/button.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/external_bounties/checkboxes.css" %}">
-    <link rel="stylesheet" href="{% static "v2/css/jquery.select2.min.css" %}">
-    <link rel="stylesheet" href="{% static "cookielaw/css/cookielaw.css" %}">
 
     <script src="{% static "v2/js/lib/jquery.js" %}"></script>
     <script src="{% static "v2/js/metamask-approval.js" %}"></script>
@@ -30,7 +16,6 @@
     <!--[if lte IE 9]><link rel="stylesheet" href="{% static "onepager/css/ie9.css" %}"><![endif]-->
     <!--[if lte IE 8]><link rel="stylesheet" href="{% static "onepager/css/ie8.css" %}"><![endif]-->
     <noscript><link rel="stylesheet" href="{% static "onepager/css/noscript.css" %}"></noscript>
-    {% include 'shared/favicon.html' %}
     <style>
       #upper_left p{
         color: white;
@@ -47,7 +32,6 @@
     {% block 'world' %}
     {% endblock %}
     {% include 'shared/rain.html' with class="color" %}
-    {% include 'shared/rain.html' with class="color" %}
     <!-- Wrapper -->
     <div id="wrapper" class="pt-1 container-fluid">
       {% include 'shared/onepager_auth.html' with source='authed' %}
@@ -55,15 +39,14 @@
       <!-- Main -->
       {% block 'main' %}
       {% endblock %}
-      <footer id="footer">
-        <ul class="copyright">
-          <li>
-            <a href="/">&copy; {% trans "Gitcoin.co" %}</a>
-          </li>
-          <li>
-            {% blocktrans %}Made with <3 &amp; bounties by <a href="https://github.com/gitcoinco/web/pull/509" target="_blank" rel="noopener noreferrer" class="pull-request-link">Scottydelta and Gitcoin Core</a>{% endblocktrans %}
-          </li>
-        </ul>
+      <footer class="container-fluid no-gutters" id="footer">
+        <div class="container d-flex justify-content-center">
+          <div class="w-50 text-center">
+            <p class="footer__text">
+              &copy; <a href="/">{% trans "Gitcoin.co" %}</a> | {% blocktrans %}Made with <3 &amp; bounties by <a href="https://github.com/gitcoinco/web/pull/509" target="_blank" rel="noopener noreferrer" class="pull-request-link">Scottydelta and Gitcoin Core</a>{% endblocktrans %}
+            </p>
+          </div>
+        </div>
       </footer>
     </div>
     <!-- Scripts -->

--- a/app/dashboard/templates/ens/ens_register.html
+++ b/app/dashboard/templates/ens/ens_register.html
@@ -33,7 +33,7 @@
       </div>
     </div>
     <a href="#" id="register" class="button button--primary">
-      <img src="{% static "v2/images/metamask.svg" %}" alt="Metamask Logo">
+      <img src="{% static "v2/images/metamask.svg" %}" alt="Metamask Logo" style="top:0">
       <span>{% trans "Register" %}</span>
     </a>
   {% endif %}


### PR DESCRIPTION
##### Description
The [ENS subdomain onepager](https://gitcoin.co/ens/) is a little bit broken. I will try to fix the layout.

###### Before
<img width="1019" alt="Bildschirmfoto 2019-09-12 um 08 25 30" src="https://user-images.githubusercontent.com/108992/64760144-4345a280-d539-11e9-9e9b-86b46497954f.png">

###### After
<img width="1039" alt="Bildschirmfoto 2019-09-12 um 08 21 37" src="https://user-images.githubusercontent.com/108992/64760161-49d41a00-d539-11e9-879a-a326d9c898cf.png">

##### Refers/Fixes
* Removing duplicate stylesheets (already loaded by [shared/head.html](https://github.com/gitcoinco/web/blob/a6d073c3c8a3be999269e1ae0b390b13ff2cb814/app/dashboard/templates/ens/base.html#L7))
* Removing favicon include (already loaded by [shared/head.html](https://github.com/gitcoinco/web/blob/a6d073c3c8a3be999269e1ae0b390b13ff2cb814/app/retail/templates/shared/head.html#L75))
* Fixing ENS page footer

##### Testing
A designer should make a visual test of the layout changes.