### PR TITLE
Fix the fetch org on login

### DIFF
--- a/app/app/utils.py
+++ b/app/app/utils.py
@@ -230,7 +230,7 @@ def sync_profile(handle, user=None, hide_profile=True):
             defaults['hide_profile'] = hide_profile
         profile, created = Profile.objects.update_or_create(handle=handle, defaults=defaults)
         access_token = profile.user.social_auth.filter(provider='github').latest('pk').access_token
-        orgs = get_user(handle, '', scope='orgs', auth=(profile.handle, access_token))
+        orgs = get_user(handle, '/orgs', auth=(profile.handle, access_token))
         profile.organizations = [ele['login'] for ele in orgs if ele and type(ele) is dict] if orgs else []
         print("Profile:", profile, "- created" if created else "- updated")
         keywords = []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     restart: unless-stopped
     environment:
       - PYTHONUNBUFFERED=1
+      - PYTHONIOENCODING=utf8
       - PYTHONPATH=/code/app
       - PYTHONPATH=/usr/bin/python3
     env_file:


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
Fix orgs not being fetched when someone without the 'orgs' scope login. This was something we changed for "permission management" but we didn't changed back when rolled back the scopes.

Also this fix an error on login happening sometimes on localhost as how is docker setup:
 "werkzeug/filesystem.py:60: BrokenFilesystemWarning: Detected a misconfigured UNIX filesystem: Will use UTF-8 as filesystem encoding instead of 'ascii'"
 "UnicodeEncodeError: 'ascii' codec can't encode character '\xe1' in position 988"
 
##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
