### PR TITLE
Proposed fix for Kudos marketplace search bar

### DIFF
--- a/app/assets/v2/js/pages/kudos-search.js
+++ b/app/assets/v2/js/pages/kudos-search.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
   var clearBtn = $('.clear-search');
 
   if (queryParam && queryParam.q) {
-    $('#kudos-search').val(queryParam.q);
+    $('#kudos-search').val(queryParam.q.replace(/\+/g, " "));
     clearBtn.removeClass('hidden');
   }
 

--- a/app/assets/v2/js/pages/kudos-search.js
+++ b/app/assets/v2/js/pages/kudos-search.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
   var clearBtn = $('.clear-search');
 
   if (queryParam && queryParam.q) {
-    $('#kudos-search').val(queryParam.q.replace(/\+/g, " "));
+    $('#kudos-search').val(decodeURIComponent(queryParam.q.replace(/\+/g, '%20')));
     clearBtn.removeClass('hidden');
   }
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

When you add whitespace in search bar value, for example: "Limited edition", the query parameters will be "Limited+edition", so when results come back in the view, the search bar get its value from query parameters (queryParam.q), so it will also show up in the search bar as Limited+edition. The simplest solution is to replace the plus signs with whitespace:\

$('#kudos-search').val(queryParam.q.replace(/\+/g, " "));

I think it does look better.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

![simplescreenrecorder-2019-10-28_10 27 32](https://user-images.githubusercontent.com/23085140/67702011-399fbf00-f96e-11e9-8d20-eff18ae60a2d.gif)
