### PR TITLE
limit maximum input in the comments 500 chars

### DIFF
--- a/app/assets/v2/js/activity.js
+++ b/app/assets/v2/js/activity.js
@@ -791,7 +791,7 @@ $(document).ready(function() {
             <img src="/dynamic/avatar/${document.contxt.github_handle}">
           </div>
           <div class="comment-area col-12 col-sm-11 text-right">
-            <textarea class="form-control bg-lightblue font-caption enter-activity-comment" placeholder="Enter comment" cols="80" rows="3">${existing_text}</textarea>
+            <textarea class="form-control bg-lightblue font-caption enter-activity-comment" placeholder="Enter comment" cols="80" rows="3" maxlength="500">${existing_text}</textarea>
             <div class="emoji-container position-absolute d-flex flex-wrap">
               <button class="btn btn-sm p-1 emoji_button grey" data-toggle="tooltip" title="Add an emoji to post.">
                 <i class="far fa-fw fa-smile"></i>


### PR DESCRIPTION
limit maximum input in the comments otherwise, you will get something like this

https://gitcoin.co/townsquare?tab=activity:273525

![image](https://user-images.githubusercontent.com/12363020/81730379-f8d84500-947c-11ea-93a0-c2290001a5c3.png)


so better allow maximum 500 chararacters