### PR TITLE
fix: duplicate registration on hackathon onboarding

### DIFF
--- a/app/dashboard/templates/dashboard/hackathon/onboard.html
+++ b/app/dashboard/templates/dashboard/hackathon/onboard.html
@@ -475,6 +475,7 @@
           const data = {'name': name, 'referer': referer};
           const sendRegister = fetchData(url, 'POST', data, {'X-CSRFToken': csrftoken});
 
+          $('[data-registration]').addClass('disabled');
           $.when(sendRegister).then((response) => {
             _alert('You have now registered for this hackathon.', 'success');
             console.log(response)
@@ -492,6 +493,7 @@
             const data = { 'name': name, 'referer': referer, 'poll': JSON.stringify(poll)};
             const sendRegister = fetchData(url, 'POST', data, {'X-CSRFToken': csrftoken});
 
+            $(this).addClass('disabled');
             $.when(sendRegister).then((response) => {
               _alert('You have now registered for this hackathon.', 'success');
               console.log(response)

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4361,6 +4361,10 @@ def hackathon_registration(request):
             status=401)
     try:
         hackathon_event = HackathonEvent.objects.filter(slug__iexact=hackathon).latest('id')
+
+        if HackathonRegistration.objects.filter(hackathon=hackathon_event, registrant=profile).exists():
+            return JsonResponse({'error': _('Already registered.')}, status=401)
+
         HackathonRegistration.objects.create(
             name=hackathon,
             hackathon=hackathon_event,


### PR DESCRIPTION
To prevent duplicate hackathon registrations under an event:

- return error on POST to /register_hackathon/ if user already registerd
- if no poll on hackathon onboard page, disable 'Join Now' button on click
- if poll on hackathon onboard page, disable poll submit button on click

fixes https://github.com/gitcoinco/web/issues/7070