### PR TITLE
remove typeform for new style grants

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -272,9 +272,6 @@ def grant_details(request, grant_id, grant_slug):
 @login_required
 def grant_new(request):
     """Handle new grant."""
-    if not request.user.has_perm('grants.add_grant'):
-        return redirect('https://gitcoin.typeform.com/to/C2IocD')
-
     profile = get_profile(request)
 
     if request.method == 'POST':


### PR DESCRIPTION
another branch removed the typeform redirect for the old grant creation endpoint, which is just used for testing - this one removes it for the new endpoint