### PR TITLE
Tribes light housekeeping #7143

### DIFF
--- a/app/assets/v2/js/pages/profile-tribes.js
+++ b/app/assets/v2/js/pages/profile-tribes.js
@@ -275,6 +275,7 @@ const loadDynamicScript = (callback, url, id) => {
           headerFilePreview: null,
           is_my_org: document.is_my_org || false,
           is_on_tribe: document.is_on_tribe || false,
+          is_staff: document.contxt.is_staff || false,
           editorOptionPrio: {
             modules: {
               toolbar: [

--- a/app/assets/v2/js/users.js
+++ b/app/assets/v2/js/users.js
@@ -7,6 +7,11 @@ let hackathonId = document.hasOwnProperty('hackathon_id') ? document.hackathon_i
 // let funderBounties = [];
 
 Vue.mixin({
+  computed: {
+    orderedUsers: function () {
+      return _.orderBy(this.users, 'position_contributor', 'asc' )
+    }
+  },
   methods: {
     chatWindow: function(channel) {
       window.chatSidebar.chatWindow(channel);

--- a/app/assets/v2/js/users.js
+++ b/app/assets/v2/js/users.js
@@ -407,15 +407,3 @@ if (document.getElementById('gc-users-directory')) {
     }
   });
 }
-
-Vue.component('tribe-directory', {
-  computed: {
-    orderedUsers: function() {
-      return _.orderBy(this.users, 'position_contributor', 'asc');
-    }
-  },
-  
-  mounted() {
-    this.fetchUsers();
-  }
-});

--- a/app/assets/v2/js/users.js
+++ b/app/assets/v2/js/users.js
@@ -8,8 +8,8 @@ let hackathonId = document.hasOwnProperty('hackathon_id') ? document.hackathon_i
 
 Vue.mixin({
   computed: {
-    orderedUsers: function () {
-      return _.orderBy(this.users, 'position_contributor', 'asc' )
+    orderedUsers: function() {
+      return _.orderBy(this.users, 'position_contributor', 'asc');
     }
   },
   methods: {
@@ -407,3 +407,15 @@ if (document.getElementById('gc-users-directory')) {
     }
   });
 }
+
+Vue.component('tribe-directory', {
+  computed: {
+    orderedUsers: function() {
+      return _.orderBy(this.users, 'position_contributor', 'asc');
+    }
+  },
+  
+  mounted() {
+    this.fetchUsers();
+  }
+});

--- a/app/assets/v2/js/vue-components.js
+++ b/app/assets/v2/js/vue-components.js
@@ -599,7 +599,56 @@ Vue.component('project-card', {
 });
 
 Vue.component('suggested-profiles', {
+<<<<<<< HEAD
+  props: ['id'],
+  computed: {
+    orderedUsers: function() {
+      return _.orderBy(this.users, 'position_contributor', 'asc');
+    }
+  },
+  data: function() {
+    return {
+      users: []
+    };
+  },
+  mounted() {
+    this.fetchUsers();
+  },
+  methods: {
+    fetchUsers: function() {
+      let vm = this;
+
+      vm.isLoading = true;
+      vm.noResults = false;
+
+      let apiUrlUsers = `/api/v0.1/users_fetch/?user_filter=all&page=1&tribe=${vm.id}`;
+
+      var getUsers = fetchData(apiUrlUsers, 'GET');
+
+      $.when(getUsers).then(function(response) {
+        for (let item = 0; response.data.length > item; item++) {
+          if (!response.data[item].is_following) {
+            if (response.data[item].handle != document.contxt.github_handle) {
+              vm.users.push(response.data[item]);
+            }
+          }
+          if (vm.users.length === 10) {
+            break;
+          }
+        }
+
+        if (vm.users.length) {
+          vm.noResults = false;
+        } else {
+          vm.noResults = true;
+        }
+        vm.isLoading = false;
+      });
+    }
+  },
+=======
   props: ['profiles'],
+>>>>>>> parent of b47d4df75... Fixes tribe townsquare sidebar shows follow suggestion for top member based on contributor rank.
   template: `<div class="townsquare_nav-list my-2 tribe">
       <div id="suggested-tribes">
         <ul class="nav d-inline-block font-body col-lg-4 col-lg-11 pr-2" style="padding-right: 0">

--- a/app/assets/v2/js/vue-components.js
+++ b/app/assets/v2/js/vue-components.js
@@ -599,7 +599,6 @@ Vue.component('project-card', {
 });
 
 Vue.component('suggested-profiles', {
-<<<<<<< HEAD
   props: ['id'],
   computed: {
     orderedUsers: function() {
@@ -646,13 +645,10 @@ Vue.component('suggested-profiles', {
       });
     }
   },
-=======
-  props: ['profiles'],
->>>>>>> parent of b47d4df75... Fixes tribe townsquare sidebar shows follow suggestion for top member based on contributor rank.
   template: `<div class="townsquare_nav-list my-2 tribe">
       <div id="suggested-tribes">
         <ul class="nav d-inline-block font-body col-lg-4 col-lg-11 pr-2" style="padding-right: 0">
-            <suggested-profile v-for="profile in profiles" :key="profile.id" :profile="profile" />
+            <suggested-profile v-for="profile in orderedUsers" :key="profile.id" :profile="profile" />
         </ul>
       </div>
     </div>`

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -675,7 +675,7 @@
                             <button class="btn blue" @click="params = {}; searchUsers()">Reset Filters</button>
                           </div>
                           <div class="grid-4">
-                            <div v-for="user in users" class="card card-user shadow-sm border-0" :key=`"user-${user.handle}"`>
+                            <div v-for="user in orderedUsers" class="card card-user shadow-sm border-0" :key=`"user-${user.handle}"`>
                               <div class="d-flex flex-column py-1 bg-lightblue">
                                 <button class="btn position-absolute align-self-end" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><i class="fas fa-ellipsis-v"></i></button>
                                 <div class="dropdown-menu dropdown-menu-right font-caption bg-white">
@@ -1544,6 +1544,7 @@
     <script src='{% static "v2/js/vue-components.js" %}'></script>
     <script defer src='https://cdn.quilljs.com/1.3.6/quill.js'></script>
     <script defer src='https://cdn.jsdelivr.net/npm/vue-quill-editor@3.0.6/dist/vue-quill-editor.js'></script>
+    <script defer src='https://cdn.jsdelivr.net/npm/lodash@4.17.19/lodash.min.js'></script>
     {{currentProfile|json_script:"current-profile"}}
     <script src='{% static "v2/js/pages/profile-tribes.js" %}'></script>
     <script src="{% static "v2/js/lib/jitsi.js" %}"></script>

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -1188,7 +1188,7 @@
                   </div>
                 </bounty-explorer>
               </b-tab>
-              <b-tab v-if="is_my_org" class="col-12" title-item-class="navigation">
+              <b-tab v-if="is_my_org || is_staff" class="col-12" title-item-class="navigation">
                 <template v-slot:title>
                   <div class="mt-3">
                     {% trans "Manage" %}

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -470,8 +470,8 @@
                 <div class="ml-md-4 mt-4 townsquare_header">
                   <div class="row">
                     <div class="col-12 col-md-4 col-lg-3">
-                      <div @click="showCoreTeam = !showCoreTeam" class="ml-4 mb-4 font-body left-ribbon text-justify btn-block justify-content-between align-items-center p-1">[[ tribe.name ]] {% trans "Team" %} <i class="fa fa-fw" :class="showCoreTeam ? 'fa-chevron-up': 'fa-chevron-down'"></i></div>
-                      <suggested-profiles v-show="showCoreTeam" :profiles="tribe.team_or_none_if_timeout" class="ml-4"></suggested-profiles>
+                      <div @click="showCoreTeam = !showCoreTeam" class="ml-4 mb-4 font-body left-ribbon text-justify btn-block justify-content-between align-items-center p-1"> {% trans "Top Tribe Members" %} <i class="fa fa-fw" :class="showCoreTeam ? 'fa-chevron-up': 'fa-chevron-down'"></i></div>
+                      <suggested-profiles v-show="showCoreTeam" :id="tribe.handle" class="ml-4"></suggested-profiles>
                     </div>
                     <div class="feed_container col-12 col-md-7 col-lg-8">
                       <div class="feed_container_child container-fluid">

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -869,7 +869,7 @@
                     </div>
                 </user-directory>
               </b-tab>
-              <b-tab v-if="is_on_tribe" class="col-12" title-item-class="navigation" lazy>
+              <b-tab class="col-12" title-item-class="navigation" lazy>
                 <template v-slot:title>
                   <div class="mt-3">
                     {% trans "Bounties" %}

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -1188,7 +1188,7 @@
                   </div>
                 </bounty-explorer>
               </b-tab>
-              <b-tab v-if="is_my_org || is_staff" class="col-12" title-item-class="navigation">
+              <b-tab v-if="is_my_org" class="col-12" title-item-class="navigation">
                 <template v-slot:title>
                   <div class="mt-3">
                     {% trans "Manage" %}


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
1. Add gitcoin staff to the tribe's admin view.
- user story: Help sponsors troubleshoot
If I’m an admin of gitcoin, I should also see admin view of tribes (so core team can help)

2. Fixes All view sorting by contributor rank
- before: All people view section under tribe sorted based on the user id.
- change: Sort all people view on the basis of users contributor rank.

3. Fixes tribe bounty tab for the default view (!minor)
- Current bounties tab was only viewable if the user follows the tribe.
- Change the bounties tab is the default for the tribe.

4. Fixes tribe Townsquare sidebar shows follow the suggestion for the top member-based on contributor rank.

- Once the user is followed it will disappear from the list
- Top 10 profiles will be shown based on the contributor rank.
- Don't show current user profile in tribe Townsquare suggestion bar.

<!-- Describe your changes here. -->

##### Refers/Fixes
<!-- If this PR is related to a Github issue, please add a link here. -->
https://github.com/gitcoinco/web/issues/7143

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
