### PR TITLE
add python diff driver to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh   text eol=lf
+*.py diff=python


### PR DESCRIPTION
Useful for when `git log -L` is used on class methods -things work without the diff driver for functions and classes- and diffcore-pickaxe options.