### PR TITLE
bug: remove unused var kudosNumClonesAvailable

### DIFF
--- a/app/assets/v2/js/pages/kudos_details.js
+++ b/app/assets/v2/js/pages/kudos_details.js
@@ -24,13 +24,6 @@ $(document).ready(function() {
     }
 
   });
-
-  if (kudosNumClonesAvailable == 0) {
-    $('#getKudos').attr('class', 'btn btn-gc-blue disabled').attr('aria-disabled', 'true');
-    return;
-  }
-
-
 });
 
 var rotate_kudos_msg = function() {


### PR DESCRIPTION
##### Refers/Fixes

https://sentry.io/organizations/gitcoin/issues/1724229795/?project=1398424&query=is%3Aunresolved

##### Testing

This variable is not used anywhere on our site ! Guess it was added but either was removed / never wired it