### PR TITLE
Update of pytest and related packages to be able to run 'make test' without errors

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,8 @@
 -r base.txt
-pytest==4.0.1
-pytest-cov==2.6.0
-pytest-isort==0.2.1
-pytest-django==3.4.4
+pytest==5.2.2
+pytest-cov==2.8.1
+pytest-isort==0.3.1
+pytest-django==3.6.0
 pytest-sugar==0.9.2
 coverage==4.5.2
 isort==4.3.4


### PR DESCRIPTION
Pytest was crashing when trying to run tests. Updating the pytest version fixed it. There is a stackoverflow issue about this:
https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert