### PR TITLE
Bump version of django-autotranslate

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ geoip2==2.8.0
 django-silk==2.0.0
 django-extensions==2.2.1
 ipdb==0.11
-django-autotranslate==1.1.0
+django-autotranslate==1.1.1
 svgutils==0.3.0
 watchdog==0.9.0
 Werkzeug[watchdog]==0.15.5


### PR DESCRIPTION
##### Description

This PR bumps the version of django-autotranslate to its latest release. It solves the error being raised when building the web docker container using a version of pip>=20.1

```
Collecting django-autotranslate==1.1.0
  Downloading django-autotranslate-1.1.0.tar.gz (8.7 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-05q5rnle/django-autotranslate/setup.py'"'"'; __file__='"'"'/tmp/pip-install-05q5rnle/django-autotranslate/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-jfqeewod
         cwd: /tmp/pip-install-05q5rnle/django-autotranslate/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-05q5rnle/django-autotranslate/setup.py", line 25, in <module>
        requirements = [str(ir.req) for ir in install_requirements]
      File "/tmp/pip-install-05q5rnle/django-autotranslate/setup.py", line 25, in <listcomp>
        requirements = [str(ir.req) for ir in install_requirements]
    AttributeError: 'ParsedRequirement' object has no attribute 'req'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Service 'web' failed to build: The command '/bin/sh -c pip3 install --upgrade -r test.txt' returned a non-zero code: 1
```

##### Refers/Fixes

Refs https://github.com/ankitpopli1891/django-autotranslate/pull/26
