### PR TITLE
Fix for Admin Address Pull on Grant

### DIFF
--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -2,7 +2,6 @@ const editableFields = [
   '#form--input__title',
   '#form--input__reference-url',
   '#contract_owner_address',
-  '#grant_contract_owner_address',
   '#grant-members',
   '#amount_goal'
 ];

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -13,10 +13,10 @@ $(document).ready(function() {
   setInterval (() => {
     notifyOwnerAddressMismatch(
       $('#grant-admin').text(),
-      $('#contract_owner_address').html(),
+      $('#contract_owner_address').text(),
       '#cancel_grant',
       'Looks like your grant has been created with ' + 
-      $('#grant_contract_owner_address').html() + '. Switch to take action on your grant.'
+      $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -1,7 +1,7 @@
 const editableFields = [
   '#form--input__title',
   '#form--input__reference-url',
-  '#gran_contract_owner_address',
+  '#grant_contract_owner_address',
   '#grant-members',
   '#amount_goal'
 ];

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
       $('#contract_owner_address').text(),
       '#cancel_grant',
       'Looks like your grant has been created with ' + 
-      $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
+      $('#contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -1,7 +1,7 @@
 const editableFields = [
   '#form--input__title',
   '#form--input__reference-url',
-  '#contract_owner_address',
+  '#gran_contract_owner_address',
   '#grant-members',
   '#amount_goal'
 ];

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
       $('#grant_contract_owner_address').text(),
       '#cancel_grant',
       'Looks like your grant has been created with ' +
-      $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
+      $('#grant_contract_owner_address').text(), + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -3,7 +3,7 @@ const editableFields = [
   '#form--input__reference-url',
   '#contract_owner_address',
   '#grant-members',
-  '#amount_goal'
+  '#amount_goal',
 ];
 
 $(document).ready(function() {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -15,8 +15,7 @@ $(document).ready(function() {
       $('#grant-admin').text(),
       $('#grant_contract_owner_address').text(),
       '#cancel_grant',
-      'Looks like your grant has been created with ' +
-      $('#grant_contract_owner_address').text(), + '. Switch to take action on your grant.'
+      'Looks like your grant has been created with ' + $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -3,7 +3,7 @@ const editableFields = [
   '#form--input__reference-url',
   '#contract_owner_address',
   '#grant-members',
-  '#amount_goal',
+  '#amount_goal'
 ];
 
 $(document).ready(function() {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -13,10 +13,10 @@ $(document).ready(function() {
   setInterval (() => {
     notifyOwnerAddressMismatch(
       $('#grant-admin').text(),
-      $('#contract_owner_address').text(),
+      $('#contract_owner_address').html(),
       '#cancel_grant',
       'Looks like your grant has been created with ' + 
-      $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
+      $('#grant_contract_owner_address').html() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -2,6 +2,7 @@ const editableFields = [
   '#form--input__title',
   '#form--input__reference-url',
   '#contract_owner_address',
+  '#grant_contract_owner_address',
   '#grant-members',
   '#amount_goal'
 ];
@@ -16,7 +17,7 @@ $(document).ready(function() {
       $('#contract_owner_address').text(),
       '#cancel_grant',
       'Looks like your grant has been created with ' + 
-      $('#contract_owner_address').text() + '. Switch to take action on your grant.'
+      $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -15,7 +15,8 @@ $(document).ready(function() {
       $('#grant-admin').text(),
       $('#contract_owner_address').text(),
       '#cancel_grant',
-      'Looks like your grant has been created with ' + $('#contract_owner_address').text() + '. Switch to take action on your grant.'
+      'Looks like your grant has been created with ' + 
+      $('#contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -1,7 +1,7 @@
 const editableFields = [
   '#form--input__title',
   '#form--input__reference-url',
-  '#grant_contract_owner_address',
+  '#contract_owner_address',
   '#grant-members',
   '#amount_goal'
 ];
@@ -13,9 +13,9 @@ $(document).ready(function() {
   setInterval (() => {
     notifyOwnerAddressMismatch(
       $('#grant-admin').text(),
-      $('#grant_contract_owner_address').text(),
+      $('#contract_owner_address').text(),
       '#cancel_grant',
-      'Looks like your grant has been created with ' + $('#grant_contract_owner_address').text() + '. Switch to take action on your grant.'
+      'Looks like your grant has been created with ' + $('#contract_owner_address').text() + '. Switch to take action on your grant.'
     );
 
     if ($('#cancel_grant').attr('disabled')) {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

Expected Admin Grant Address <code> #grant_contract_owner_address </code> on the Error Message but I am seeing on the file it's appending the value as <code> #contract_owner_address </code>

![71016247-79da1d00-2127-11ea-9ef3-3a39ae3a8dfb](https://user-images.githubusercontent.com/41552663/71048113-8acd6300-2114-11ea-8de8-bdfbb21ca3aa.png)

Syntax:

<code> $('selector expression').text('content if applied'); </code>


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Line fixing

#5647 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Brave Browser
This should not break any other components
