### PR TITLE
vacuum tables on our own schedule

### DIFF
--- a/app/perftools/management/commands/vacuum.py
+++ b/app/perftools/management/commands/vacuum.py
@@ -1,0 +1,47 @@
+'''
+    Copyright (C) 2019 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+'''
+
+import time
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+SLEEP_TIME_BETWEEN_VACUUMS_S = 10
+
+
+class Command(BaseCommand):
+
+    help = 'vacuums all the postgres tables; on our schedule (auto vacuumer cant take site down anymore'
+
+    def handle(self, *args, **options):
+        tables = connection.introspection.table_names()
+        seen_models = connection.introspection.installed_models(tables)
+        cursor = connection.cursor()
+
+        for model in seen_models:
+            table = model._meta.db_table
+            query = f"VACUUM {table};"
+
+            start_time = time.time()
+            cursor.execute(query)
+            end_time = time.time()
+
+            total_time = round(end_time - start_time, 2)
+            print(f"{table} took {total_time}s")
+
+            time.sleep(SLEEP_TIME_BETWEEN_VACUUMS_S)

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -79,6 +79,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 
 
 0 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash create_gas_history  >> /var/log/gitcoin/create_gas_history.log  2>&1
+0 19 * * 7 cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash vacuum  >> /var/log/gitcoin/vacuum.log  2>&1
 5 */3 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash create_page_cache  >> /var/log/gitcoin/create_page_cache.log  2>&1
 */2 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash create_activity_cache  >> /var/log/gitcoin/create_activity_cache.log  2>&1
 


### PR DESCRIPTION
as you guys know, i have OCD about site speed.  so today when the postgres auto vacuum er locked up the site, i had a conniption.

i wrote this quick script to turn off the auto vacuumer https://bits.owocki.com/bLum0Ene 

and then i wrote this PR so we could vacuuum the site on our own schedule.. when load is lowest (sundays)

sample output:
```
root@f48599102c8a:/code/app# ./manage.py vacuum
dashboard_profilestathistory took 0.66s
quests_questfeedback took 0.05s
economy_conversionrate took 0.18s
feeswapper_currencyconversion took 0.07s
dashboard_blockedurlfilter took 0.02s
townsquare_like took 0.02s
faucet_faucetrequest took 0.03s
grants_update took 0.02s
marketing_accountdeletionrequest took 0.02s
dashboard_bounty took 1.97s
economy_token took 0.03s
auth_group took 0.02s
dashboard_coupon took 0.02s
townsquare_matchranking took 0.03s
avatar_socialavatar took 0.02s
tdi_accesscodes took 0.02s
django_session took 0.09s
gas_gasadvisory took 0.02s
marketing_alumni took 0.02s
townsquare_announcement took 0.02s
```

proof of sundays being the slow time for us:
<img width="252" alt="Screen Shot 2020-03-04 at 2 45 46 PM" src="https://user-images.githubusercontent.com/513929/75926092-1f4b8580-5e27-11ea-9cd7-250a97ee722b.png">
