### PR TITLE
Fix small zkSync bugs, run linter

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1800,8 +1800,9 @@ Vue.component('grants-cart', {
           // signing key is set
 
           // +1 for each additional token in their cart
-          Object.keys(this.donationsTotal).forEach((token) => {
-            if (token !== 'ETH') {
+          selectedTokens.forEach((token, index) => {
+            if (index !== 0) {
+              // SKip first one since we already expect at least one token transfer
               this.maxPossibleSignatures += 1;
             }
           });
@@ -2002,7 +2003,9 @@ Vue.component('grants-cart', {
         const tx = await this.nominalSyncWallet.syncTransfer({
           to: transferInfo.dest,
           token: transferInfo.name,
-          amount,
+          // totalRequiredAmount amount includes fee of this transfer, so subtract that now because
+          // otherwise we'd be transferring one additional fee
+          amount: zksync.utils.closestPackableTransactionAmount(amount.sub(fee)),
           fee
         });
 

--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -113,11 +113,11 @@ Vue.component('grant-sidebar', {
     isMobileDevice: function() {
       return window.innerWidth < 576;
     },
-    filterLink: function(params){
+    filterLink: function(params) {
       if (params.type === this.type) {
-        this.filter_grants(params)
+        this.filter_grants(params);
       } else {
-        document.location.href = `/grants/${params.type}`
+        document.location.href = `/grants/${params.type}`;
       }
     },
     searchKeyword: function() {


### PR DESCRIPTION
For zkSync Flow A:
- We were sending too much as amount for first transfer, so zkSync transfers could fail if the total amount held in zkSync was close to the total donation amount
- Previously we were incorrectly estimating max required signatures for zkSync

Also ran the linter which is the only reason `index.js` is modified