### PR TITLE
save empty curve if no contributions to fix sorting

### DIFF
--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -280,14 +280,17 @@ def predict_clr(random_data=False, save_to_db=False, from_date=None, clr_type=No
             base = grant.clr_prediction_curve[0][1]
             if base:
                 grant.clr_prediction_curve  = [[ele[0], ele[1], ele[1] - base] for ele in grant.clr_prediction_curve ]
-                JSONStore.objects.create(
-                    created_on=from_date,
-                    view='clr_contribution',
-                    key=f'{grant.id}',
-                    data=grant.clr_prediction_curve,
-                )
-                if from_date > (clr_calc_start_time - timezone.timedelta(hours=1)):
-                    grant.save()
+           else:
+                grant.clr_prediction_curve = [[0.0, 0.0, 0.0] for x in range(0, 6)]
+
+            JSONStore.objects.create(
+                created_on=from_date,
+                view='clr_contribution',
+                key=f'{grant.id}',
+                data=grant.clr_prediction_curve,
+            )
+            if from_date > (clr_calc_start_time - timezone.timedelta(hours=1)):
+                grant.save()
 
         debug_output.append({'grant': grant.id, "clr_prediction_curve": (potential_donations, potential_clr), "grants_clr": grants_clr})
     return debug_output


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR sets an empty clr prediction curve for grants that have no contributions, so that sorting on the grants index page works as expected

##### Refers/Fixes


##### Testing

Tested this fix in interactive shell on production