### PR TITLE
Allow hackathon sponsors to mass email hacker registrants 

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -4589,6 +4589,15 @@ class HackathonEvent(SuperModel):
     def town_square_link(self):
         return f'townsquare/?tab=hackathon:{self.pk}'
 
+    def is_sponsor_tribe_admin(self, username):
+        for sponsor in self.sponsors.all():
+            if sponsor.tribe is not None:
+                for tribe_member in sponsor.tribe.tribe_members.all():
+                    if username == tribe_member.profile.handle:
+                        return tribe_member.leader
+        return False
+
+
     def get_absolute_url(self):
         """Get the absolute URL for the HackathonEvent.
 

--- a/app/dashboard/templates/dashboard/index-vue.html
+++ b/app/dashboard/templates/dashboard/index-vue.html
@@ -366,7 +366,7 @@
                     <div class="feed_container col-12 col-lg-8">
                       <div class="feed_container_child">
                         {% csrf_token %}
-                        {% include 'townsquare/shared/shareactivity.html' %}
+                        {% include 'profiles/status_box.html' with suppress_tags=1 placeholder="What are you thinking?" max_length=1000 suppress_data_toggle=1 what="hackathon" whatid=hackathon_event.id %}
 
                         <div id="activities" class="activity_stream {% if not is_search %}mt-4{% endif %}">
                           <span id=activity_subheader>

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 '''
     Copyright (C) 2020 Gitcoin Core
 
@@ -3623,17 +3624,6 @@ def hackathon(request, hackathon='', panel='prizes'):
         }
         orgs.append(org)
 
-
-    import pdb; pdb.set_trace()
-    is_sponsor_tribe_admin = False
-    for sponsor in hackathon_event.sponsors.all():
-        if sponsor.tribe is not None:
-            for tribe_member in sponsor.tribe.tribe_members.all():
-                if request.user.username == tribe_member.profile.handle \
-                                                    and tribe_member.leader == True:
-                    is_sponsor_tribe_admin = True
-                    break
-
     if hasattr(request.user, 'profile') == False:
         is_registered = False
     else:
@@ -3688,7 +3678,11 @@ def hackathon(request, hackathon='', panel='prizes'):
         'use_pic_card': True,
         'projects': [],
         'panel': active_tab,
-        'options': [(f'Email Hackathon Participants ({hacker_count})', 'bullhorn', 'Select this option to email your status update to all the hackathon participants.')] if is_sponsor_tribe_admin else [],
+        'options': [(
+            f'Email Hackathon Participants ({hacker_count})',
+            'bullhorn', 
+            'Select this option to email your status update to all the hackathon participants.'
+        )] if hackathon_event.is_sponsor_tribe_admin(request.user.username) else [],
     }
 
     if hackathon_event.identifier == 'grow-ethereum-2019':

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3624,6 +3624,7 @@ def hackathon(request, hackathon='', panel='prizes'):
         orgs.append(org)
 
 
+    import pdb; pdb.set_trace()
     is_sponsor_tribe_admin = False
     for sponsor in hackathon_event.sponsors.all():
         if sponsor.tribe is not None:

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -32,20 +32,19 @@ from app.utils import get_profiles_from_text
 from marketing.utils import func_name, get_or_save_email_subscriber, should_suppress_notification_email
 from python_http_client.exceptions import HTTPError, UnauthorizedError
 from retail.emails import (
-    email_to_profile, get_notification_count, render_admin_contact_funder, render_bounty_changed,
-    render_bounty_expire_warning, render_bounty_feedback, render_bounty_request, render_bounty_startwork_expire_warning,
-    render_bounty_unintersted, render_comment, render_faucet_rejected, render_faucet_request,
-    render_featured_funded_bounty, render_funder_payout_reminder, render_funder_stale, render_gdpr_reconsent,
-    render_gdpr_update, render_grant_cancellation_email, render_grant_update, render_kudos_email,
-    render_match_distribution, render_match_email, render_mention, render_new_bounty, render_new_bounty_acceptance,
-    render_new_bounty_rejection, render_new_bounty_roundup, render_new_grant_email, render_new_supporter_email,
-    render_new_work_submission, render_no_applicant_reminder, render_nth_day_email_campaign, render_quarterly_stats,
-    render_request_amount_email, render_reserved_issue, render_share_bounty,
-    render_start_work_applicant_about_to_expire, render_start_work_applicant_expired, render_start_work_approved,
-    render_start_work_new_applicant, render_start_work_rejected, render_subscription_terminated_email,
-    render_successful_contribution_email, render_support_cancellation_email, render_tax_report,
-    render_thank_you_for_supporting_email, render_tip_email, render_unread_notification_email_weekly_roundup,
-    render_wallpost, render_weekly_recap,
+    render_admin_contact_funder, render_bounty_changed, render_bounty_expire_warning, render_bounty_feedback,
+    render_bounty_request, render_bounty_startwork_expire_warning, render_bounty_unintersted, render_comment,
+    render_faucet_rejected, render_faucet_request, render_featured_funded_bounty, render_funder_payout_reminder,
+    render_funder_stale, render_gdpr_reconsent, render_gdpr_update, render_grant_cancellation_email,
+    render_grant_update, render_kudos_email, render_match_distribution, render_match_email, render_mention,
+    render_new_bounty, render_new_bounty_acceptance, render_new_bounty_rejection, render_new_bounty_roundup,
+    render_new_grant_email, render_new_supporter_email, render_new_work_submission, render_no_applicant_reminder,
+    render_nth_day_email_campaign, render_quarterly_stats, render_request_amount_email, render_reserved_issue, 
+    render_share_bounty, render_start_work_applicant_about_to_expire, render_start_work_applicant_expired, 
+    render_start_work_approved, render_start_work_new_applicant, render_start_work_rejected, 
+    render_subscription_terminated_email, render_successful_contribution_email, render_support_cancellation_email, 
+    render_tax_report, render_thank_you_for_supporting_email,render_tip_email, render_unread_notification_email_weekly_roundup,
+    render_wallpost, render_weekly_recap, render_hackathon_update,
 )
 from sendgrid.helpers.mail import Attachment, Content, Email, Mail, Personalization
 from sendgrid.helpers.stats import Category
@@ -491,6 +490,27 @@ def mention_email(post, to_emails):
 
     translation.activate(cur_language)
 
+def hackathon_wall_post_email(activity, participants):
+    to_emails = []
+    what = activity.hackathonevent.name
+    print('Try count partipants')
+    for pt in participants:
+        to_emails.append(pt.registrant.email)
+
+    subject = f"📣 Message from @{activity.profile.handle} of Gitcoin Hackathon Event: {what}"
+
+    cur_language = translation.get_language()
+    for to_email in to_emails:
+        try:
+            setup_lang(to_email)
+            from_email = settings.CONTACT_EMAIL
+            html, text = render_hackathon_update(to_email, activity)
+
+            if not should_suppress_notification_email(to_email, 'wall_post'):
+                send_mail(from_email, to_email, subject, text, html, categories=['transactional', func_name()])
+        finally:
+            pass
+    translation.activate(cur_language)
 
 def tip_comment_awarded_email(post, to_emails):
     subject = gettext("🏆 @{} has awarded you.").format(post.profile.handle)
@@ -507,6 +527,8 @@ def tip_comment_awarded_email(post, to_emails):
         except Exception as e:
             logger.error('Status Update error - Error: (%s) - Handle: (%s)', e, to_email)
     translation.activate(cur_language)
+
+
 
 
 def wall_post_email(activity):

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -816,6 +816,18 @@ def render_mention(to_email, post):
     return response_html, response_txt
 
 
+def render_hackathon_update(to_email, activity):
+    params = {
+        'activity': activity,
+        'email_type': 'hackathonevent_updates',
+        'subscriber': get_or_save_email_subscriber(to_email, 'internal'),
+    }
+
+    response_html = premailer_transform(render_to_string("emails/hackathon_update.html", params))
+    response_txt = render_to_string("emails/hackathon_update.txt", params)
+
+    return response_html, response_txt
+
 def render_grant_update(to_email, activity):
     params = {
         'activity': activity,

--- a/app/retail/templates/emails/hackathon_update.html
+++ b/app/retail/templates/emails/hackathon_update.html
@@ -1,0 +1,51 @@
+{% extends 'emails/template.html' %}
+{% comment %}
+  Copyright (C) 2018 Gitcoin Core
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+{% endcomment %}
+{% load i18n humanize %}
+
+{% block content %}
+
+<h1>💬@{{activity.profile.handle}} writes: 💬</h1>
+
+<p>
+
+<a href="{{activity.profile.url}}">@{{activity.profile.handle}}</a> sent a message to the participants of {{activity.hackathonevent.name}}. This is what they said:
+
+<pre>
+  {{activity.metadata.title}}
+</pre>
+
+<div style="margin-bottom: 2em; margin-top: 2em;">
+  <a class="button" href="{{ activity.url }}">View Message</a>
+</div>
+- OR -
+<div style="margin-bottom: 1em; margin-top: 1em;">
+  <a class="" href="{{ activity.hackathonevent.quest_link }}?unsubscribe=1">Unsubscribe to Messages from @{{activity.hackathonevent.name}}</a>
+</div>
+- OR -
+<div style="margin-bottom: 1em; margin-top: 1em;">
+  <a class="" href="{% url "email_settings" subscriber.priv %}{% if email_type %}?type={{email_type}}{% endif %}">Unsubscribe From ALL Hackathon Event Updates</a>
+</div>
+
+</p>
+
+<br>
+
+
+
+
+{% endblock %}

--- a/app/retail/templates/emails/hackathon_update.txt
+++ b/app/retail/templates/emails/hackathon_update.txt
@@ -1,0 +1,4 @@
+💬 Message from @{{activity.profile.handle}} 💬
+
+To view the update click here: {{activity.url}}
+

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -42,7 +42,7 @@ from django.views.decorators.csrf import csrf_exempt
 from app.utils import get_default_network, get_profiles_from_text
 from cacheops import cached_as, cached_view, cached_view_as
 from dashboard.models import (
-    Activity, Bounty, HackathonRegistration, HackathonEvent, Profile, Tip, TribeMember, get_my_earnings_counter_profiles, get_my_grants,
+    Activity, Bounty, HackathonEvent, Profile, Tip, TribeMember, get_my_earnings_counter_profiles, get_my_grants,
 )
 from dashboard.notifications import amount_usdt_open_work, open_bounties
 from dashboard.tasks import grant_update_email_task
@@ -1199,8 +1199,7 @@ def create_status_update(request):
                 if 'Email Grant Funders' in activity.metadata.get('ask'):
                     grant_update_email_task.delay(activity.pk)
                 if 'Email Hackathon Participants' in activity.metadata.get('ask'):
-                    participants = HackathonRegistration.objects.filter(hackathon=activity.hackathonevent).all()
-                    hackathon_wall_post_email(activity, participants)
+                    hackathon_wall_post_email_task.delay(activity.pk)
                 else:
                     wall_post_email(activity)
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Allow hackathon sponsors to mass email hacker registrants. Update the Hackathon event to have a statusbox option that sends the message to all the participants

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/6500

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

From a database relationship perspective, I created a few Sponsors and linked an Organization Profile as a Tribe. I also added Tribe members and some leaders to this linked tribe so that only leaders/admins of the tribe are able to get the 'Mass Email' checkbox.

For the UX I opted (as described on the bounty) to copy the UX of the Grant page mass emailer status box. I had to disable the tags as they mess with the `activity.metadata.get('ask')` attribute which is needed for the `wall_post_email` function to be called.

##  Loading the Hackathon event Townsquare as Tribe Leader for Sponsor
![Loading the Townsquare as Tribe Leader for Sponsor](https://i.imgur.com/LMdGF8M.png "Loading the Townsquare as Tribe Leader for Sponsor")

## Participant Debug Email received
![Participant Debug Email received](https://i.imgur.com/NDB3P7a.png "Participant Debug Email received")

##  Loading the Hackathon event Townsquare as a regular user, non-admin non Tribe member
![non-admin non Tribe member](https://i.imgur.com/zrmYBoQ.png "non-admin non Tribe member")



