### PR TITLE
feat: account for single contribution for grant in clr

### DIFF
--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -64,6 +64,10 @@ def generate_grant_pair(grant):
             else:
                 unique_contributions[profile] = amount
 
+    if len(unique_contributions) == 1:
+        profile = next(iter(unique_contributions))
+        unique_contributions['_' + profile] = 1
+
     profile_pairs = list(combinations(unique_contributions.keys(), 2))
     contribution_pairs = list(combinations(unique_contributions.values(), 2))
 


### PR DESCRIPTION
##### Description

Pairs the contributor with itself and ensures grants get matching clr even if it has one contributor

If grant has only 1 contributor. 
Assume with `contributor_profile : 1` who contributed `5 DAI` :

- while generating pair we assume another pseudo contribution who makes `1 DAI` 
  (I'm assuming this is the lowest possible contribution )
- pair generated would : `1` & `_1` with contributions `5 DAI` and `1 DAI`  

If a new profile contributes,
the pesudo contributor_profile's (`_1`) contibution (`1 DAI`) is ignored and algorithm works as usual


##### Refers/Fixes

Fixes: https://github.com/gitcoinco/web/issues/5223

##### Testing

https://share.vidyard.com/watch/rTqnXvuiRuswAnbvK91GbR?