### PR TITLE
Add 1.4x Multiplier Verification Case

### DIFF
--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -205,8 +205,20 @@ def calculate_clr(aggregated_contributions, pair_totals, sms_verified_list, brig
 
             # pairwise matches to current round
             for k2, v2 in contribz.items():
+                # both (sms & bright)
+                if k2 > k1 and all(i in sms_verified_list and i in bright_verified_list for i in [k2, k1]):
+                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / (v_threshold * 1.4) + 1)
+                # (sms & bright) & bright
+                elif k2 > k1 and (((k2 in sms_verified_list and k2 in bright_verified_list) and (k1 in bright_verified_list)) or ((k1 in sms_verified_list and k1 in bright_verified_list) and (k2 in bright_verified_list))):
+                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / (v_threshold * 1.3) + 1)
+                # (sms & bright) & sms
+                elif k2 > k1 and (((k2 in sms_verified_list and k2 in bright_verified_list) and (k1 in sms_verified_list)) or ((k1 in sms_verified_list and k1 in bright_verified_list) and (k2 in sms_verified_list))):
+                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / (v_threshold * 1.225) + 1)
+                # (sms & bright) & none
+                elif k2 > k1 and (((k2 in sms_verified_list and k2 in bright_verified_list) and (k1 not in sms_verified_list + bright_verified_list)) or ((k1 in sms_verified_list and k1 in bright_verified_list) and (k2 not in sms_verified_list + bright_verified_list))):
+                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / uv_threshold + 1)
                 # both sms
-                if k2 > k1 and all(i in sms_verified_list for i in [k2, k1]):
+                elif k2 > k1 and all(i in sms_verified_list for i in [k2, k1]):
                     tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / (v_threshold * 1.05) + 1)
                 # both bright
                 elif k2 > k1 and all(i in bright_verified_list for i in [k2, k1]):

--- a/scripts/debug/ingest_tip.py
+++ b/scripts/debug/ingest_tip.py
@@ -1,0 +1,38 @@
+from django.utils import timezone
+from dashboard.models import Profile, Tip
+from dashboard.tip_views import get_profile
+
+to_username = ''
+from_username = ''
+txid = ''
+token_address = ''
+from_address = ''
+tokenName = ''
+amount = 0
+created_on = timezone.now()
+#created_on = timezone.datetime(2020, 6, 15, 8, 0)
+ip='192.168.0.1'
+
+tip = Tip.objects.create(
+    primary_email=get_profile(to_username).email,
+    emails=[],
+    tokenName=tokenName,
+    amount=amount,
+    comments_priv='',
+    comments_public='',
+    ip=ip,
+    expires_date=created_on,
+    github_url='',
+    from_name=from_username,
+    from_email=get_profile(from_username).email,
+    from_username=from_username,
+    username=to_username,
+    network='mainnet',
+    tokenAddress=token_address,
+    from_address=from_address,
+    is_for_bounty_fulfiller=False,
+    metadata={},
+    recipient_profile=get_profile(to_username),
+    sender_profile=get_profile(from_username),
+)
+print(tip.pk)


### PR DESCRIPTION
##### Description

If someone is Bright ID and SMS verified, they achieve a even higher multiplier. We want to account for this in the calculation. I've added 4 additional cases:

1.  x and y are both Bright and SMS verified (1.4x)
2. x is both and y is Bright (1.3x)
3. x is both and y is SMS (1.225x)
4. x is both and y is none (1x) 

There were also some weird merge conflicts. Parts of the CLR code looked a little outdated between the two versions, but I resolved them

##### Refers/Fixes

Doesn't fix anything, just an add-on.

##### Testing

`if` and `elif` logic follows previous iterations currently in the code.
