### PR TITLE
Set the z-index for .activity.hackathon_new_hacker to 0

### DIFF
--- a/app/assets/v2/css/town_square.css
+++ b/app/assets/v2/css/town_square.css
@@ -1218,7 +1218,7 @@ body.green.offer_view .announce {
 .activity.hackathon_new_hacker {
   position: relative;
   box-sizing: border-box;
-  z-index: 2;
+  z-index: 0;
 }
 
 .activity.hackathon_new_hacker:before {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

The current z-index overlaps with the top navigation bar when you're scrolling. Setting the z-index to 0 would make the activity card go under the navbar as expected.

![image](https://user-images.githubusercontent.com/3248587/87900034-f576b200-ca07-11ea-9b1c-1aef2201dc8d.png)


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
