### PR TITLE
proactively stop retrying tasks before max retries exception

### DIFF
--- a/app/kudos/tasks.py
+++ b/app/kudos/tasks.py
@@ -36,7 +36,7 @@ def mint_token_request(self, token_req_id, retry=False):
             obj = TokenRequest.objects.get(pk=token_req_id)
             multiplier = 1
             gas_price = int(float(recommend_min_gas_price_to_confirm_in_time(1)) * multiplier)
-            if gas_price > delay_if_gas_prices_gt_mint:
+            if gas_price > delay_if_gas_prices_gt_mint and self.request.retries < self.max_retries:
                 self.retry(countdown=120)
                 return
             tx_id = obj.mint(gas_price)
@@ -66,7 +66,8 @@ def redeem_bulk_kudos(self, kt_id, retry=False):
             try:
                 multiplier = 1
                 gas_price = int(float(recommend_min_gas_price_to_confirm_in_time(1)) * multiplier)
-                if gas_price > delay_if_gas_prices_gt_redeem:
+                if gas_price > delay_if_gas_prices_gt_redeem and self.request.retries < self.max_retries:
+
                     self.retry(countdown=120)
                     return
 
@@ -96,4 +97,7 @@ def redeem_bulk_kudos(self, kt_id, retry=False):
                 pass
             except Exception as e:
                 print(e)
-                self.retry(countdown=(30 * (self.request.retries + 1)))
+                if self.request.retries < self.max_retries:
+                    self.retry(countdown=(30 * (self.request.retries + 1)))
+                else:
+                    print("max retries for bulk kudos redeem exceeded ... giving up!")


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR stops exceptions that are thrown when minting or redeeming airdropped kudos, either due to network congestion or some other reason that causes the celery task to be retried. After the max retries are hit, we stop attempting to retry to the task.

##### Refers/Fixes

n/a

##### Testing

untested