### PR TITLE
Change Gitcoin's Terms & Conditions to point to legal/terms instead of legal/policy

### DIFF
--- a/app/retail/templates/cookielaw/banner.html
+++ b/app/retail/templates/cookielaw/banner.html
@@ -15,7 +15,7 @@
             <span class="font-weight-bold">Privacy Policy</span>
             <span>
               {% trans "Gitcoin is GDPR complaint. Learn more in" %}
-              <a href="/legal/policy">{% trans "Gitcoin's Terms & Conditions." %}</a>
+              <a href="/legal/terms">{% trans "Gitcoin's Terms & Conditions." %}</a>
             </span>
           </p>
         </div>


### PR DESCRIPTION


<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
In the cookie banner, the `Gitcoin's Terms & Conditions` is redirecting to `legal/policy` instead it should point to `legal/terms`, I've jsut changed that.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
PR so small, no need to test