### PR TITLE
Add personal only filter for activity feed

### DIFF
--- a/app/assets/v2/js/pages/townsquare.js
+++ b/app/assets/v2/js/pages/townsquare.js
@@ -42,8 +42,9 @@ $(document).ready(function() {
 
   var get_redir_location = function(tab) {
     let trending = $('#trending').is(':checked') ? 1 : 0;
+    let personal = $('#personal').is(':checked') ? 1 : 0;
 
-    return '/?tab=' + tab + '&trending=' + trending;
+    return '/?tab=' + tab + '&trending=' + trending + '&personal=' + personal;
   };
 
   $('body').on('focus change paste keyup blur', '#keyword', function(e) {
@@ -54,6 +55,11 @@ $(document).ready(function() {
   });
 
   $('body').on('click', '#trending', function(e) {
+    setTimeout(function() {
+      document.location.href = get_redir_location($('.nav-link.active').data('slug'));
+    }, 10);
+  });
+  $('body').on('click', '#personal', function(e) {
     setTimeout(function() {
       document.location.href = get_redir_location($('.nav-link.active').data('slug'));
     }, 10);

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1978,6 +1978,47 @@ class ActivityQuerySet(models.QuerySet):
             activity_type='bounty_abandonment_escalation_to_mods',
         )
 
+    def related_to(self, profile):
+        """Filter results to Activity objects which are related to a particular profile.
+
+        Activities related to a Profile can be defined as:
+            - Posts created by that user
+            - Posts that the user likes (even a comment)
+            - Posts tipped by that user (even a comment)
+            - Posts the user commented on
+        """
+        from townsquare.models import Like, Comment
+
+        # Posts created by that user
+        posts = self.filter(profile=profile)
+
+        # Posts that the user likes (even a comment)
+        likes = Like.objects.filter(profile=profile).all()
+        activity_pks = [_.activity.pk for _ in likes]
+        posts.union(self.filter(pk__in=activity_pks))
+
+        comments = Comment.objects.filter(likes__contains=[profile.pk]).all()
+        activity_pks = [_.activity.pk for _ in comments]
+        posts.union(self.filter(pk__in=activity_pks))
+
+        # Posts tipped by that user (even a comment)
+        tips = Tip.objects.filter(sender_profile=profile).all()
+        activity_pks = []
+        for tip in tips:
+            obj = tip.attached_object()
+            if 'activity:' in tip.comments_priv:
+                activity_pks.append(obj.pk)
+            if 'comment:' in tip.comments_priv:
+                activity_pks.append(obj.activity.pk)
+        posts.union(self.filter(pk__in=activity_pks))
+
+        # Posts the user commented on
+        comments = Comment.objects.filter(profile=profile).all()
+        activity_pks = [_.activity.pk for _ in comments]
+        posts.union(self.filter(pk__in=activity_pks))
+
+        return posts
+
 
 class Activity(SuperModel):
     """Represent Start work/Stop work event.

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -1125,6 +1125,7 @@ def activity(request):
     page = int(request.GET.get('page', 1))
     what = request.GET.get('what', 'everywhere')
     trending_only = int(request.GET.get('trending_only', 0))
+    personal_only = int(request.GET.get('personal_only', 0))
 
     # create diff filters
     print(1, round(time.time(), 1))
@@ -1168,6 +1169,9 @@ def activity(request):
             activities = activities.filter(profile__in=relevant_profiles)
         if len(relevant_grants):
             activities = activities.filter(grant__in=relevant_grants)
+
+        if personal_only:
+            activities = activities.related_to(request.user.profile)
     if what == 'connect':
         activities = activities.filter(activity_type__in=['status_update', 'wall_post'])
     if what == 'kudos':

--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -148,8 +148,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div class="checkbox_container">
                       <input name="trending" id="trending" type="checkbox" value="0" val-ui='Trending' {% if trending_only %}checked=checked{%endif%} />
                       <span class="checkbox"></span>
-                      <div class="filter-label ml-1">
+                      <div class="filter-label ml-1 mr-2">
                         <label for=beginner>{% trans "Trending Only" %}</label>
+                      </div>
+                      <input name="personal" id="personal" type="checkbox" value="0" val-ui='Personal' {% if personal_only %}checked=checked{%endif%} />
+                      <span class="checkbox"></span>
+                      <div class="filter-label ml-1">
+                        <label for=beginner>{% trans "Personal Only" %}</label>
                       </div>
                     </div>
                   </div>

--- a/app/townsquare/views.py
+++ b/app/townsquare/views.py
@@ -207,6 +207,7 @@ def town_square(request):
 
     # render page context
     trending_only = int(request.GET.get('trending', 0))
+    personal_only = int(request.GET.get('personal', 0))
     context = {
         'title': title,
         'card_desc': desc,
@@ -214,7 +215,7 @@ def town_square(request):
         'use_pic_card': True,
         'page_seo_text_insert': page_seo_text_insert,
         'nav': 'home',
-        'target': f'/activity?what={tab}&trending_only={trending_only}',
+        'target': f'/activity?what={tab}&trending_only={trending_only}&personal_only={personal_only}',
         'tab': tab,
         'tabs': tabs,
         'matching_leaderboard': matching_leaderboard,
@@ -223,6 +224,7 @@ def town_square(request):
         'now': timezone.now(),
         'is_townsquare': True,
         'trending_only': bool(trending_only),
+        'personal_only': bool(personal_only),
         'search': search,
         'tags': [('#announce','bullhorn'), ('#mentor','terminal'), ('#jobs','code'), ('#help','laptop-code'), ('#other','briefcase'), ],
         'announcements': announcements,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Added the filter for getting only those activities which are related to the user.

<img width="1253" alt="Screenshot 2020-02-23 at 1 12 13 AM" src="https://user-images.githubusercontent.com/22390515/75098220-8a03f200-55d9-11ea-9950-d94df0ababbb.png">

##### Refers/Fixes

Fixes: https://github.com/gitcoinco/web/issues/6012

##### Testing

N/A
