### PR TITLE
rethinks the town square nav - FOR DISCUSSION ONLY; DO NOT MERGE

### DIFF
--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -146,6 +146,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                   </div>
                   <div class="mt-2">
                     <div class="checkbox_container">
+                      <input name="tribe_only" id="tribe_only" type="checkbox" value="0" val-ui='Tribe' {% if tribe_only %}checked=checked{%endif%} />
+                      <span class="checkbox"></span>
+                      <div class="filter-label ml-1">
+                        <label for=beginner>{% trans "My Tribe Only" %}</label>
+                      </div>
+                    </div>
+                    <div class="checkbox_container">
+                      <input name="tribe_only" id="tribe_only" type="checkbox" value="0" val-ui='Tribe' {% if tribe_only %}checked=checked{%endif%} />
+                      <span class="checkbox"></span>
+                      <div class="filter-label ml-1">
+                        <label for=beginner>{% trans "My Threads Only" %}</label>
+                      </div>
+                    </div>
+                    <div class="checkbox_container">
                       <input name="trending" id="trending" type="checkbox" value="0" val-ui='Trending' {% if trending_only %}checked=checked{%endif%} />
                       <span class="checkbox"></span>
                       <div class="filter-label ml-1">
@@ -170,6 +184,38 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                       </li>
                     {% endfor %}
                   </ul>
+                <div class="townsquare_nav-list mb-1 mt-3">
+                  <div class="townsquare_block-header">
+                    Explore
+                  </div>
+                  <ul class="nav d-inline-block font-body">
+                      <li class="nav-item">
+                        <a href="#" class="nav-link nav-line">
+                          <span class="nav-title">Developers</span>
+                        </a>
+                      </li>
+                      <li class="nav-item">
+                        <a href="#" class="nav-link nav-line">
+                          <span class="nav-title">Grants</span>
+                        </a>
+                      </li>
+                      <li class="nav-item">
+                        <a href="#" class="nav-link nav-line">
+                          <span class="nav-title">Kudos</span>
+                        </a>
+                      </li>
+                      <li class="nav-item">
+                        <a href="#" class="nav-link nav-line">
+                          <span class="nav-title">Bounties</span>
+                        </a>
+                      </li>
+                      <li class="nav-item">
+                        <a href="#" class="nav-link nav-line">
+                          <span class="nav-title">Quests</span>
+                        </a>
+                      </li>
+                  </ul>
+                </div>
                   <div class="townsquare_nav-list_footer font-body font-weight-semibold">
                 <!--
                     <a href="#">Explore Topics <i class="ml-1 fab fa-wpexplorer font-weight-normal"></i></a>

--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -144,6 +144,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                   <div class="search-area">
                     <input type="search" class="form__input w-100" id="keyword" name="keyword" placeholder="Search 🔎" value="{{search}}" style="width: 100px;">
                   </div>
+                  <div class="bg-lightblue pt-1 d-flex flex-column flex-sm-row justify-content-between">
+                    <div class="btn-group-toggle text-left activity_type_selector" data-toggle="buttons">
+                      {% if tags %}
+                        {% for tag in tags %}
+                          <label class="btn btn-radio m-1 mb-md-0 frontend font-weight-semibold font-caption py-0 px-2 font-smaller-2 " >
+                            <input type="checkbox" name="activity_type" value="{{tag.0}}" autocomplete="off">
+                          {{tag.0}}
+                          </label>
+                        {% endfor %}
+                      {% endif %}
+                    </div>
+                  </div>
                   <div class="mt-2">
                     <div class="checkbox_container">
                       <input name="tribe_only" id="tribe_only" type="checkbox" value="0" val-ui='Tribe' {% if tribe_only %}checked=checked{%endif%} />
@@ -164,6 +176,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                       <span class="checkbox"></span>
                       <div class="filter-label ml-1">
                         <label for=beginner>{% trans "Trending Only" %}</label>
+                      </div>
+                    </div>
+                    <div class="checkbox_container">
+                      <input name="trending" id="trending" type="checkbox" value="0" val-ui='Trending' {% if trending_only %}checked=checked{%endif%} />
+                      <span class="checkbox"></span>
+                      <div class="filter-label ml-1">
+                        <label for=beginner>{% trans "From New Users" %}</label>
+                      </div>
+                    </div>
+                    <div class="checkbox_container">
+                      <input name="trending" id="trending" type="checkbox" value="0" val-ui='Trending' {% if trending_only %}checked=checked{%endif%} />
+                      <span class="checkbox"></span>
+                      <div class="filter-label ml-1">
+                        <label for=beginner>{% trans "From Influencers" %}</label>
                       </div>
                     </div>
                   </div>

--- a/app/townsquare/views.py
+++ b/app/townsquare/views.py
@@ -77,7 +77,7 @@ def town_square(request):
             default_tab = 'grants'
 
             new_tab = {
-                'title': f'Bounties',
+                'title': f'Bounties/Tips',
                 'slug': f'bounties',
                 'helper_text': f'Activity on the {num_grants_relationships} Bounties you\'ve created or funded.',
                 'badge': num_grants_relationships
@@ -86,6 +86,8 @@ def town_square(request):
             default_tab = 'grants'
 
     hours = 24 if not settings.DEBUG else 1000
+
+    tags = [('#announce','bullhorn'), ('#mentor','terminal'), ('#jobs','code'), ('#help','laptop-code'), ('#other','briefcase'), ('#meme','briefcase'), ]
 
     connect_last_24_hours = lazy_round_number(Activity.objects.filter(activity_type__in=['status_update', 'wall_post'], created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count())
     if connect_last_24_hours:
@@ -96,7 +98,7 @@ def town_square(request):
             'helper_text': f'The {connect_last_24_hours} announcements, requests for help, kudos jobs, mentorship, or other connective requests on Gitcoin in the last 24 hours.',
             'badge': connect_last_24_hours
         }
-        tabs = tabs + [new_tab]
+        tabs = [new_tab] + tabs
 
     kudos_last_24_hours = lazy_round_number(Activity.objects.filter(activity_type__in=['new_kudos', 'receive_kudos'], created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count())
     if kudos_last_24_hours:
@@ -113,9 +115,10 @@ def town_square(request):
         for hackathon in hackathons:
             default_tab = f'hackathon:{hackathon.pk}'
             new_tab = {
-                'title': hackathon.name,
+                'title': f"{hackathon.name} Hackathon",
                 'slug': default_tab,
                 'helper_text': f'Activity from the {hackathon.name} Hackathon.',
+                'badge': kudos_last_24_hours
             }
             tabs = tabs + [new_tab]
 
@@ -225,7 +228,7 @@ def town_square(request):
         'is_townsquare': True,
         'trending_only': bool(trending_only),
         'search': search,
-        'tags': [('#announce','bullhorn'), ('#mentor','terminal'), ('#jobs','code'), ('#help','laptop-code'), ('#other','briefcase'), ],
+        'tags': tags,
         'announcements': announcements,
         'is_subscribed': is_subscribed,
         'offers_by_category': offers_by_category,


### PR DESCRIPTION
This is a re-imaginging of the townsquare nav that

1. SEARCH - suggests search terms (spoiler alert: the same search terms from the status posting module)
2. SEARCH - adds filters so you can filter ANY tab by your tribe, your threads you've previously interacted with, new users only, influencers only.
3. FEED - consolidates the feed tab so that things that relate to ME as the user are broken into filters in SEARCH . (eg My Relationships, My Grants).
4. adds an 'explore' area which conveniently links out to user search, grants search, etc

<img width="259" alt="Screen Shot 2020-02-24 at 11 51 39 AM" src="https://user-images.githubusercontent.com/513929/75181684-0db5ff80-56fc-11ea-9e9d-d24a3fa4f766.png">

What do people think?  Does this help you navigate the network easier?