### PR TITLE
bug: no applicant email

### DIFF
--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -530,24 +530,21 @@ def funder_payout_reminder(to_email, bounty, github_username, live):
 def no_applicant_reminder(to_email, bounty):
     from_email = settings.SERVER_EMAIL
     subject = "Get more applicants on your bounty"
-    html, text = render_no_applicant_reminder(to_email=to_email, bounty=bounty)
-    if (live):
-        try:
-            send_mail(
-                from_email,
-                to_email,
-                subject,
-                text,
-                html,
-                from_name="No Reply from Gitcoin.co",
-                categories=['marketing', func_name()],
-            )
-        except Exception as e:
-            logger.warning(e)
-            return False
-        return True
-    else:
-        return html
+    html, text = render_no_applicant_reminder(bounty=bounty)
+    try:
+        send_mail(
+            from_email,
+            to_email,
+            subject,
+            text,
+            html,
+            from_name="No Reply from Gitcoin.co",
+            categories=['marketing', func_name()],
+        )
+    except Exception as e:
+        logger.warning(e)
+        return False
+    return True
 
 
 def share_bounty(emails, msg, profile, invite_url=None, kudos_invite=False):


### PR DESCRIPTION
##### Description

Looks like there are a couple of undefined variables which needed to be fixed!

- `render_no_applicant_reminder` takes only one argument  as shown [here](https://github.com/gitcoinco/web/blob/a88246ea9c96801bc2d482acf4bde9f03c4f6cbf/app/retail/emails.py#L324)

- `live` is not defined anywhere so it would not work