### PR TITLE
Fix token selection dropdown

### DIFF
--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -113,7 +113,7 @@ function tokenOptionsForGrant(grant) {
 
     if (tokenData.divider) {
       options += `
-                <option disabled>_________</option>
+                <option disabled>&mdash;&mdash;&mdash;&mdash;</option>
             `;
     } else {
       options += `

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -110,7 +110,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
               </div>
               {% comment %} Cart Contents: MOBILE {% endcomment %}
               <div v-if="isMobileDevice">
-                <div v-for="(grant, index) in grantData" class="grant-row">
+                <div v-for="(grant, index) in grantData" :key="grant.grant_id" class="grant-row">
                   <div class="grant-row-style">
                     <div class="row align-items-center justify-content-between">
                       {% comment %} Logo, title, and delete button {% endcomment %}
@@ -130,8 +130,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                         <div class="row flex-nowrap justify-content-between">
                           <input class="col-5 form-control" style="margin-left:0.5rem" min="0"
                             v-model="grant.grant_donation_amount" type="number" placeholder="Amount">
-                          <select2 :options="currencies[index]" v-model="grant.grant_donation_currency"
-                            class="col-6 form-control" style="margin-right:0.5rem" placeholder="Select token">
+                          <select2 v-model="grant.grant_donation_currency" class="col-6 form-control"
+                            style="margin-right:0.5rem" placeholder="Select token">
+                            <option v-for="option in currencies[index]" v-bind:value="option" :disabled="!option">
+                              <span v-if="!option" style="height:1px; font-size:1px">&mdash;&mdash;&mdash;&mdash;</span>
+                              <span v-else>[[ option ]]</span>
+                            </option>
                           </select2>
                         </div>
                       </div>
@@ -171,8 +175,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                       <div class="row flex-nowrap align-items-center justify-content-start">
                         <input class="col-6 form-control" v-model="grant.grant_donation_amount" type="number" min="0"
                           placeholder="Amount" style="margin-right: 1rem">
-                        <select2 :options="currencies[index]" v-model="grant.grant_donation_currency"
-                          class="col-6 form-control" placeholder="Select token">
+                        <select2 v-model="grant.grant_donation_currency" class="col-6 form-control"
+                          placeholder="Select token">
+                          <option v-for="option in currencies[index]" v-bind:value="option" :disabled="!option">
+                            <span v-if="!option" style="height:1px; font-size:1px">&mdash;&mdash;&mdash;&mdash;</span>
+                            <span v-else>[[ option ]]</span>
+                          </option>
                         </select2>
                       </div>
                     </div>


### PR DESCRIPTION
Closes https://github.com/gitcoinco/web/issues/6867

Changes:
- Replaces `select2` component `:options` parameter with `<option>` elements
- Replaces underscores with emdashes for token divider (this centers the divider in its row instead of having it at the bottom)

To test:
1. Add multiple grants to cart
2. Remove one
3. Make sure token selections do not change
4. Change token selections of remaining grant check local storage > `grants_cart` 
 and make sure the `grant_donation_currency` field is updated and matches what is in the token selection box

cc @owocki @apbendi 