### PR TITLE
feat: add support for new type manual

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -248,8 +248,13 @@ Vue.mixin({
         });
       }
     },
-    getTenant: function(token_name) {
+    getTenant: function(token_name, web3_type) {
       let tenant;
+
+      if (web3_type == 'manual') {
+        tenant = 'OTHERS';
+        return tenant;
+      }
 
       switch (token_name) {
 
@@ -272,7 +277,7 @@ Vue.mixin({
 
       return tenant;
     },
-    fulfillmentComplete: function(fulfillment_id, event) {
+    fulfillmentComplete: function(payout_type, fulfillment_id, event) {
       let vm = this;
 
       const token_name = vm.bounty.token_name;
@@ -280,10 +285,10 @@ Vue.mixin({
       const amount = vm.fulfillment_context.amount;
       const payout_tx_id = vm.fulfillment_context.payout_tx_id ? vm.fulfillment_context.payout_tx_id : null;
       const funder_address = vm.bounty.bounty_owner_address;
-      const tenant = vm.getTenant(token_name);
+      const tenant = vm.getTenant(token_name, vm.bounty.web3_type);
 
       const payload = {
-        payout_type: 'qr',
+        payout_type: payout_type,
         tenant: tenant,
         amount: amount * 10 ** decimals,
         token_name: token_name,
@@ -497,12 +502,19 @@ Vue.mixin({
     initFulfillmentContext: function(fulfillment) {
       let vm = this;
 
-      if (fulfillment.payout_type == 'fiat') {
-        vm.fulfillment_context.active_step = 'payout_amount';
-      } else if (fulfillment.payout_type == 'qr') {
-        vm.fulfillment_context.active_step = 'check_wallet_owner';
-      } else if (fulfillment.payout_type == 'web3_modal') {
-        vm.fulfillment_context.active_step = 'payout_amount';
+      switch (fulfillment.payout_type) {
+        case 'fiat':
+          vm.fulfillment_context.active_step = 'payout_amount';
+          break;
+
+        case 'qr':
+        case 'manual':
+          vm.fulfillment_context.active_step = 'check_wallet_owner';
+          break;
+
+        case 'web3_modal':
+          vm.fulfillment_context.active_step = 'payout_amount';
+          break;
       }
     }
   },

--- a/app/assets/v2/js/pages/hackathon_new_bounty.js
+++ b/app/assets/v2/js/pages/hackathon_new_bounty.js
@@ -149,8 +149,10 @@ Vue.mixin({
         case '102': // zilliqa
         case '42220': // celo mainnet
         case '44786': // celo alfajores tesnet
-        case '717171': // other
           type = 'qr';
+          break;
+        case '717171': // other
+          type = 'manual';
           break;
         default:
           type = 'web3_modal';

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -283,7 +283,8 @@ class Bounty(SuperModel):
         ('legacy_gitcoin', 'Legacy Bounty'),
         ('bounties_network', 'Bounties Network'),
         ('qr', 'QR Code'),
-        ('web3_modal', 'Web3 Modal')
+        ('web3_modal', 'Web3 Modal'),
+        ('manual', 'Manual')
     )
 
     bounty_state = models.CharField(max_length=50, choices=BOUNTY_STATES, default='open', db_index=True)
@@ -1345,7 +1346,8 @@ class BountyFulfillment(SuperModel):
         ('bounties_network', 'bounties_network'),
         ('qr', 'qr'),
         ('fiat', 'fiat'),
-        ('web3_modal', 'web3_modal')
+        ('web3_modal', 'web3_modal'),
+        ('manual', 'manual')
     ]
 
     TENANT = [
@@ -1353,7 +1355,8 @@ class BountyFulfillment(SuperModel):
         ('ETC', 'ETC'),
         ('ZIL', 'ZIL'),
         ('CELO', 'CELO'),
-        ('PYPL', 'PYPL')
+        ('PYPL', 'PYPL'),
+        ('OTHERS', 'OTHERS')
     ]
 
     bounty = models.ForeignKey(Bounty, related_name='fulfillments', on_delete=models.CASCADE, help_text="the bounty against which the fulfillment is made")

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -254,7 +254,12 @@
                       [[ fulfillment.profile.handle ]]
                     </a>
                     <div class="font-smaller-4" v-if="fulfillment.fulfiller_address">
-                      <a :href="getAddressURL(fulfillment.token_name, fulfillment.fulfiller_address)" target="_blank">[[ fulfillment.fulfiller_address | truncateHash ]]</a>
+
+                      <span v-if="fulfillment.payout_type == 'manual'">[[ fulfillment.fulfiller_address | truncateHash ]]</span>
+                      <a v-else :href="getAddressURL(fulfillment.token_name, fulfillment.fulfiller_address)" target="_blank">
+                        [[ fulfillment.fulfiller_address | truncateHash ]]
+                      </a>
+
                       <button class="btn btn-sm my-0 px-1" @click="copyTextToClipboard(fulfillment.fulfiller_address)">
                         <i class="far fa-clipboard-check"></i>
                       </button>
@@ -271,8 +276,13 @@
                         <span class="my-auto px-3 font-smaller-2 font-weight-semibold">
                           <i class="fas fa-check mr-2 font-caption"></i> Bounty Paid
                         </span>
-                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0">
-                          <a :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">([[ fulfillment.payout_tx_id | truncateHash ]])</a>
+                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0 pl-lg-4">
+
+                          <span v-if="fulfillment.payout_type == 'manual'">[[ fulfillment.payout_tx_id | truncateHash ]]</span>
+                          <a v-else :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">
+                            ([[ fulfillment.payout_tx_id | truncateHash ]])
+                          </a>
+
                           <button class="btn btn-sm my-0 px-1" @click="copyTextToClipboard(fulfillment.payout_tx_id)">
                             <i class="far fa-clipboard-check"></i>
                           </button>
@@ -283,8 +293,13 @@
                         <button class="btn btn-sm btn-outline-gc-blue my-auto px-3 font-smaller-2 font-weight-semibold">
                           <i class="fas fa-spinner fa-spin mr-2 font-caption"></i>Pending Verification
                         </button>
-                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0">
-                          <a :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">([[ fulfillment.payout_tx_id | truncateHash ]])</a>
+                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0 pl-lg-4">
+
+                          <span v-if="fulfillment.payout_type == 'manual'">[[ fulfillment.payout_tx_id | truncateHash ]]</span>
+                          <a v-else :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">
+                            ([[ fulfillment.payout_tx_id | truncateHash ]])
+                          </a>
+
                           <button class="btn btn-sm my-0 px-1" @click="copyTextToClipboard(fulfillment.payout_tx_id)">
                             <i class="far fa-clipboard-check"></i>
                           </button>
@@ -311,8 +326,13 @@
                         <span class="my-auto px-3 font-smaller-2 font-weight-semibold">
                           <i class="fas fa-check mr-2 font-caption"></i> Bounty Paid
                         </span>
-                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0">
-                          <a :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">([[ fulfillment.payout_tx_id | truncateHash ]])</a>
+                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0 pl-lg-4">
+
+                          <span v-if="fulfillment.payout_type == 'manual'">[[ fulfillment.payout_tx_id | truncateHash ]]</span>
+                          <a v-else :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">
+                            ([[ fulfillment.payout_tx_id | truncateHash ]])
+                          </a>
+
                             <button class="btn btn-sm my-0 px-1" @click="copyTextToClipboard(fulfillment.payout_tx_id)">
                             <i class="far fa-clipboard-check"></i>
                           </button>
@@ -322,8 +342,13 @@
                         <button class="btn btn-sm btn-outline-gc-blue my-auto px-3 font-smaller-2 font-weight-semibold">
                           <i class="fas fa-spinner fa-spin mr-2 font-caption"></i>Pending Verification
                         </button>
-                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0">
-                          <a :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">([[ fulfillment.payout_tx_id | truncateHash ]])</a>
+                        <p v-if="fulfillment.payout_type !== 'fiat'" class="font-smaller-4 my-0 pl-lg-4">
+
+                          <span v-if="fulfillment.payout_type == 'manual'">[[ fulfillment.payout_tx_id | truncateHash ]]</span>
+                          <a v-else :href="getTransactionURL(fulfillment.token_name, fulfillment.payout_tx_id)" target="_blank">
+                            ([[ fulfillment.payout_tx_id | truncateHash ]])
+                          </a>
+
                           <button class="btn btn-sm my-0 px-1" @click="copyTextToClipboard(fulfillment.payout_tx_id)">
                             <i class="far fa-clipboard-check"></i>
                           </button>
@@ -476,7 +501,126 @@
 
                           </div>
 
-                          <!-- CROSS CHAIN-->
+                          <!-- MANUAL FLOW -->
+                          <div v-else-if="fulfillment.payout_type == 'manual'" class="px-sm-4">
+
+                            <div class="text-center pb-3">
+                              <p class="mb-3 font-subheader font-weight-bold">Payout</p>
+                              <img class="avatar" :src="[[ fulfillment.profile.avatar_url ]]" class="fullfiller_profile">
+
+                              <p class="font-subheader font-weight-bold mt-3 mb-1">
+                                [[ fulfillment.fulfiller_github_username ]]
+                              </p>
+
+                              <p class="font-body text-medium-dark-grey">
+                                [[ fulfillment.fulfiller_address | truncateHash ]]
+                              </p>
+                            </div>
+
+                            <!-- STEP : WALLET OWNER CHECK -->
+                            <div id="check_wallet_owner" v-if="fulfillment_context.active_step == 'check_wallet_owner'">
+
+                              <p>
+                                This bounty can only be paid out from the same wallet address that funded it.
+                              </p>
+                              <p class="mb-4 font-weight-bold">
+                                Make sure you’re paying out from this address
+
+                                <span v-if="fulfillment.payout_type == 'manual'">[[ bounty.bounty_owner_address | truncateHash ]]</span>
+                                <a v-else class="font-weight-bold" :href="getAddressURL(fulfillment.token_name, bounty.bounty_owner_address)" target="_blank">
+                                  [[ bounty.bounty_owner_address ]]
+                                </a>
+
+                              </p>
+                              <button class="btn btn-gc-blue button--full py-3 font-subheader mt-4"
+                                v-on:click="goToStep('payout_amount', 'check_wallet_owner')"
+                              >
+                                Yes, I understand
+                              </button>
+                            </div>
+
+                            <!-- STEP : ENTER PAYOUT AMOUNT -->
+                            <div id="payout_amount" v-else-if="fulfillment_context.active_step == 'payout_amount'" class="text-center">
+                              <p class="font-subheader">How much are you paying out to this person?</p>
+
+                              <p class="payout-input-amount-container font-weight-semibold">
+                                <input type="number" class="mb-4 font-bigger-4 text-center" v-model="fulfillment_context.amount" min="0">
+                                <span class="font-body font-weight-bold">[[ bounty.token_name ]]</span>
+                              </p>
+
+                              <button  class="btn btn-gc-blue button--full py-3 font-subheader mt-3"
+                                :disabled="!fulfillment_context.amount || fulfillment_context.amount == 0"
+                                v-on:click="goToStep('submit_transaction', 'payout_amount')"
+                              >
+                                Next
+                              </button>
+
+                              <p class="font-subheader mt-4 mb-0 text-center">
+                                <a href="#" v-on:click="goToStep('check_wallet_owner', 'payout_amount')">
+                                  <i class="fas fa-chevron-left mr-2 font-caption"></i>
+                                  Previous Step
+                                </a>
+                              </p>
+                            </div>
+
+                            <!-- STEP: SUBMIT TXN ID -->
+                            <div id="submit_transaction" v-else-if="fulfillment_context.active_step == 'submit_transaction'">
+                              <div v-if="fulfillment_context.flow == 'access_to_wallet'" class="text-center">
+
+                              </div>
+
+                              <p class="mb-1 font-subheader">
+                                Pay with your wallet and enter the transaction ID
+                              </p>
+
+
+                              <p class="font-caption text-medium-dark-grey mb-2">
+                                Input the
+                                <span class="font-weight-bold">Transaction ID</span>
+                                of the payment:
+                              </p>
+                              <div class="payout-tx-container">
+                                <input v-model="fulfillment_context.payout_tx_id"
+                                  name="payout_tx_id" id="payout_tx_id" placeholder="Transaction ID"
+                                  class="w-100 p-2 font-smaller-5 border-0"
+                                >
+                              </div>
+
+                              <div class="font-caption payout-summary-container p-3 my-4">
+                                <p class="mb-1">
+                                  From: <span class="font-weight-bold">[[ bounty.bounty_owner_address ]] </span>
+                                </p>
+                                <p class="mb-1">
+                                  Amount: <span class="font-weight-bold">[[ fulfillment_context.amount ]] [[ bounty.token_name ]]</span>
+                                </p>
+                                <p class="mb-1">To:</p>
+                                <p class="mb-1">
+                                  <img class="avatar avatar-small" :src="[[ fulfillment.profile.avatar_url ]]" class="fullfiller_profile">
+                                  <span class="font-weight-bold">[[ fulfillment.fulfiller_address ]]</span>
+                                  <a @click="copyTextToClipboard(fulfillment.fulfiller_address)" href="#" class="font-weight-bold float-right">
+                                    Copy
+                                  </a>
+                                </p>
+                              </div>
+
+                              <button class="btn btn-gc-blue button--full py-3 font-subheader mt-3"
+                                @click="fulfillmentComplete(fulfillment.payout_type, fulfillment.pk, $event)"
+                              >
+                                I have Paid
+                              </button>
+
+                              <p class="font-subheader mt-4 mb-0 text-center">
+                                <a href="#" v-on:click="goToStep('payout_amount', 'submit_transaction')">
+                                  <i class="fas fa-chevron-left mr-2 font-caption"></i>
+                                  Previous Step
+                                </a>
+                              </p>
+
+                            </div>
+
+                          </div>
+
+                          <!-- CROSS CHAIN FLOW -->
                           <div v-else class="px-sm-4">
 
                             <div class="text-center pb-3">
@@ -500,9 +644,12 @@
                               </p>
                               <p class="mb-4">
                                 Make sure you’re paying out from this address
-                                <a class="font-weight-bold" :href="getAddressURL(fulfillment.token_name, bounty.bounty_owner_address)" target="_blank">
+
+                                <span v-if="fulfillment.payout_type == 'manual'">[[ bounty.bounty_owner_address | truncateHash ]]</span>
+                                <a v-else class="font-weight-bold" :href="getAddressURL(fulfillment.token_name, bounty.bounty_owner_address)" target="_blank">
                                   [[ bounty.bounty_owner_address ]]
                                 </a>
+
                               </p>
                               <button class="btn btn-gc-blue button--full py-3 font-subheader mt-4"
                                 v-on:click="goToStep('payout_amount', 'check_wallet_owner', 'access_to_wallet')"
@@ -585,7 +732,7 @@
                               </div>
 
                               <button class="btn btn-gc-blue button--full py-3 font-subheader mt-3"
-                                @click="fulfillmentComplete(fulfillment.pk, $event)"
+                                @click="fulfillmentComplete(fulfillment.payout_type, fulfillment.pk, $event)"
                               >I have paid
                               </button>
                               <p class="font-subheader mt-4 mb-0 text-center">
@@ -645,7 +792,7 @@
                               </div>
 
                               <button class="btn btn-gc-blue button--full py-3 font-subheader mt-3"
-                                @click="fulfillmentComplete(fulfillment.pk, $event)"
+                                @click="fulfillmentComplete(fulfillment.payout_type, fulfillment.pk, $event)"
                               >
                                 I have Paid
                               </button>


### PR DESCRIPTION
#### Description

- Add new payout_type/web_3_type manual
- Add new tenant CUSTOM
- Add validation to ensure manual bounties are allowed only for hack bounties
- Update hackathon form logic to set web3_type -> manual for other chains
- Add Bounty Details Payout Modal for manual payout flow 



##### Testing

creation -> https://share.vidyard.com/watch/Uakjjvo3tahiCvHfkdqMG8?
submission + payout -> https://share.vidyard.com/watch/vZXjB1eeDGjKzS1Rp3E666?

![image](https://user-images.githubusercontent.com/5358146/86718706-f5a6a300-c040-11ea-8bc8-9d2c5f40969d.png)
