### PR TITLE
quiet common sentry error when syncing orgs w/o tokens

### DIFF
--- a/app/app/utils.py
+++ b/app/app/utils.py
@@ -242,7 +242,8 @@ def sync_profile(handle, user=None, hide_profile=True):
 
         profile.keywords = keywords
         profile.save()
-
+    except UserSocialAuth.DoesNotExist:
+        pass
     except Exception as e:
         logger.error(e)
         return None


### PR DESCRIPTION

##### Description

This handles a common sentry error when attempting to sync an org where we don't have a valid github token for that org's profile

##### Refers/Fixes

Triage issue

##### Testing

Untested