### PR TITLE
fix: missing JSONStore object

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4451,6 +4451,11 @@ def hackathon_registration(request):
 def get_hackathons(request):
     """Handle rendering all Hackathons."""
 
+    if settings.DEBUG:
+        from perftools.management.commands import create_page_cache
+        
+        create_page_cache.create_hackathon_list_page_cache()
+
     tabs = [
         ('current', 'happening now'),
         ('upcoming', 'upcoming'),


### PR DESCRIPTION
related to recent PR https://github.com/gitcoinco/web/pull/7254

prevent error in local docker builds due to non-existing JSONStore object by automatically calling `create_hackathon_list_page_cache` from the `get_hackathons` view if `debug` is on.