### PR TITLE
Fix tip avatar not matching

### DIFF
--- a/app/dashboard/templates/onepager/send2.html
+++ b/app/dashboard/templates/onepager/send2.html
@@ -90,7 +90,7 @@
     <div class="pb-1 to_name">
       <label>{% trans "To Github Username" %}:</label> <br>
       <select id="username" class="username-search custom-select" style="max-width: 400px; margin-left: auto; margin-right: auto;">
-        {% if user_json %} {{user_json}}
+        {% if user_json %}
         <option value="{{ user_json.id }}" avatar_id="{{ user_json.avatar_id }}" avatar_url="{{ user_json.avatar_url }}"  preferred_payout_address="{{ user_json.preferred_payout_address }}">{{ user_json.text }}</option>
         {% endif %}
       </select>

--- a/app/dashboard/templates/onepager/send2.html
+++ b/app/dashboard/templates/onepager/send2.html
@@ -90,7 +90,7 @@
     <div class="pb-1 to_name">
       <label>{% trans "To Github Username" %}:</label> <br>
       <select id="username" class="username-search custom-select" style="max-width: 400px; margin-left: auto; margin-right: auto;">
-        {% if user_json %}
+        {% if user_json %} {{user_json}}
         <option value="{{ user_json.id }}" avatar_id="{{ user_json.avatar_id }}" avatar_url="{{ user_json.avatar_url }}"  preferred_payout_address="{{ user_json.preferred_payout_address }}">{{ user_json.text }}</option>
         {% endif %}
       </select>

--- a/app/dashboard/tip_views.py
+++ b/app/dashboard/tip_views.py
@@ -157,7 +157,7 @@ def receive_tip_v3(request, key, txid, network):
             # tip.username
             # tip.metadata.max_redemptions
             # tip.metadata.override_send_amount
-            # tip.amount to the amount you want to send 
+            # tip.amount to the amount you want to send
             # ,"override_send_amount":1,"max_redemptions":29
 
             num_redemptions += 1
@@ -418,10 +418,11 @@ def send_tip_2(request):
             profile = profiles.first()
             user['id'] = profile.id
             user['text'] = profile.handle
+            user['avatar_url'] = profile.avatar_url
 
             if profile.avatar_baseavatar_related.exists():
-                user['avatar_id'] = profile.avatar_baseavatar_related.first().pk
-                user['avatar_url'] = profile.avatar_baseavatar_related.first().avatar_url
+                user['avatar_id'] = profile.avatar_baseavatar_related.filter(active=True).first().pk
+                user['avatar_url'] = profile.avatar_baseavatar_related.filter(active=True).first().avatar_url
                 user['preferred_payout_address'] = profile.preferred_payout_address
 
     params = {

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3571,10 +3571,10 @@ def get_users(request):
             profile_json = {}
             profile_json['id'] = user.id
             profile_json['text'] = user.handle
-            #profile_json['email'] = user.email
+            profile_json['avatar_url'] = user.avatar_url
             if user.avatar_baseavatar_related.exists():
-                profile_json['avatar_id'] = user.avatar_baseavatar_related.first().pk
-                profile_json['avatar_url'] = user.avatar_baseavatar_related.first().avatar_url
+                profile_json['avatar_id'] = user.avatar_baseavatar_related.filter(active=True).first().pk
+                profile_json['avatar_url'] = user.avatar_baseavatar_related.filter(active=True).first().avatar_url
             profile_json['preferred_payout_address'] = user.preferred_payout_address
             results.append(profile_json)
         # try github


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This use the same avatar as profiles when tipping a user by searching or linking from profiles 
Also fix the logic to pick the active avatar of the user to match the profile instead of the first one on the query results.
Example:
Is very confusing when you search some user to tip and the picture doesn't match with the one on profile, that make you feel insecure. 

![image](https://user-images.githubusercontent.com/1358093/74376939-c6f20c80-4dc1-11ea-9f4b-de2fc87907bf.png)

![image](https://user-images.githubusercontent.com/1358093/74377088-0caed500-4dc2-11ea-8410-442563210a47.png)


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
locally testes with users and non users with base avatar and with just the GitHub image.