### PR TITLE
Removes edit this page link from every page

### DIFF
--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -1,6 +1,6 @@
 site_name: "Gitcoin Developer Documentation"
 repo_name: 'gitcoinco/web'
-repo_url: 'https://github.com/gitcoinco/web'
+edit_uri: ''
 
 # This tells pydocmd which pages to generate from which Python modules,
 # functions and classes. At the first level is the page name, below that


### PR DESCRIPTION
##### Description

The PR removes the `Edit this page` button from the documentation pages which redundantly redirects to a 404 page.

![Screenshot_2019-12-13 Home - Gitcoin Developer Documentation](https://user-images.githubusercontent.com/21157929/70771749-43ec1000-1d98-11ea-9427-4546e9fc5d7e.png)

##### Refers/Fixes

#4943

##### Testing

No tests required.
