### PR TITLE
Improve cart gas estimates for DAI, aDAI, cDAI, and ANT

### DIFF
--- a/app/retail/templates/about.html
+++ b/app/retail/templates/about.html
@@ -45,7 +45,7 @@
             <div class="col-10 col-md-6 col-lg-3 mx-auto">
               <div class="card">
                 {%  if handle %}
-                <a href="/profile/{{handle}}" data-usercard="{{handle}}>
+                <a href="/profile/{{handle}}" data-usercard="{{handle}}">
                 {% endif %}
                   <img class="avatar {{fname}} mx-auto" src="/static/v2/images/team/{{fname}}.png">
                 {%  if handle %}


### PR DESCRIPTION
This PR has two changes in regards to gas estimates

### Changes for Carts with ANT, aDAI, or cDAI

The current default estimate for token donations is 100k per donation, but this is insufficient for some tokens:
- A standard ANT transfer costs up to 131k gas, so for ANT donations we add some margin and now use a value of 170k gas
- An aDAI transfer can vary in gas cost depending on your address status in the platform (e.g. if you are borrowing it might be more costly than if you're not borrowing). The Aave team suggested a gas limit of 500k per transfer which they say should be more than enough
- If transferring cDAI in MetaMask, the gas limit is automatically set to 400k. So we add a bit of margin here and use 450k gas per transfer

### Changes for Carts that Only Use DAI

If a cart is all Dai (which is about 75% of checkouts), we use a linear regression to estimate the gas price based on actual transaction data.

The raw data was obtained using the script located at this repo: https://github.com/mds1/Gitcoin-Checkout-Gas-Analysis

That script does the following:
1. Finds all cart checkout transactions that only use Dai
2. For a given number of donations, generate a data set that only keeps the transactions that used the most gas
3. Plot those results in Plotly

We then used the Plotly Chart Studio to generate a linear best fit line, then tweak the result so the results are more conservative than a typical best fit line (because we'd rather overestimate gas costs than underestimate). This chart can be found in Plotly Chart Studio here: https://plotly.com/~mds1/7/number-of-donations-vs-gas-used-all/

This gave us a new curve of `gasLimit = 25000 * n + 125000;` where `n` is number of donations in a transaction. For 1 donation we use a special case and set the estimate to 80k to avoid overestimating too much (in practice this will not really be seen since the default contribution to Gitcoin means there's two donations when you choose one grant).

Some comparisons are shown below:

| # of Donations Per Tx | Old Estimate | New Estimate | True Value |
|-----------------------|--------------|--------------|------------|
| 1                     | 100k         | 80k         | 44k        |
| 2                     | 200k         | 175k         | 84k        |
| 3                     | 300k         | 200k         | 122k       |
| 5                     | 500k         | 250k         | 181k       |
| 9                     | 900k         | 350k         | 296k       |
| 15                    | 1.5M         | 500k         | 396k       |
| 25                    | 2.5M         | 750k         | 658k       |
| 40                    | 4.0M         | 1.125M         | 1.04M      |

cc @owocki @apbendi 