### PR TITLE
fix hackathon override org listing 

### DIFF
--- a/app/dashboard/templates/dashboard/sidebar_search_hackathon.html
+++ b/app/dashboard/templates/dashboard/sidebar_search_hackathon.html
@@ -51,8 +51,6 @@
           <input name="org" id="any_org" type="radio" value="any" checked="">
           <label class="filter-label" for="any_org">All</label>
         </div>
-
-
         {% for org in orgs %}
           <div class="form__radio option {{org.org_name}}">
             <input name="org" id="{{org.org_name}}" type="radio" value="{{org.org_name}}" val-ui="Turing-Chain">

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -860,7 +860,7 @@ def onboard(request, flow=None):
             profile.preferred_payout_address = eth_address
             profile.save()
         return JsonResponse({'OK': True})
-    
+
     theme = request.GET.get('theme', '3d')
     from avatar.views_3d import get_avatar_attrs
     skin_tones = get_avatar_attrs(theme, 'skin_tones')
@@ -3591,7 +3591,7 @@ def hackathon(request, hackathon=''):
         }
         orgs.append(org)
 
-    orgs = list({v['org_name']:v for v in orgs}.values())
+    orgs = list({v['display_name']:v for v in orgs}.values())
 
     params = {
         'active': 'dashboard',


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

`orgs = list({v['org_name']:v for v in orgs}.values())`

That list code is to remove duplicates from the org sidebar list
as both org_name (sablier and gitcoinco)  were actually "gitcoinco"  then only one is surviving

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://gitcoincore.slack.com/archives/CAXQ7PT60/p1580912469043700
##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
