### PR TITLE
match strictly to prevent profiles starting with web3 from redirecting

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -449,7 +449,7 @@ urlpatterns = [
     re_path(r'^medium/?', retail.views.medium, name='medium'),
     re_path(r'^github/?', retail.views.github, name='github'),
     re_path(r'^youtube/?', retail.views.youtube, name='youtube'),
-    re_path(r'^web3/?', retail.views.web3, name='web3'),
+    re_path(r'^web3$/?', retail.views.web3, name='web3'),
 
     # increase funding limit
     re_path(r'^requestincrease/?', retail.views.increase_funding_limit_request, name='increase_funding_limit_request'),


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR fixes an issue where a username starting with the prefix "web3" would get handled by the wrong view if trying to view their profile.

##### Refers/Fixes

reported on slack

##### Testing

tested locally
