### PR TITLE
remove command that doesnt exist that causes travis error in pydoc

### DIFF
--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -164,7 +164,6 @@ generate:
     - marketing.management.commands.funder_stale_email++
     - marketing.management.commands.gdpr_reconsent_eu++
     - marketing.management.commands.gdpr_update_email++
-    - marketing.management.commands.ingest_slack_users++
     - marketing.management.commands.new_bounties_email++
     - marketing.management.commands.pending_start_work_actions++
     - marketing.management.commands.process_email_events++


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR fixes pydoc in travis

##### Refers/Fixes

broken travis on master

##### Testing

tested on travis