### PR TITLE
add .gitattributes and ensure LF for shell files - fixes exit code 2 of Worker in local docker builds on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh   text eol=lf


### PR DESCRIPTION
add .gitattributes and ensure LF for shell files - fixes exit code 2 of Worker in local Docker builds on Windows

closes https://github.com/gitcoinco/web/issues/6136