### PR TITLE
FIX requests with arrays on the site

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -120,7 +120,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'app.middleware.drop_accept_langauge',
-    'app.middleware.bleach_requests',
+    # 'app.middleware.bleach_requests',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This was first reporter as permissions not saving on the admin but actually affection any data sent by a form containing an array. Just the last one element of the array was getting into the backend so instead of `<QueryDict: {'skills[]': ['css', 'solidity'], 'bountyId': ['37']}>` the `request.POST` was getting `<QueryDict: {'skills[]': [ 'solidity'], 'bountyId': ['37']}>` Probably affecting lot of places on the application. 

For now this PR just disabled  django-bleach until we solved or probably remove it as that project is very new and just have 1 issue, not enough usage. 
##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Fix #5190
Fix #4893
And actually any array sent, like grants team people probably failing.
##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
