### PR TITLE
chore: remove on blur event for amount update

### DIFF
--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -312,11 +312,10 @@ $(function() {
 
   // fetch issue URL related info
   $('input[name=amount]').keyup(setUsdAmount);
-  $('input[name=amount]').blur(setUsdAmount);
   $('input[name=usd_amount]').keyup(usdToAmount);
-  $('input[name=usd_amount]').blur(usdToAmount);
   $('input[name=hours]').keyup(setUsdAmount);
   $('input[name=hours]').blur(setUsdAmount);
+
   $('input[name=amount]').on('change', function() {
     const amount = $('input[name=amount]').val();
 


### PR DESCRIPTION
##### Description

>  can’t fund an issue with exactly 15 ETH which is a small, random issue

- removes blue events to ensure while tabbing token amount / usd amount don't change

https://share.vidyard.com/watch/gFMn84vzHT6tHBrTfWC6ik?