### PR TITLE
move the bootstrap vue global styles into the shared head template

### DIFF
--- a/app/dashboard/templates/dashboard/index-vue.html
+++ b/app/dashboard/templates/dashboard/index-vue.html
@@ -27,7 +27,6 @@
       {% include 'shared/cards.html' %}
     {% endif %}
     <link rel="stylesheet" href='{% static "v2/css/dashboard-hackathon.css" %}'/>
-    <link rel="stylesheet" href='{% static "v2/css/bootstrap-vue.min.css" %}'/>
     <link rel="stylesheet" href='{% static "v2/css/featured-bounties.css" %}'/>
     <link rel="stylesheet" href='{% static "v2/css/tag.css" %}'/>
     <link rel="stylesheet" href='{% static "v2/css/users.css" %}' />

--- a/app/retail/templates/shared/head.html
+++ b/app/retail/templates/shared/head.html
@@ -34,6 +34,7 @@
 <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 <link rel="stylesheet" href="{% static "v2/css/search.css" %}">
 <link rel="stylesheet" href="{% static "v2/css/bootstrap.min.css" %}" crossorigin="anonymous">
+<link rel="stylesheet" href='{% static "v2/css/bootstrap-vue.min.css" %}'/>
 <link rel="stylesheet" href="{% static "v2/css/lib/typography.css" %}">
 <link rel="stylesheet" href="{% static "v2/css/fontawesome-all.min.css" %}">
 <link rel="stylesheet" href="{% static "v2/css/gitcoin.css" %}" />

--- a/app/townsquare/templates/townsquare/index.html
+++ b/app/townsquare/templates/townsquare/index.html
@@ -79,7 +79,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href='{% static "v2/css/bootstrap-vue.min.css" %}'/>
     <script src='{% static "v2/js/theme_switcher.js" %}'></script>
   </head>
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
The bootstrap-vue styles are globally required now that chat is available in a fly out.
<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
