### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p /usr/share/GeoIP/ && \
 RUN pip3 install --upgrade pip setuptools wheel dumb-init pipenv
 
 COPY requirements/ /code/
+RUN apt-get update
 RUN apt-get install -y build-essential libssl-dev python3-dev
 RUN apt-get install -y libsecp256k1-dev
 RUN pip3 install --upgrade -r test.txt


### PR DESCRIPTION
Resolves the `Failed to fetch` error shown in the image below. This occurs when building with `docker-compose up -d --build`

![image](https://user-images.githubusercontent.com/17163988/83572629-c56a6280-a4de-11ea-9014-b82c0d6bcfcb.png)
