### PR TITLE
fix: count distinct registrants to avoid duplicates

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3631,7 +3631,7 @@ def hackathon(request, hackathon='', panel='prizes'):
         is_registered = HackathonRegistration.objects.filter(registrant=request.user.profile,
                                                              hackathon=hackathon_event) if request.user and request.user.profile else None
 
-    hacker_count = HackathonRegistration.objects.filter(hackathon=hackathon_event).all().count()
+    hacker_count = HackathonRegistration.objects.filter(hackathon=hackathon_event).distinct('registrant').count()
     projects_count = HackathonProject.objects.filter(hackathon=hackathon_event).all().count()
     view_tags = get_tags(request)
     active_tab = 0


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

`HackathonRegistration` instances are prone to have duplicates as described here https://github.com/gitcoinco/web/issues/7070. This pull requests ensures that `hacker_count` counts only distinct `registrants` for a hackathon event.  Tested locally.

##### Refers/Fixes

fixes https://github.com/gitcoinco/web/issues/7051
related https://github.com/gitcoinco/web/issues/7070
