### PR TITLE
chore: cleanup sponsor sidebar

### DIFF
--- a/app/dashboard/templates/dashboard/index-vue.html
+++ b/app/dashboard/templates/dashboard/index-vue.html
@@ -278,7 +278,7 @@
               </p>
             </div>
           </div>
-          <div class="col-12 col-xl-9 body hackathon-explorer">
+          <div class="col-12 col-xl-10 body hackathon-explorer">
             <b-tabs :value="activePanel" @input="tabChange" justified nav-class="col-12 col-md-8 offset-md-3 px-4" nav-wrapper-class="col-12 nav-tabs" align="left" content-class="col-12 px-4 mt-4 light-blue" class="row">
               <template v-slot:tabs-start>
                 <div class="hack-logo-wrapper d-none d-xl-block">
@@ -802,31 +802,33 @@
               </template>
             </b-tabs>
           </div>
-          <div class="d-none d-xl-block col-xl-3">
+          <div class="d-none d-xl-block col-xl-2">
             <div id="sponsor_sidebar" class="font-body">
               <div class="sponsor-top"></div>
               <sponsor-tribes-widget v-if="hackathonSponsors.length > 0" inline-template>
-                <div class="p-xl-0 p-4">
+                <div class="p-xl-2 p-4">
                   <div class="offset-1 subheading left-ribbon">
                     {% trans "Sponsor Tribes" %}
                   </div>
                   <ul class="list-unstyled">
-                    <b-media v-for="sponsor in tribesData" tag="li"  class="bg-white rounded m-4" vertical-align="center">
+                    <b-media v-for="sponsor in tribesData" tag="li"  class="rounded my-4 ml-4" vertical-align="center">
                       <template v-slot:aside>
                         <b-avatar :src="sponsor.avatar_url" size="46" :alt="sponsor.org_name" class="ml-n3"></b-avatar>
                       </template>
-                      <div class="py-3 pr-3">
-                        <div class="d-flex justify-content-between">
-                          <a class="mb-1 font-bigger-1 text-truncate w-50" :href="`/profile/${sponsor.org_name}`">[[ sponsor.display_name ]]</a>
-                          <b-button variant="outline-primary" @click="followTribe(sponsor.org_name, $event)" v-bind:class="[sponsor.followed ? 'btn-outline-gc-green' : 'btn-gc-blue', 'btn-sm']">[[ sponsor.followed ? "following" : "follow" ]]</b-button>
-                        </div>
+                      <div>
+                        <a class="mb-1 font-body font-weight-semibold w-50" :href="`/profile/${sponsor.org_name}`">
+                          [[ sponsor.display_name ]]
+                        </a>
+                        <ul class="list-unstyled font-caption mb-1">
+                          <li><i class="fas fa-fw fa-user"></i> [[ sponsor.follower_count ]] Followers</li>
+                          <li><i class="fas fa-fw fa-trophy"></i> [[ sponsor.bounty_count ]] Bounties Funded</li>
+                        </ul>
+                        <b-button variant="outline-primary" @click="followTribe(sponsor.org_name, $event)"
+                          v-bind:class="[sponsor.followed ? 'btn-outline-gc-green' : 'btn-gc-blue', 'btn-sm', 'font-smaller-5', 'font-weight-semibold']"
+                        >
+                          [[ sponsor.followed ? "following" : "follow" ]]
+                        </b-button>
 
-                        <div class="">
-                          <ul class="list-unstyled" class="mb-0">
-                            <li><i class="fas fa-fw fa-user"></i> [[ sponsor.follower_count ]] Followers</li>
-                            <li><i class="fas fa-fw fa-trophy"></i> [[ sponsor.bounty_count ]] Bounties Funded</li>
-                          </ul>
-                        </div>
                       </div>
                     </b-media>
                   </ul>


### PR DESCRIPTION
##### Description

noticed the hackathon nav on 13inch laptop while @vs77bb  was sharing screen
The hackathon sponsor takes too much real estate

This PR cleans it up 
- by shrinking the sponsor section
- fixing the wonky css where the sponsor logo overflows the white bg

##### Testing

LIVE: https://gitcoin.co/hackathon/clarity/?tab=hackathon:20

In 13inch screen:
<img width="1117" alt="Screenshot 2020-06-09 at 6 14 46 AM" src="https://user-images.githubusercontent.com/5358146/84093817-e9ff9680-aa18-11ea-8ba0-2f74e133d227.png">



**This PR:** 

In 13inch screen:
![image](https://user-images.githubusercontent.com/5358146/84093780-c76d7d80-aa18-11ea-8ecf-0c4d966b1d58.png)

In 15inch screen: 
<img width="1680" alt="Screenshot 2020-06-09 at 6 09 27 AM" src="https://user-images.githubusercontent.com/5358146/84093587-4ca46280-aa18-11ea-9d08-875ed8cdad53.png">

