### PR TITLE
Handle Prod Timeout Worker Approve Timeout Errors

### DIFF
--- a/app/app/context.py
+++ b/app/app/context.py
@@ -131,7 +131,9 @@ def preprocess(request):
         'github_handle': request.user.username if user_is_authenticated else False,
         'email': request.user.email if user_is_authenticated else False,
         'name': request.user.get_full_name() if user_is_authenticated else False,
-        'last_chat_status': request.user.profile.last_chat_status if (hasattr(request.user, 'profile') and user_is_authenticated) else False,
+        'last_chat_status':
+            request.user.profile.last_chat_status if
+            (hasattr(request.user, 'profile') and user_is_authenticated) else False,
         'raven_js_version': settings.RAVEN_JS_VERSION,
         'raven_js_dsn': settings.SENTRY_JS_DSN,
         'release': settings.RELEASE,

--- a/app/app/utils.py
+++ b/app/app/utils.py
@@ -1,6 +1,8 @@
 import email
+import functools
 import imaplib
 import logging
+import multiprocessing.pool
 import os
 import re
 import time
@@ -490,3 +492,22 @@ def get_profiles_from_text(text):
     username_pattern = re.compile(r'@(\S+)')
     mentioned_usernames = re.findall(username_pattern, text)
     return Profile.objects.filter(handle__in=mentioned_usernames).distinct()
+
+
+def timeout(max_timeout):
+    """Timeout decorator, parameter in seconds."""
+
+    def timeout_decorator(item):
+        """Wrap the original function."""
+
+        @functools.wraps(item)
+        def func_wrapper(*args, **kwargs):
+            """Closure for function."""
+            pool = multiprocessing.pool.ThreadPool(processes=1)
+            async_result = pool.apply_async(item, args, kwargs)
+            # raises a TimeoutError if execution exceeds max_timeout
+            return async_result.get(max_timeout)
+
+        return func_wrapper
+
+    return timeout_decorator

--- a/app/avatar/views_3d.py
+++ b/app/avatar/views_3d.py
@@ -766,7 +766,10 @@ def save_custom_avatar(request, output):
             profile.activate_avatar(custom_avatar.pk)
             profile.save()
             create_user_action(profile.user, 'updated_avatar', request)
-            messages.info(request, f'Your avatar has been updated & will be refreshed when the cache expires (every hour). Or hard refresh (Apple-Shift-R) to view it now.')
+            messages.info(
+                request,
+                f'Your avatar has been updated & will be refreshed when the cache expires (every hour). Or hard refresh (Apple-Shift-R) to view it now.'
+            )
             response['message'] = 'Avatar updated'
     except Exception as e:
         logger.exception(e)

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -31,6 +31,7 @@ from django.utils.translation import gettext_lazy as _
 
 import requests
 import twitter
+from app.utils import timeout
 from economy.utils import convert_token_to_usdt
 from git.utils import delete_issue_comment, org_name, patch_issue_comment, post_issue_comment, repo_name
 from marketing.mails import featured_funded_bounty, send_mail, setup_lang, tip_email
@@ -255,7 +256,7 @@ def build_message_for_integration(bounty, event_name):
           f"\n{bounty.get_absolute_url()}"
     return msg
 
-
+@timeout(2)
 def maybe_market_to_user_slack(bounty, event_name):
     """Send a Slack message to the user's slack channel for the specified Bounty.
 

--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -256,8 +256,15 @@ def build_message_for_integration(bounty, event_name):
           f"\n{bounty.get_absolute_url()}"
     return msg
 
-@timeout(2)
+
 def maybe_market_to_user_slack(bounty, event_name):
+    try:
+        return maybe_market_to_user_slack_helper(bounty, event_name)
+    except TimeoutError as e:
+        logger.exception(e)
+
+@timeout(1)
+def maybe_market_to_user_slack_helper(bounty, event_name):
     """Send a Slack message to the user's slack channel for the specified Bounty.
 
     Args:

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1776,10 +1776,7 @@ def helper_handle_approvals(request, bounty):
 
                 maybe_market_to_github(bounty, 'work_started', profile_pairs=bounty.profile_pairs)
                 maybe_market_to_slack(bounty, 'worker_approved')
-                try:
-                    maybe_market_to_user_slack(bounty, 'worker_approved')
-                except TimeoutError:
-                    pass
+                maybe_market_to_user_slack(bounty, 'worker_approved')
                 record_bounty_activity(bounty, request.user, 'worker_approved', interest)
             else:
                 start_work_rejected(interest, bounty)
@@ -1789,10 +1786,7 @@ def helper_handle_approvals(request, bounty):
                 interest.delete()
 
                 maybe_market_to_slack(bounty, 'worker_rejected')
-                try:
-                    maybe_market_to_user_slack(bounty, 'worker_rejected')
-                except TimeoutError:
-                    pass
+                maybe_market_to_user_slack(bounty, 'worker_rejected')
 
             messages.success(request, _(f'{worker} has been {mutate_worker_action_past_tense}'))
         else:

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1776,7 +1776,10 @@ def helper_handle_approvals(request, bounty):
 
                 maybe_market_to_github(bounty, 'work_started', profile_pairs=bounty.profile_pairs)
                 maybe_market_to_slack(bounty, 'worker_approved')
-                maybe_market_to_user_slack(bounty, 'worker_approved')
+                try:
+                    maybe_market_to_user_slack(bounty, 'worker_approved')
+                except TimeoutError:
+                    pass
                 record_bounty_activity(bounty, request.user, 'worker_approved', interest)
             else:
                 start_work_rejected(interest, bounty)
@@ -1786,7 +1789,10 @@ def helper_handle_approvals(request, bounty):
                 interest.delete()
 
                 maybe_market_to_slack(bounty, 'worker_rejected')
-                maybe_market_to_user_slack(bounty, 'worker_rejected')
+                try:
+                    maybe_market_to_user_slack(bounty, 'worker_rejected')
+                except TimeoutError:
+                    pass
 
             messages.success(request, _(f'{worker} has been {mutate_worker_action_past_tense}'))
         else:


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
Uses a [solution found here](https://stackoverflow.com/questions/492519/timeout-on-a-function-call) to prevent production timeout errors.

adds a re-usable decorator for managing those timeouts

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Production timeout errors on approving users
<img width="1748" alt="Screen Shot 2020-03-16 at 11 15 13 AM" src="https://user-images.githubusercontent.com/513929/76783476-89ddb900-6777-11ea-9ea4-ffc4890af9be.png">


##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
```
from app.utils import timeout
import time

@timeout(2)
def foo():
    time.sleep(10)

foo()
```

will yield

```
---------------------------------------------------------------------------
TimeoutError                              Traceback (most recent call last)
<ipython-input-1-f4b9f2b0c14b> in <module>
      6     time.sleep(10)
      7
----> 8 foo()

/code/app/app/utils.py in func_wrapper(*args, **kwargs)
    508             async_result = pool.apply_async(item, args, kwargs)
    509             # raises a TimeoutError if execution exceeds max_timeout
--> 510             return async_result.get(max_timeout)
    511
    512         return func_wrapper

/usr/lib/python3.6/multiprocessing/pool.py in get(self, timeout)
    638         self.wait(timeout)
    639         if not self.ready():
--> 640             raise TimeoutError
    641         if self._success:
    642             return self._value

TimeoutError:

In [2]:
```