### PR TITLE
Make amount, contributors, and match_amount more readable in mini-clr leaderboard

### DIFF
--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -297,7 +297,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     Ref Link <i data-toggle="tooltip" data-html="true" class="fas fa-info-circle mr-3" title="
                     <strong>
                       Gitcoin is better with friends!
-                    </strong> - 
+                    </strong> -
                     Do you have a coworker, classmate, or friend that would benefit from access to Gitcoin's products?  Send them this reflink to get them onboarded.
                     <BR>
                     How it works:
@@ -467,9 +467,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             {% endfor %}
                           </ul>
                           ">
-                            {{mli.contributors}} x
-                            ${{mli.amount}} =
-                            ${{mli.match_amount}}
+                            ${{mli.amount}} from
+                            {{mli.contributors}} contributor means
+                            ${{mli.match_amount}} matched
                             <br>
                             {% if not mli.following %}
                               <a class="btn btn-gc-blue btn-sm follow_button mt-2" data-jointribe='{{mli.handle}}' href="#">Follow </a>

--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -468,8 +468,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                           </ul>
                           ">
                             ${{mli.amount}} from
-                            {{mli.contributors}} contributor means
-                            ${{mli.match_amount}} matched
+                            {{mli.contributors}} contributor <br>
+                            <span style="color:#17a2b8;">${{mli.match_amount}} matched</span>
                             <br>
                             {% if not mli.following %}
                               <a class="btn btn-gc-blue btn-sm follow_button mt-2" data-jointribe='{{mli.handle}}' href="#">Follow </a>


### PR DESCRIPTION
Based on: https://gitcoin.co/townsquare?tab=activity:140260

For each ranked user, it current provides the amount, contributors, and match amount in the following format: `amount x contributors = match_amount`

The concern is this reads wrong and I agree. Alternative is: `amount from contributors amount matched`

Example: ` $41.78 from 13 contributors $60.66 matched`

Screenshot:

![222222](https://user-images.githubusercontent.com/1489224/75190350-1dded680-571e-11ea-8d14-eb1cf2881f1d.png)
