### PR TITLE
fix: duplicate activity comments

### DIFF
--- a/app/assets/v2/js/activity.js
+++ b/app/assets/v2/js/activity.js
@@ -280,6 +280,7 @@ $(document).ready(function() {
 
     // user input
     var comment = $parent.parents('.box').find('.comment_container textarea').val();
+    $parent.parents('.box').find('.comment_container textarea').prop('disabled', true);
 
     // validation
     if (!comment) {
@@ -316,6 +317,7 @@ $(document).ready(function() {
       })
       .always(function() {
         $parent.parents('.activity.box').find('.loading').addClass('hidden');
+        $parent.parents('.box').find('.comment_container textarea').prop('disabled', false);
       });
   };
 

--- a/app/assets/v2/js/activity.js
+++ b/app/assets/v2/js/activity.js
@@ -280,6 +280,7 @@ $(document).ready(function() {
 
     // user input
     var comment = $parent.parents('.box').find('.comment_container textarea').val();
+    
     $parent.parents('.box').find('.comment_container textarea').prop('disabled', true);
 
     // validation


### PR DESCRIPTION
When commenting/replying on activities/status posts, comments can be duplicated by hitting the return key more than once Disabling the textarea for every call of post_comment would solve the duplication problem.

closes https://github.com/gitcoinco/web/issues/6007
