### PR TITLE
re-enable free kudos for Gitcoin Quests/Grants

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -2874,7 +2874,7 @@ class Profile(SuperModel):
         kt_sender_profile = KudosTransfer.objects.filter(sender_profile=self)
 
         kudos_transfers = kt_address | kt_sender_profile
-        kudos_transfers = kudos_transfers.send_success() | kudos_transfers.send_pending()
+        kudos_transfers = kudos_transfers.send_success() | kudos_transfers.send_pending() | kudos_transfers.not_submitted()
         kudos_transfers = kudos_transfers.filter(
             kudos_token_cloned_from__contract__network=settings.KUDOS_NETWORK
         )

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1457,6 +1457,10 @@ class SendCryptoAssetQuerySet(models.QuerySet):
         """Filter results down to successful sends only."""
         return self.filter(tx_status='success').exclude(txid='')
 
+    def not_submitted(self):
+        """Filter results down to successful sends only."""
+        return self.filter(tx_status='not_subed')
+
     def send_pending(self):
         """Filter results down to pending sends only."""
         return self.filter(tx_status='pending').exclude(txid='')
@@ -1496,6 +1500,7 @@ class SendCryptoAsset(SuperModel):
         ('error', 'error'),
         ('unknown', 'unknown'),
         ('dropped', 'dropped'),
+        ('not_subed', 'not_subed'), # not submitted to chain yet
     )
 
     web3_type = models.CharField(max_length=50, default='v3')
@@ -2853,7 +2858,7 @@ class Profile(SuperModel):
         kudos_transfers = kudos_transfers.filter(
             kudos_token_cloned_from__contract__network=settings.KUDOS_NETWORK
         )
-        kudos_transfers = kudos_transfers.send_success() | kudos_transfers.send_pending()
+        kudos_transfers = kudos_transfers.send_success() | kudos_transfers.send_pending() | kudos_transfers.not_submitted()
 
         # remove this line IFF we ever move to showing multiple kudos transfers on a profile
         kudos_transfers = kudos_transfers.distinct('id')

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -194,7 +194,7 @@ def get_fund_reward(request, grant):
         secret=_key,
         comments_to_put_in_kudos_transfer=f"Thank you for funding '{grant.title}' on Gitcoin Grants!",
         sender_profile=Profile.objects.get(handle='gitcoinbot'),
-        make_paid_for_first_minutes=300,
+        make_paid_for_first_minutes=0,
         )
 
     #store btc on session

--- a/app/kudos/templates/transaction/receive_bulk.html
+++ b/app/kudos/templates/transaction/receive_bulk.html
@@ -24,16 +24,23 @@
 <!-- Main -->
 <section id="main" class="box-transaction">
   <header class="text-center">
-  <div id="receove_eth_done" class="text-center" {% if not kudos_transfer.receive_txid %} style="display:none;" {% endif %}>
+  <div id="receove_eth_done" class="text-center" {% if not kudos_transfer.receive_txid and kudos_transfer.tx_status != 'not_subed' %} style="display:none;" {% endif %}>
     <h1>{% trans "Congrats!" %} 🎉</h1>
     <p>You've received a "{{ coupon.token.humanized_name }}" Kudos 
-      {% if kudos_transfer.receive_txid != 'pending_celery' %}
+      {% if kudos_transfer.tx_status == 'not_subed' %}
+      to your Gitcoin profile.  The web3 transaction will be submitted when gas fees are below 10 gWei.
+      {% elif kudos_transfer.receive_txid != 'pending_celery' %}
         via transaction <a href="https://etherscan.io/tx/{{kudos_transfer.receive_txid}}"><span id="trans_id">{{kudos_transfer.receive_txid}}</span></a>
       {% else %}
       {% endif %}
 
     .</p>
-    <p>{% trans "You can see your kudos in any web3 wallet that supports ERC-721-compliant NFTs, or in your" %} <a href="{% url 'profile' %}">Gitcoin {% trans "profile" %}</a>.</p>
+    <p>
+      {% if kudos_transfer.tx_status == 'not_subed' %}
+      Once the web3 transaction has been submitted, 
+      {% endif %}
+
+      {% trans "You can see your kudos in any web3 wallet that supports ERC-721-compliant NFTs, or in your" %} <a href="{% url 'profile' %}">Gitcoin {% trans "profile" %}</a>.</p>
       {% include 'shared/twitter.html' %}
       <p>
         <a class="twitter-share-button"

--- a/app/kudos/views.py
+++ b/app/kudos/views.py
@@ -688,7 +688,7 @@ def receive(request, key, txid, network):
     return TemplateResponse(request, 'transaction/receive.html', params)
 
 
-def redeem_bulk_coupon(coupon, profile, address, ip_address, save_addr=False):
+def redeem_bulk_coupon(coupon, profile, address, ip_address, save_addr=False, submit_later=False, exit_after_sending_tx=False):
     try:
         address = Web3.toChecksumAddress(address)
     except:
@@ -723,18 +723,27 @@ def redeem_bulk_coupon(coupon, profile, address, ip_address, save_addr=False):
         return None, error, None
     else:
 
-        if profile.bulk_transfer_redemptions.filter(coupon=coupon).exists():
-            error = f'You have already redeemed this kudos.'
-            return None, error, None
+        #if profile.bulk_transfer_redemptions.filter(coupon=coupon).exists():
+        #    error = f'You have already redeemed this kudos.'
+        #    return None, error, None
 
 
         signed = w3.eth.account.signTransaction(tx, private_key)
         retry_later = False
-        try:
-            txid = w3.eth.sendRawTransaction(signed.rawTransaction).hex()
-        except Exception as e:
-            txid = "pending_celery"
-            retry_later = True
+        tx_status = 'pending'
+
+        if submit_later:
+            txid = ''
+            tx_status = 'not_subed'
+        else:
+            try:
+                txid = w3.eth.sendRawTransaction(signed.rawTransaction).hex()
+            except Exception as e:
+                txid = "pending_celery"
+                retry_later = True
+
+        if exit_after_sending_tx:
+            return txid, None, None
 
         with transaction.atomic():
             kudos_transfer = KudosTransfer.objects.create(
@@ -757,8 +766,8 @@ def redeem_bulk_coupon(coupon, profile, address, ip_address, save_addr=False):
                 sender_profile=coupon.sender_profile,
                 txid=txid,
                 receive_txid=txid,
-                tx_status='pending',
-                receive_tx_status='pending',
+                tx_status=tx_status,
+                receive_tx_status=tx_status,
                 receive_address=address,
             )
 
@@ -809,7 +818,9 @@ def receive_bulk(request, secret):
         if request.user.is_anonymous:
             error = "You must login."
         if not error:
-            success, error, _ = redeem_bulk_coupon(coupon, request.user.profile, request.POST.get('forwarding_address'), get_ip(request), request.POST.get('save_addr'))
+            submit_later = (recommend_min_gas_price_to_confirm_in_time(1)) > 10 and not coupon.is_paid_right_now
+            submit_later = False
+            success, error, _ = redeem_bulk_coupon(coupon, request.user.profile, request.POST.get('forwarding_address'), get_ip(request), request.POST.get('save_addr'), submit_later=submit_later)
         if error:
             messages.error(request, error)
 

--- a/app/kudos/views.py
+++ b/app/kudos/views.py
@@ -723,9 +723,9 @@ def redeem_bulk_coupon(coupon, profile, address, ip_address, save_addr=False, su
         return None, error, None
     else:
 
-        #if profile.bulk_transfer_redemptions.filter(coupon=coupon).exists():
-        #    error = f'You have already redeemed this kudos.'
-        #    return None, error, None
+        if profile.bulk_transfer_redemptions.filter(coupon=coupon).exists():
+            error = f'You have already redeemed this kudos.'
+            return None, error, None
 
 
         signed = w3.eth.account.signTransaction(tx, private_key)

--- a/app/quests/helpers.py
+++ b/app/quests/helpers.py
@@ -78,7 +78,7 @@ def record_award_helper(qa, profile, layer=1, action='Beat', value_multiplier=1)
             metadata={
                 'recipient': profile.pk,
             },
-            make_paid_for_first_minutes=999999,
+            make_paid_for_first_minutes=1,
             )
         cta_url = btc.url
         cta_text = 'Redeem Kudos'
@@ -205,7 +205,7 @@ def process_win(request, qa):
             metadata={
                 'recipient': request.user.profile.pk,
             },
-            make_paid_for_first_minutes=999999,
+            make_paid_for_first_minutes=1,
             )
     prize_url = tweetify_prize_url(btc.url, quest, request.user)
     qa.success = True

--- a/app/revenue/management/commands/submit_pending_kudos.py
+++ b/app/revenue/management/commands/submit_pending_kudos.py
@@ -1,0 +1,62 @@
+'''
+    Copyright (C) 2019 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+'''
+
+import logging
+import warnings
+import time
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+import requests
+from dashboard.utils import has_tx_mined
+from gas.utils import recommend_min_gas_price_to_confirm_in_time
+from kudos.models import KudosTransfer
+from kudos.views import redeem_bulk_coupon
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+
+    help = 'submits pending kudos, when the gas prices are low enough to do so'
+
+    def handle(self, *args, **options):
+        network = 'mainnet'
+        if int(recommend_min_gas_price_to_confirm_in_time(1)) > 10:
+            return
+        kts = KudosTransfer.objects.not_submitted().filter(network='mainnet')
+        for kt in kts:
+            redemption = kt.bulk_transfer_redemptions.first()
+            address = kt.receive_address
+            profile = kt.recipient_profile
+            coupon = redemption.coupon
+            ip_address = redemption.ip_address
+            tx_id, _, _ = redeem_bulk_coupon(coupon, profile, address, ip_address, exit_after_sending_tx=True)
+            print(tx_id)
+            while not has_tx_mined(tx_id, network):
+                time.sleep(1)
+
+            kt.txid = txid
+            kt.receive_txid = txid
+            kt.receive_tx_status = 'success'
+            kt.tx_status = 'success'
+            kt.save()
+
+
+

--- a/app/revenue/management/commands/submit_pending_kudos.py
+++ b/app/revenue/management/commands/submit_pending_kudos.py
@@ -22,6 +22,7 @@ import warnings
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 import requests
 from dashboard.utils import has_tx_mined
@@ -57,4 +58,6 @@ class Command(BaseCommand):
             kt.receive_txid = txid
             kt.receive_tx_status = 'success'
             kt.tx_status = 'success'
+            kt.received_on = timezone.now()
+            kt.tx_time = timezone.now()
             kt.save()

--- a/app/revenue/management/commands/submit_pending_kudos.py
+++ b/app/revenue/management/commands/submit_pending_kudos.py
@@ -17,11 +17,12 @@
 '''
 
 import logging
-import warnings
 import time
+import warnings
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
 import requests
 from dashboard.utils import has_tx_mined
 from gas.utils import recommend_min_gas_price_to_confirm_in_time
@@ -57,6 +58,3 @@ class Command(BaseCommand):
             kt.receive_tx_status = 'success'
             kt.tx_status = 'success'
             kt.save()
-
-
-

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -22,7 +22,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 */15 3,10,17 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --catchup >> /var/log/gitcoin/sync_kudos_catchup.log 2>&1
 */10 4,11,18 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --start 1 >> /var/log/gitcoin/sync_kudos_all.log 2>&1
 0 */1 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash kudos_revenue mainnet --account-address 0xdb282cee382244e05dd226c8809d2405b76fbdc9  >> /var/log/gitcoin/kudos_revenue.log  2>&1
-*/5 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash submit_pending_kudos  >> /var/log/gitcoin/submit_pending_kudos.log  2>&1
+1,31 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash submit_pending_kudos  >> /var/log/gitcoin/submit_pending_kudos.log  2>&1
 
 ## TOWN SQUARE
 * * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash create_rankings >> /var/log/gitcoin/create_rankings.log 2>&1

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -22,6 +22,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 */15 3,10,17 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --catchup >> /var/log/gitcoin/sync_kudos_catchup.log 2>&1
 */10 4,11,18 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --start 1 >> /var/log/gitcoin/sync_kudos_all.log 2>&1
 0 */1 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash kudos_revenue mainnet --account-address 0xdb282cee382244e05dd226c8809d2405b76fbdc9  >> /var/log/gitcoin/kudos_revenue.log  2>&1
+*/5 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash submit_pending_kudos  >> /var/log/gitcoin/submit_pending_kudos.log  2>&1
 
 ## TOWN SQUARE
 * * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash create_rankings >> /var/log/gitcoin/create_rankings.log 2>&1


### PR DESCRIPTION
A few weeks ago, i noticed that with high gas prices on the eth network, the kudos minter was burning $200 per day in gas fees.

so i introduced a change to require people to pay their own gas, which would cut down the costs.

but following up on that today, it looks like this has really hurt the number of quest players, see below:

<img width="1858" alt="Screen Shot 2020-05-30 at 9 54 14 PM" src="https://user-images.githubusercontent.com/513929/83344144-32ec7800-a2c0-11ea-810c-0d46a973b75a.png">

so i'm introducing this PR, which introduces a "not submitted" state to the kudos transfer object, wherein the kudos will be submitted to one's profile immediately, but not to their web3 wallet until the ethereum network isnt super expensive anymore.

hopefully this approach reaches the twin goal of keeping gitcoin's costs down AND also keeping quest usage up

from testing:
<img width="746" alt="Screen Shot 2020-05-30 at 9 55 23 PM" src="https://user-images.githubusercontent.com/513929/83344195-b9a15500-a2c0-11ea-89ca-e28d8e33f162.png">
