### PR TITLE
Fix check to see if cart uses only DAI

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -210,7 +210,8 @@ Vue.component('grants-cart', {
       // If we have a cart where all donations are in Dai, we use a linear regression to
       // estimate gas costs based on real checkout transaction data, and add a 50% margin
       const donationCurrencies = this.donationInputs.map(donation => donation.token);
-      const isAllDai = donationCurrencies.every((addr, index, array) => addr === array[0]);
+      const daiAddress = this.getTokenByName('DAI').addr;
+      const isAllDai = donationCurrencies.every((addr) => addr === daiAddress);
 
       if (isAllDai) {
         if (donationCurrencies.length === 1) {


### PR DESCRIPTION
Closes https://github.com/gitcoinco/web/issues/7056

During checkout, if the user selects DAI for each grant contribution in their cart, a special heuristic is used to estimate gas. Before this PR, this heuristic would be accidentally applied any time a cart used the same token for each grant in their cart, regardless of whether or not that token was DAI. 

This PR resolves that so the gas estimation heuristic is now only used for carts with DAI

cc @owocki 