### PR TITLE
fix typecast for query param

### DIFF
--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -1108,7 +1108,7 @@ def results(request, keyword=None):
     context['updated'] = js.created_on
     context['is_outside'] = True
     context['prefix'] = 'data-'
-    context['target'] = "/activity?page=" + str(request.GET.get('page', 0) + 1)
+    context['target'] = "/activity?page=" + str(int(request.GET.get('page', 0)) + 1)
     import json
     context['avatar_url'] = static('v2/images/results_preview.gif')
     return TemplateResponse(request, 'results.html', context)


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This change correctly casts the query parameter for the page number to an int before adding 1 to it.

##### Refers/Fixes

Fixes a recurring sentry error when viewing the activity feed

##### Testing

not tested