### PR TITLE
Fixed all wrong target "blank" to "_blank"

### DIFF
--- a/app/avatar/migrations/0007_auto_20200229_2343.py
+++ b/app/avatar/migrations/0007_auto_20200229_2343.py
@@ -19,7 +19,7 @@ def get_preview_img(key):
 
 def get_artist_bio(key):
     if key == 'metacartel':
-        return 'This piece was originally created by <a target="blank" href="https://twitter.com/frankynines">@frankynies</a>, an amazing artist of Mexican heritage who works at Dapper Labs.'
+        return 'This piece was originally created by <a target="_blank" href="https://twitter.com/frankynines">@frankynies</a>, an amazing artist of Mexican heritage who works at Dapper Labs.'
     if key == 'comic':
         return 'This piece was created by <a target=new href="/TheDataDesigner">@TheDataDesigner</a>.'
     if key == 'square_bot':
@@ -33,7 +33,7 @@ def get_artist_bio(key):
     if key == 'bot':
         return 'This piece was created by <a target=new href="/GuistF">@GuistF</a>.'
     if key == 'bufficorn':
-        return 'The Bufficorn was created by <a target="blank" href="https://twitter.com/EthereumDenver">@EthereumDenver</a>.'
+        return 'The Bufficorn was created by <a target="_blank" href="https://twitter.com/EthereumDenver">@EthereumDenver</a>.'
     return ''
 
 

--- a/app/grants/templates/grants/fund.html
+++ b/app/grants/templates/grants/fund.html
@@ -49,7 +49,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <div class="col-12 text-left mt-md-3">
         <a href="{{ grant.url }}" class="float-left ml-2">< Back to {{ grant.title }}</a>
       </div>
-    </div> 
+    </div>
     <div class="row" id="grants_form">
       <div class="col-12 text-center mt-md-3">
         <img src="/static/v2/images/grants/{{img}}" style="max-width: 200px; max-height: 200px; ">
@@ -233,7 +233,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         <p class="font-body">
                           {% trans "By using this service, you’ll also be contributing" %}
                           <span class="gitcoin-grant-percent">5</span>
-                          {% trans "% of your contribution to the" %} <a href="https://gitcoin.co/grants/86/gitcoin-sustainability-fund" target="blank">Gitcoin Grants Round 6+ Development Fund <i class="fas fa-external-link-alt"></i></a>.
+                          {% trans "% of your contribution to the" %} <a href="https://gitcoin.co/grants/86/gitcoin-sustainability-fund" target="_blank">Gitcoin Grants Round 6+ Development Fund <i class="fas fa-external-link-alt"></i></a>.
                           <br>
                           <a href="#" id="adjust">Adjust &gt;&gt;</a>
                         </p>

--- a/app/grants/templates/grants/shared/landing_hero.html
+++ b/app/grants/templates/grants/shared/landing_hero.html
@@ -12,7 +12,7 @@
                 </span>
                 <span style="">
                   Upcoming Dates:
-                  <br>  
+                  <br>
                   - Grants Round 6 starts {{after_that_next_round_begin|date:'Y-m-d'}}.
                   (<span class="m-0" data-time="{{after_that_next_round_begin|date:'c'}}" data-base_time="{{now|date:'Y-m-d H:i'}}"></span>)
                 </span>
@@ -30,7 +30,7 @@
               </div>
             </div>
             <div class="m-0 col-12 col-md-6 offset-lg-1 col-lg-5 d-none d-sm-block">
-              <h1 class="font-title-xl font-weight-semibold">Get Matching Funding for Your <a style="text-decoration: underline;" target="blank" href="https://en.wikipedia.org/wiki/Public_good_(economics)">Public Goods</a> Projects.</h1>
+              <h1 class="font-title-xl font-weight-semibold">Get Matching Funding for Your <a style="text-decoration: underline;" target="_blank" href="https://en.wikipedia.org/wiki/Public_good_(economics)">Public Goods</a> Projects.</h1>
             </div>
           </div>
         </div>

--- a/app/retail/templates/shared/footer.html
+++ b/app/retail/templates/shared/footer.html
@@ -58,7 +58,7 @@
         <div class="d-flex flex-wrap">
           <div class="sitenav sitenav__product">
             <h5>{% trans "Product" %}</h5>
-            <a href="https://github.com/gitcoinco/web/releases/" target="blank">{% trans "Latest Updates" %}</a>
+            <a href="https://github.com/gitcoinco/web/releases/" target="_blank">{% trans "Latest Updates" %}</a>
             <a href="{% url "explorer" %}">{% trans "Issue Explorer" %}</a>
             <a href="{% url "kudos_main" %}">{% trans "Kudos" %}</a>
             <a href="{% url "grants:grants" %}">{% trans "Grants" %}</a>
@@ -77,7 +77,7 @@
             <h5>{% trans "Community" %}</h5>
             <a href="https://gitcoin.co/wiki/wiki-code-conduct/">{% trans "Code of Conduct" %}</a>
             <a class="slack{% if active == 'slack' %} selected{% endif %}" href="{% url "landing_chat" %}">
-              Chat 
+              Chat
             </a>
             <a href="{% url "request_money" %}">{% trans "Request Money" %}</a>
             <a href="/wiki/">{% trans "Wiki" %}</a>

--- a/app/townsquare/templates/townsquare/offer.html
+++ b/app/townsquare/templates/townsquare/offer.html
@@ -43,7 +43,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 <div class="container-fluid py-1 pt-3 announce indent_on_mobile">
   <div class="container">
-    
+
     <h4 class="pt-0">{{offer.title}}</h4>
     <p>
       {{offer.desc}}
@@ -52,7 +52,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         Expires: {{offer.valid_to | naturaltime}}
     </p>
 
-    <a class="accept hero-p-mobile btn btn-gc-blue my-2" target="blank" href="{{offer.go_url}}">
+    <a class="accept hero-p-mobile btn btn-gc-blue my-2" target="_blank" href="{{offer.go_url}}">
       Go
     </a>
     <BR>

--- a/app/townsquare/templates/townsquare/shared/matchround.html
+++ b/app/townsquare/templates/townsquare/shared/matchround.html
@@ -3,7 +3,7 @@
   <div class="clr_container mt-2">
     <div class="townsquare_block-header text-left mb-1" data-target="miniclr">
       <strong>#{{current_match_round.number}}</strong> MINI CLR Distribution <strong>${{current_match_round.amount|floatformat:0}}</strong>
-      <a href="https://medium.com/gitcoin/experiments-with-liberal-radicalism-ad68e02efd4" target="blank">
+      <a href="https://medium.com/gitcoin/experiments-with-liberal-radicalism-ad68e02efd4" target="_blank">
         <i data-toggle="tooltip" data-html="true" class="fas fa-info-circle mr-3 font-caption" title="
         <strong>Gitcoin is reinvesting in it's community</strong>
         <br>


### PR DESCRIPTION
##### Description

Using `target="blank"` opens links each time in the same window with name "blank". The intended behavior seems to be to create a new window for each link, so this PR fixes all wrong targets "blank" to "_blank".

##### Refers/Fixes

N.A.

##### Testing

This fixes only static HTML, no changes in test.
