### PR TITLE
fix for missing is_bounties_network value

### DIFF
--- a/app/dashboard/templates/bounty/details.html
+++ b/app/dashboard/templates/bounty/details.html
@@ -519,7 +519,11 @@
   {% include 'shared/current_profile.html' %}
 
   <script>
+    {% if is_bounties_network %}
     const is_bounties_network = {{ is_bounties_network|lower }};
+    {% else %}
+    const is_bounties_network = true;
+    {% endif %}
     document.issueURL = '{{ issueURL }}';
 
     // ETC-TODO: remove network + std bounties for ETC


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Fixes a sentry error when is_bounties_network is None in bounties detail

##### Refers/Fixes
n/a

##### Testing

Tested locally