### PR TITLE
Adjust scopes for Github oAuth Login

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -532,7 +532,7 @@ SOCIAL_AUTH_GITHUB_KEY = GITHUB_CLIENT_ID
 SOCIAL_AUTH_GITHUB_SECRET = GITHUB_CLIENT_SECRET
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'last_name', 'email']
-SOCIAL_AUTH_GITHUB_SCOPE = ['read:public_repo', 'read:user', 'user:email', 'read:org', 'repo']
+SOCIAL_AUTH_GITHUB_SCOPE = ['public_repo', 'read:user', 'user:email', 'read:org']
 SOCIAL_AUTH_SANITIZE_REDIRECTS = True
 
 SOCIAL_AUTH_PIPELINE = (


### PR DESCRIPTION

##### Description

Scalling back scopes for the github oauth request to only ask for read/write on public repos vs all repos, while a workflow for private repos is established.