### PR TITLE
[Small Fix] Added Logo width on Contributing.md [Documentation]

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -376,5 +376,5 @@ Run: `make collect-static` if using Docker or `cd app; python3 manage.py collect
 
 Additionally, you can check out the [Django Managing Static Files Documentation](https://docs.djangoproject.com/en/2.0/howto/static-files/)
 
-<img src='https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png' width=185px height=185px alt="Gitcoin logo">
+<img src='https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png' width="185" height="185" alt="Gitcoin logo">
 Welcome to the gitcoin community. Lets Grow Open Source Software.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -376,5 +376,5 @@ Run: `make collect-static` if using Docker or `cd app; python3 manage.py collect
 
 Additionally, you can check out the [Django Managing Static Files Documentation](https://docs.djangoproject.com/en/2.0/howto/static-files/)
 
-<img src='https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png'/>
+<img src='https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png' width=185px height=185px alt="Gitcoin logo">
 Welcome to the gitcoin community. Lets Grow Open Source Software.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<img src="https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png" width=75px height=75px alt="Gitcoin logo">
+<img src="https://d3vv6lp55qjaqc.cloudfront.net/items/263e3q1M2Y2r3L1X3c2y/helmet.png" width="75" height="75" alt="Gitcoin logo">
 
 # Gitcoin
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

There is a tiny issue on our lovely 'Logo' on the <code> contributing.md </code> and it's happening in all screen sizes.

While the logo on <code> contributing.md</code> it's looking pretty good on Github. It's not in the actual deployed document site https://docs.gitcoin.co/mk_contributors/

![issue](https://user-images.githubusercontent.com/41552663/70165058-9e9ab300-1698-11ea-9fc3-c498fc9b6725.png)

**It has an automatic width of 238 x 238. Which is causing the conflict.**

![width](https://user-images.githubusercontent.com/41552663/70165339-208adc00-1699-11ea-8392-d106d06825af.png)



##### Refers/Fixes

Since it looks like we want our logo there to be bigger in size. We have added specific width in the <code> contributing.md</code> so it makes the logo look as we want

![issue1](https://user-images.githubusercontent.com/41552663/70165554-7d869200-1699-11ea-8877-86403f94dbc2.png)

Issue: #4943 

##### Testing

- All Browsers, And all sizes. 
