### PR TITLE
Add bulk edit of cart amounts

### DIFF
--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -61,11 +61,12 @@ $(document).ready(function() {
     // Get preferred cart data
     let cartData = CartData.loadCart();
     const network = document.web3network || 'mainnet';
-    const preferredAmount = cartData[0].grant_donation_amount;
-    const preferredTokenName = cartData[0].grant_donation_currency;
+    const selected_grant_index = $(this).data('id');
+    const preferredAmount = cartData[selected_grant_index].grant_donation_amount;
+    const preferredTokenName = cartData[selected_grant_index].grant_donation_currency;
     const preferredTokenAddress = tokens(network)
       .filter(token => token.name === preferredTokenName)
-      .map(token => token.addr)[0];
+      .map(token => token.addr)[selected_grant_index];
 
     // Get fallback amount in ETH (used when token is not available for a grant)
     const url = `${window.location.origin}/sync/get_amount?amount=${preferredAmount}&denomination=${preferredTokenName}`;
@@ -98,48 +99,41 @@ $(document).ready(function() {
 
 function sideCartRowForGrant(grant, index) {
   let cartRow = `
-        <div id="side-cart-row-${grant.grant_id}" class="side-cart-row mb-3">
-            <div class="form-row mb-2">
-                <div class="col-2">
-                    <img src="${grant.grant_logo}" alt="Grant logo" width="40">
-                </div>
-                <div class="col-9">
-                    ${grant.grant_title}
-                </div>
-                <div class="col-1" style="opacity: 40%">
-                    <i id="side-cart-row-remove-${grant.grant_id}" class="fas fa-trash-alt" style="cursor: pointer"></i>
-                </div>
-            </div>
-            <div class="form-row">
-                <div class="col-2"></div>
-                <div class="col-5">
-                    <input type="number" id="side-cart-amount-${grant.grant_id}" class="form-control" value="${grant.grant_donation_amount}">
-                </div>
-                <div class="col-5">
-                    <select id="side-cart-currency-${grant.grant_id}" class="form-control">
+      <div id="side-cart-row-${grant.grant_id}" class="side-cart-row mb-3">
+        <div class="form-row mb-2">
+          <div class="col-2">
+            <img src="${grant.grant_logo}" alt="Grant logo" width="40">
+          </div>
+          <div class="col-9">
+              ${grant.grant_title}
+          </div>
+          <div class="col-1" style="opacity: 40%">
+            <i id="side-cart-row-remove-${grant.grant_id}" class="fas fa-trash-alt" style="cursor: pointer"></i>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="col-2"></div>
+          <div class="col-5">
+            <input type="number" id="side-cart-amount-${grant.grant_id}" class="form-control" value="${grant.grant_donation_amount}">
+          </div>
+          <div class="col-5">
+            <select id="side-cart-currency-${grant.grant_id}" class="form-control">
     `;
 
   cartRow += tokenOptionsForGrant(grant);
 
   cartRow += `
-                    </select>
-                </div>
-            </div>
-  `;
-  if (index === 0) {
-    cartRow += `
-            <div class="form-row">
-                <div class="col-2"></div>
-                <div class="col-auto font-smaller-2" style="cursor:pointer; color:#3e00ff" id="apply-to-all">
-                  Apply to all
-                </div>
-            </div>
-    `;
-  }
-
-  cartRow += `
+            </select>
+          </div>
         </div>
-    `;
+        <div class="form-row">
+          <div class="col-2"></div>
+          <div class="col-auto font-smaller-3 pt-1 text-highlight-gc-blue" style="cursor:pointer;" data-id="${index}" id="apply-to-all">
+            Apply to all
+          </div>
+        </div>
+      </div>
+  `;
 
   return cartRow;
 }

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -142,6 +142,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             </option>
                           </select2>
                         </div>
+                        <div class="font-smaller-2 hyperlink" @click="applyAmountToAllGrants(grant, index)">
+                          Apply to all
+                        </div>
                       </div>
                       {% comment %} Add comment {% endcomment %}
                       <div class="col-12 font-smaller-3" style="margin-top:1rem">
@@ -213,6 +216,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             <span v-else>[[ option ]]</span>
                           </option>
                         </select2>
+                      </div>
+                      <div class="row flex-nowrap align-items-center justify-content-start">
+                        <div class="text-left font-smaller-2 hyperlink" @click="applyAmountToAllGrants(grant)">
+                          Apply to all
+                        </div>
                       </div>
                     </div>
                     {% comment %} CLR Match Amount {% endcomment %}


### PR DESCRIPTION
Closes https://github.com/gitcoinco/web/issues/6965

Changes:
- Adds an "Apply to all" button under each item on the /grants/cart page
- Adds an "Apply to all" button under the first item on the side cart
- When "Apply to all" is clicked, each cart entry is changed to use that amount and token. If the selected token is not available for a given grant, we convert to that amount to the equivalent amount in ETH and use that

If someone with better jQuery skills than me can add "Apply to all" under each item in the side cart that would be appreciated! I'm not sure how to split up the IDs with jQuery so it recognizes the array index

cc @apbendi @owocki 

Also, I originally planned to use this branch to also let users set their default amounts and currencies. But we'd want that saved to the user's profile, and since I'm not yet familiar with that aspect of the codebase I figured we can handle that in a separate PR and ship this one for now