### PR TITLE
Prevent decimal on estimated hour field

### DIFF
--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -9,7 +9,8 @@ Vue.component('v-select', VueSelect.VueSelect);
 Vue.mixin({
   methods: {
     estHoursValidator: function() {
-      this.form.hours = parseInt(this.form.hours || 0);
+      this.form.hours = parseFloat(this.form.hours || 0);
+      this.form.hours = Math.ceil(this.form.hours);
       this.calcValues('token');
     },
     getIssueDetails: function(url) {

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -8,6 +8,10 @@ window.addEventListener('dataWalletReady', function(e) {
 Vue.component('v-select', VueSelect.VueSelect);
 Vue.mixin({
   methods: {
+    estHoursValidator: function() {
+      this.form.hours = parseInt(this.form.hours || 0);
+      this.calcValues('token');
+    },
     getIssueDetails: function(url) {
       let vm = this;
 

--- a/app/dashboard/templates/bounty/new_bounty.html
+++ b/app/dashboard/templates/bounty/new_bounty.html
@@ -390,7 +390,7 @@
 
                   <div class="col-12 col-md-3" id="usd-amount-wrapper">
                     <label class="form__label" for="hours">Est. Hours of Work</label>
-                    <input name="hours" id="hours" class="form__input" type="number" step="1" min="1" v-model="form.hours" @input="calcValues('token')">
+                    <input name="hours" id="hours"  pattern="[0-9]" class="form__input" type="number" step="1" min="1" v-model="form.hours" @input="estHoursValidator">
                   </div>
                 </div>
                 <div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
Prevents having a decimal value, entered into the estimated hours' field. This is accomplished by using the Math.ceil function to round to the next hour. Since typically, 20minutes work should be billed on an hourly basis.

##### Refers/Fixes
https://github.com/gitcoinco/web/issues/7261
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing
1. Attempted inputing a whole number value, nothing changes
2. Input Decimal value that can be rounded up (e.g 3.7), it should round up to 4
3. Input decimal value that can be rounded down (e.g 2.2), it should round up to 3
4. Attempt pastiing decimal value (e.g 5.19), it should round up to 6.
![ezgif-7-b54a0304e086](https://user-images.githubusercontent.com/14205064/92375928-b7d60180-f0f9-11ea-8ef5-e8bd626da62d.gif)

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
