### PR TITLE
Fixed redirect for Send Tip link

### DIFF
--- a/app/dashboard/templates/onepager/base.html
+++ b/app/dashboard/templates/onepager/base.html
@@ -80,7 +80,7 @@
       <footer id="footer" class="copyright d-flex font-smaller-1 justify-content-center mt-5 p-4">
         <a href="/">&copy; Gitcoin.co</a>
         {% if not hide_send_tip %}
-          <a href="{% url "tip" %}">{% trans "Send Tip" %}</a>
+          <a href="{% url "send_tip_2" %}">{% trans "Send Tip" %}</a>
         {% endif %}
       </footer>
     </div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
The Send Tip button in the footer doesn't redirect to the correct url:
![immagine](https://user-images.githubusercontent.com/50027175/67559171-b20d4280-f718-11e9-9da8-9c5f99fe9de8.png)
It should redirect to `/tip/send/2`

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
