### PR TITLE
Import Grant model used in townsquare utils

### DIFF
--- a/app/townsquare/utils.py
+++ b/app/townsquare/utils.py
@@ -1,4 +1,5 @@
 from .models import Offer
+from grants.models import Grant
 
 
 def is_user_townsquare_enabled(user):


### PR DESCRIPTION
##### Description

When logged in and visiting the Grant Details page, the backend is throwing an error due to a missing import. This PR adds the import needed.
