### PR TITLE
ensure bounty is open when advanced payout is done using tips

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -721,7 +721,7 @@ class Bounty(SuperModel):
         is_traditional_bounty_type = self.project_type == 'traditional'
         try:
             has_tips = self.tips.filter(is_for_bounty_fulfiller=False).send_happy_path().exists()
-            if has_tips and is_traditional_bounty_type:
+            if has_tips and is_traditional_bounty_type and not self.is_open :
                 return 'done'
             if not self.is_open:
                 if self.accepted:


### PR DESCRIPTION
##### Description

As of now -> if you use advanced payout using wallet , 
the UI renders the status as DONE which is confusing despite the bounty being open.

- This happens on the explorer 
- Bounty Page (preventing users from performing contributor/funder actions which should be possible on the original bounty )


<img width="1679" alt="Screenshot 2019-11-04 at 6 25 11 PM" src="https://user-images.githubusercontent.com/5358146/68173680-9849d780-ff30-11e9-9e5d-9d8df7e2920d.png">

<img width="1443" alt="Screenshot 2019-11-04 at 6 25 39 PM" src="https://user-images.githubusercontent.com/5358146/68173691-9f70e580-ff30-11e9-892c-e419436d8299.png">


AFTER THIS CHANGE

<img width="1680" alt="Screenshot 2019-11-04 at 6 27 17 PM" src="https://user-images.githubusercontent.com/5358146/68173736-c4655880-ff30-11e9-862e-6082ede4de7f.png">

<img width="1309" alt="Screenshot 2019-11-04 at 6 27 09 PM" src="https://user-images.githubusercontent.com/5358146/68173739-c7604900-ff30-11e9-8512-2c5cc050224c.png">


