### PR TITLE
show twitter card w/o login, alert w/o login

### DIFF
--- a/app/grants/templates/grants/new-whitelabel.html
+++ b/app/grants/templates/grants/new-whitelabel.html
@@ -213,7 +213,7 @@
     is_logged_in = {{ is_logged_in }};
     if (is_logged_in == 0) {
         _alert("You must be logged in to register your DApp");
-        $('#new_grant').prop('disabled', true);
+        $('#new_button').prop('disabled', true);
     }
   </script>
 </html>

--- a/app/grants/templates/grants/new-whitelabel.html
+++ b/app/grants/templates/grants/new-whitelabel.html
@@ -209,4 +209,11 @@
   <script src="{% static "v2/js/pages/shared_bounty_mutation_estimate_gas.js" %}"></script>
   <script src="{% static "v2/js/grants/shared.js" %}"></script>
   <script src="{% static "v2/js/grants/new.js" %}"></script>
+  <script>
+    is_logged_in = {{ is_logged_in }};
+    if (is_logged_in == 0) {
+        _alert("You must be logged in to register your DApp");
+        $('#new_grant').prop('disabled', true);
+    }
+  </script>
 </html>

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -613,9 +613,10 @@ def flag(request, grant_id):
     })
 
 
-@login_required
 def grant_new_whitelabel(request):
     """Create a new grant, with a branded creation form for specific tribe"""
+
+    profile = get_profile(request)
 
     params = {
         'active': 'new_grant',
@@ -623,6 +624,7 @@ def grant_new_whitelabel(request):
         'card_desc': _('Earn Rewards by Making Your DApps Superior'),
         'card_player_thumb_override': request.build_absolute_uri(static('v2/images/grants/maticxgitcoin.png')),
         'profile': profile,
+        'is_logged_in': 1 if profile else 0,
         'grant': {},
         'keywords': get_keywords(),
         'recommend_gas_price': recommend_min_gas_price_to_confirm_in_time(4),


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR allows the matic dapp registration page to be loaded w/o logging in, enabling the Twitter card to work properly

##### Refers/Fixes

n/a
##### Testing

Tested locally
