### PR TITLE
zkSync updates part 2

### DIFF
--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -204,7 +204,7 @@ $(document).ready(function() {
         type: 'post',
         url: '',
         data: {
-          'grant_cancel_tx_id': '0x0',
+          'grant_cancel_tx_id': '0x0'
         },
         success: function(json) {
           window.location.reload(false);

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -542,14 +542,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                       <div class="font-weight-bold">PLEASE DO NOT CLOSE THIS WINDOW!</div>
                       <div>
                         <div>
-                          Estimated processing time: <span class="font-weight-bold">2m&ndash;4m</span>.&nbsp;
-                          <span v-if="zkSyncDepositEtherscanUrl">
-                            <a :href="zkSyncDepositEtherscanUrl" target="_blank">
-                              View deposit transaction&nbsp;<i class="fas fa-external-link-alt"></i>
+                          <span v-if="hasSufficientZkSyncBalance">
+                            Estimated processing time: <span class="font-weight-bold">&lt; 1m</span>.&nbsp;
+                          </span>
+                          <span v-else>
+                            Estimated processing time: <span class="font-weight-bold">2m&ndash;4m</span>.&nbsp;
+                          </span>
+                          <span v-if="zkSyncBlockExplorerUrl">
+                            <a :href="zkSyncBlockExplorerUrl" target="_blank">
+                              View transaction<span v-if="hasSufficientZkSyncBalance">s</span>
+                              &nbsp;<i class="fas fa-external-link-alt"></i>
                             </a>
                           </span>
                         </div>
-                        <div v-if="zkSyncDepositEtherscanUrl && zkSyncCheckoutStep3Status !== 'not-started'">
+                        <div v-if="zkSyncBlockExplorerUrl && zkSyncCheckoutStep3Status !== 'not-started'">
                           <div v-if="zkSyncCheckoutFlowStep === 0">
                             Confirmations received: [[currentConfirmationNumber]] of [[numberOfConfirmationsNeeded]]
                           </div>
@@ -575,26 +581,32 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                         </div>
                       </div>
                     </div>
-                    <p v-if="!zkSyncWasInterrupted" class="my-4 text-left">
+                    <p v-if="!zkSyncWasInterrupted" class="mt-4 text-left">
                       <span v-if="zkSyncCheckoutStep2Status === 'not-started'">
                         zkSync is powered by zkRollup with a universal setup &mdash; an L2
                         scaling solution. Save gas fees and get faster confirmations.
                         <a href="https://zksync.io/" target="_blank">Learn more</a>.
                         <br><br>
                       </span>
-                      To pay with zkSync, you will have to sign one message and send up to
-                      [[maxPossibleTransactions]] transactions with your Web3 wallet.
+                      <span v-if="hasSufficientZkSyncBalance">
+                        To pay with zkSync, you will have to sign
+                        <span v-if="zkSyncCheckoutStep2Status !== 'complete'">up to</span>
+                        [[maxPossibleSignatures]] messages with your Web3 wallet.
+                      </span>
+                      <span v-else>
+                        To pay with zkSync, you will have to sign one message and send up to
+                        [[maxPossibleTransactions]] transactions with your Web3 wallet.
+                      </span>
                     </p>
-                    <p v-else class="my-4 text-left">
+                    <p v-else class="mt-4 text-left">
                       You started checking out with zkSync but never completed the process. 
                       You must complete this checkout before proceeding with any other checkouts.
                       Please follow the prompts below to complete the process.
                     </p>
                     </div>
                   </div>
-                  <br>
                   {% comment %} Advanced settings {% endcomment %}
-                  <div v-if="!zkSyncWasInterrupted" class="mb-3">
+                  <div v-if="!zkSyncWasInterrupted && !hasSufficientZkSyncBalance" class="mb-3">
                     <div class="row justify-content-end font-smaller-1 font-weight-semibold text-highlight-dark-blue">
                       <div @click="showAdvancedSettings = !showAdvancedSettings" class="col-auto" style="cursor: pointer;">
                         Advanced settings <i class="ml-1 fas fa-cog"></i>
@@ -655,11 +667,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                           Step 1
                         </div>
                         <div>
-                          Sign in to zkSync
+                          Sign in to zkSync via Gitcoin
                         </div>
                       </div>
                       <div class="col-4">
-                        <button v-if="zkSyncCheckoutStep1Status === 'not-started'" class="btn btn-gc-blue button--full shadow-none" @click="zkSyncLogin">
+                        <button v-if="zkSyncCheckoutStep1Status === 'not-started'" 
+                          class="btn btn-gc-blue button--full shadow-none" @click="zkSyncLoginGitcoinFlow"
+                        >
                           Sign in
                         </button>
                         <div v-else-if="zkSyncCheckoutStep1Status === 'pending'">
@@ -683,12 +697,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                           Step 2
                         </div>
                         <div>
-                          ERC20 token approvals
+                          <span v-if="hasSufficientZkSyncBalance">Sign in to zkSync directly</span>
+                          <span v-else>ERC20 token approvals</span>
                         </div>
                       </div>
                       <div class="col-4">
-                        <button v-if="zkSyncCheckoutStep2Status === 'not-started'" :disabled="zkSyncCheckoutStep1Status !== 'complete'" class="btn btn-gc-blue button--full shadow-none" @click="zkSyncApprovals">
-                          Approve
+                        <button v-if="zkSyncCheckoutStep2Status === 'not-started'" 
+                          :disabled="zkSyncCheckoutStep1Status !== 'complete'" class="btn btn-gc-blue button--full shadow-none" 
+                          @click="zkSyncBeginStep2"
+                        >
+                          <span v-if="hasSufficientZkSyncBalance">Sign in</span>
+                          <span v-else>Approve</span>
                         </button>
                         <div v-else-if="zkSyncCheckoutStep2Status === 'not-applicable'">
                           <span class="text-highlight-green">
@@ -723,7 +742,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                       <div class="col-4">
                         <button v-if="zkSyncCheckoutStep3Status === 'not-started' && !zkSyncWasInterrupted" 
                           :disabled="zkSyncCheckoutStep2Status === 'not-started'" 
-                          class="btn btn-gc-blue button--full shadow-none" @click="sendZkSyncDonation"
+                          class="btn btn-gc-blue button--full shadow-none" @click="zkSyncBeginStep3"
                         >
                           Confirm
                         </button>

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -550,6 +550,59 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                     </div>
                   </div>
                   <br>
+                  {% comment %} Advanced settings {% endcomment %}
+                  <div v-if="!zkSyncWasInterrupted" class="mb-3">
+                    <div class="row justify-content-end font-smaller-1 font-weight-semibold text-highlight-dark-blue">
+                      <div @click="showAdvancedSettings = !showAdvancedSettings" class="col-auto" style="cursor: pointer;">
+                        Advanced settings <i class="ml-1 fas fa-cog"></i>
+                      </div> 
+                    </div>
+                    <div v-if="showAdvancedSettings" class="p-3 text-left" style="background-color: #F1F1F1; width: 100%;">
+                      <div>
+                        Save 99% on future checkouts!
+                      </div>
+                      <div class="mt-1 font-smaller-1 text-medium-dark-grey">
+                        When you have enough funds on zkSync there is no need for an L1 transaction.
+                        The funds can also be accessed via
+                        <a href="https://wallet.zksync.io/" target="_blank">https://wallet.zksync.io/</a>
+                        for use outside of Gitcoin.
+                      </div>
+                      <div class="row justify-content-start align-items-center mt-3">
+                        <div class="col-4 font-smaller-1 text-medium-dark-grey">
+                          Current deposit
+                        </div>
+                        <div class="col-1">
+                          &nbsp;
+                        </div>
+                        <div class="col-7 font-smaller-1 text-medium-dark-grey">
+                          Additional deposit
+                        </div>
+                      </div>
+                      <div>
+                        {% comment %} v-for each token in cart {% endcomment %}
+                        <div v-for="(additionalDeposit, index) in zkSyncAdditionalDeposits"
+                          class="row justify-content-start align-items-center mt-1"
+                        >
+                          <div class="col-4">
+                            [[ donationsTotal[additionalDeposit.tokenSymbol] ]] [[ additionalDeposit.tokenSymbol ]]
+                          </div>
+                          <div class="col-1">
+                            +
+                          </div>
+                          <div class="col-7">
+                            <div class="row justify-content-start align-items-center">
+                              {% comment %} User must input amount before {% endcomment %}
+                              <input v-model.number="additionalDeposit.amount" class="col-5 form-control"
+                                style="margin-left:0.5rem" min="0" step="any" type="number"
+                                :disabled="zkSyncCheckoutStep2Status !== 'not-started'"
+                              >
+                              <div class="col-5">[[ additionalDeposit.tokenSymbol ]]</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                   {% comment %} Body {% endcomment %}
                   <div>
                     {% comment %} Step 1 {% endcomment %}
@@ -662,15 +715,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                           Confirmations received: [[currentConfirmationNumber]] of [[numberOfConfirmationsNeeded]]
                           </div>
                           <div v-else-if="zkSyncCheckoutFlowStep === 1">
+                            {% comment %} Wait for state change commitment {% endcomment %}
                             Waiting for confirmation that deposit was received by zkSync...
                           </div>
                           <div v-else-if="zkSyncCheckoutFlowStep === 2">
+                          {% comment %} Get signatures for each transfer {% endcomment %}
                             Preparing transfer [[currentTxNumber]] of [[donationInputs.length]]
                           </div>
                           <div v-else-if="zkSyncCheckoutFlowStep === 3">
+                            {% comment %} Dispatch transfers to the zkSync network {% endcomment %}
                             Sending transfer [[currentTxNumber]] of [[donationInputs.length]]
                           </div>
                           <div v-else-if="zkSyncCheckoutFlowStep === 4">
+                            {% comment %} Transfer remaining balances to user's main wallet {% endcomment %}
+                            Finalizing contributions...
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 5">
                             Checkout complete!
                           </div>
                         </div>

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -520,33 +520,76 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                 </button>
               </template>
               <template v-slot:default="{ hide }">
-                <div class="mx-4 mb-4 text-center">
+                <div class="mx-2 mb-4 text-center">
                   {% comment %} Header {% endcomment %}
                   <div class="mb-3">
                     <img src="{% static 'v2/images/grants/zksync.svg' %}" alt="zkSync Logo" width="150">
-                    {% comment %} Ordinary header and text {% endcomment %}
+                    {% comment %} Header {% endcomment %}
                     <div v-if="!zkSyncWasInterrupted">
                       <h1 class="font-bigger-4 font-weight-bold mt-2">Pay with zkSync</h1>
-                      <p class="my-4 text-left">
-                        zkSync is powered by zkRollup with a universal setup &mdash; an L2
-                        scaling solution. Save gas fees and get faster confirmations.
-                      <a href="https://zksync.io/" target="_blank">Learn more</a>.
-                      <br><br>
-                        To pay with zkSync, you will have to sign one message and send up to
-                        [[maxPossibleTransactions]] transactions with your Web3 wallet.
-                      </p>
                     </div>
-                    {% comment %} Special header and text if user is finishing checkout {% endcomment %}
                     <div v-else>
                       <h1 class="font-bigger-4 font-weight-bold mt-2">
-                      <i class="fas fa-exclamation-triangle" style="color: #ECC94B"></i>
+                        <i class="fas fa-exclamation-triangle" style="color: #ECC94B"></i>
                         Complete zkSync Checkout
                       </h1>
-                      <p class="my-4 text-left">
-                        You started checking out with zkSync but never completed the process. 
-                        You must complete this checkout before proceeding with any other checkouts.
-                        Please follow the prompts below to complete the process.
-                      </p>
+                    </div>
+                    {% comment %} Body {% endcomment %}
+                    <div v-if="zkSyncCheckoutStep2Status !== 'not-started'" 
+                      class="mt-4 p-2 text-left font-smaller-1" style="background-color: #FFF6CF; width: 100%;"
+                    >
+                      {% comment %} Status updates for user {% endcomment %}
+                      <div class="font-weight-bold">PLEASE DO NOT CLOSE THIS WINDOW!</div>
+                      <div>
+                        <div>
+                          Estimated processing time: <span class="font-weight-bold">2m&ndash;4m</span>.&nbsp;
+                          <span v-if="zkSyncDepositEtherscanUrl">
+                            <a :href="zkSyncDepositEtherscanUrl" target="_blank">
+                              View deposit transaction&nbsp;<i class="fas fa-external-link-alt"></i>
+                            </a>
+                          </span>
+                        </div>
+                        <div v-if="zkSyncDepositEtherscanUrl && zkSyncCheckoutStep3Status !== 'not-started'">
+                          <div v-if="zkSyncCheckoutFlowStep === 0">
+                            Confirmations received: [[currentConfirmationNumber]] of [[numberOfConfirmationsNeeded]]
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 1">
+                            {% comment %} Wait for state change commitment {% endcomment %}
+                            Waiting for confirmation that deposit was received by zkSync...
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 2">
+                            {% comment %} Get signatures for each transfer {% endcomment %}
+                            Preparing transfer [[currentTxNumber]] of [[donationInputs.length]]
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 3">
+                            {% comment %} Dispatch transfers to the zkSync network {% endcomment %}
+                            Sending transfer [[currentTxNumber]] of [[donationInputs.length]]
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 4">
+                            {% comment %} Transfer remaining balances to user's main wallet {% endcomment %}
+                            Finalizing contributions...
+                          </div>
+                          <div v-else-if="zkSyncCheckoutFlowStep === 5">
+                            Checkout complete!
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <p v-if="!zkSyncWasInterrupted" class="my-4 text-left">
+                      <span v-if="zkSyncCheckoutStep2Status === 'not-started'">
+                        zkSync is powered by zkRollup with a universal setup &mdash; an L2
+                        scaling solution. Save gas fees and get faster confirmations.
+                        <a href="https://zksync.io/" target="_blank">Learn more</a>.
+                        <br><br>
+                      </span>
+                      To pay with zkSync, you will have to sign one message and send up to
+                      [[maxPossibleTransactions]] transactions with your Web3 wallet.
+                    </p>
+                    <p v-else class="my-4 text-left">
+                      You started checking out with zkSync but never completed the process. 
+                      You must complete this checkout before proceeding with any other checkouts.
+                      Please follow the prompts below to complete the process.
+                    </p>
                     </div>
                   </div>
                   <br>
@@ -701,38 +744,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             <i class="fas fa-check"></i>
                             Completed
                           </span>
-                        </div>
-                      </div>
-                      {% comment %} Status updates for user {% endcomment %}
-                      <div v-if="zkSyncDepositEtherscanUrl" class="mt-4 p-2 text-left font-smaller-1" style="background-color: #F1F1F1; width: 100%;">
-                        <div class="font-weight-bold">PLEASE DO NOT CLOSE THIS WINDOW!</div>
-                        <div>
-                          <div>
-                            Estimated processing time: <span class="font-weight-bold">2m&ndash;3m</span>.&nbsp;
-                            <span><a :href="zkSyncDepositEtherscanUrl" target="_blank">View deposit transaction&nbsp;<i class="fas fa-external-link-alt"></i></a></span>
-                          </div>
-                          <div v-if="zkSyncCheckoutFlowStep === 0">
-                          Confirmations received: [[currentConfirmationNumber]] of [[numberOfConfirmationsNeeded]]
-                          </div>
-                          <div v-else-if="zkSyncCheckoutFlowStep === 1">
-                            {% comment %} Wait for state change commitment {% endcomment %}
-                            Waiting for confirmation that deposit was received by zkSync...
-                          </div>
-                          <div v-else-if="zkSyncCheckoutFlowStep === 2">
-                          {% comment %} Get signatures for each transfer {% endcomment %}
-                            Preparing transfer [[currentTxNumber]] of [[donationInputs.length]]
-                          </div>
-                          <div v-else-if="zkSyncCheckoutFlowStep === 3">
-                            {% comment %} Dispatch transfers to the zkSync network {% endcomment %}
-                            Sending transfer [[currentTxNumber]] of [[donationInputs.length]]
-                          </div>
-                          <div v-else-if="zkSyncCheckoutFlowStep === 4">
-                            {% comment %} Transfer remaining balances to user's main wallet {% endcomment %}
-                            Finalizing contributions...
-                          </div>
-                          <div v-else-if="zkSyncCheckoutFlowStep === 5">
-                            Checkout complete!
-                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Second round of zkSync changes is ready for review. There are a lot of code paths and I've only tested against Rinkeby, so there are almost guaranteed to be some bugs and issues so please report any issues you find while testing this PR.

Changes in this PR are explained below.

### Background

There are two zkSync accounts to consider: 
1. gitcoinSyncWallet — A zkSync wallet generated by having the user sign a Gitcoin-specific message. This gives us the private key used to create this deterministic wallet. Since we have the private key, we can send transfers without prompting the user
2. nominalSyncWallet — The default zkSync wallet generated through the zkSync SDK, using the user's web3 account. We do not have the private key, so the user receives a signature prompt on each transfer

### User Flows

Upon clicking "Checkout with zkSync", the flow looks like this:
1. Does user have sufficient balance in nominalSyncWallet to cover all deposits? If yes, we call this Flow A which only requires signatures and is extremely cheap and fast. If no, we call this Flow B, which requires an L1 transaction so is costly and slow.

2. Flow A:
    1. Prompt user to sign in to gitcoinSyncWallet (user sees prompt 1)
    2. Prompt user to sign in to nominalSyncWallet (user sees prompt 2)
    3. If user has never used zkSync (e.g. maybe someone sent them funds and they never used it), they see a signature prompt to register their zkSync account (user prompt 3)
    3. Prompt user to transfer funds from nominalSyncWallet to gitcoinSyncWallet (user sees prompts 3 or 4–_n_, where _n_ = number of different currencies selected in cart)

3. Flow B:
   1. "Advanced settings" toggle lets users choose to deposit additional funds on top of their donation
   2. Prompt user to sign in to gitcoinSyncWallet (user sees prompt 1)
   3. Prompt user to approve ERC20 tokens (user sees prompts 2–_n_, where _n_ depends on number of different currencies selected in cart and pre-existing allowances)
   4. Prompt user to deposit funds into zkSync (user sees prompt _n_+1)

4. Flows A and B now converge
5. We sign each donation transfer with the gitcoinSyncWallet (no user prompts)
6. We dispatch each donation transfer from the gitcoinSyncWallet (no user prompts)
7. If there are any excess funds left in gitcoinSyncWallet, we transfer them to nominalSyncWallet. (Sometimes there will be dust leftover in gitcoinSyncWallet based on [amount packing](https://github.com/matter-labs/zksync/blob/2990cfa294d50b87f8d3ccb3c3f418cc2d0d5a40/docs/protocol.md#amount-packing) and fees, but there's not much we can do about this). 

### Notes

The main remaining tasks for zkSync that are not included in this PR are:
- Transaction validator must be updated to support Flow A
- Make gas estimates smarter — for now it's temporarily hardcoded at 1M 
- Make suggestion to user whether to use zkSync vs. L1 depending on balances and estimated gas costs. Our suggestion here cannot be perfect and will be wrong sometimes. This is because we'll only have imperfect gas estimates, but we may be able to tweak this as the round goes on and we get some real data

Also, apologies for the monster that cart.js has become 😅

cc @thelostone-mc @octavioamu @owocki @apbendi 