### PR TITLE
More zkSync fixes

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1570,9 +1570,6 @@ Vue.component('grants-cart', {
         console.log(`  ✅ Got transfer ${i + 1} receipt`, receipt);
       }
 
-      // Save contributions to database
-      await this.postToDatabase(this.gitcoinSyncWallet.cachedAddress, '', this.userAddress);
-
       // Transfer any remaining tokens to user's main wallet ---------------------------------------
       this.zkSyncCheckoutFlowStep += 1; // Done!
       const gitcoinZkSyncState = await this.syncProvider.getState(this.gitcoinSyncWallet.cachedAddress);
@@ -2020,6 +2017,10 @@ Vue.component('grants-cart', {
       // Final steps
 
       this.zkSyncCheckoutFlowStep = 2; // Steps 0 and 1 are skipped here
+
+      // Save contributions to database once transfers to gitcoinSyncWallet are complete
+      await this.postToDatabase(this.gitcoinSyncWallet.cachedAddress, '', this.userAddress);
+
       await this.finishZkSyncTransfersAllFlows();
     },
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1714,11 +1714,11 @@ Vue.component('grants-cart', {
       const numberOfFees = 3 + this.donationInputs.filter((x) => x.name === tokenSymbol).length;
 
       // Transfers to an address that has never used zkSync are more expensive, which is why we
-      // use the zero address as the recipient -- this gives us a conservative estimate. We also
+      // use a random address as the recipient -- this gives us a conservative estimate. We also
       // do this to avoid hitting the zkSync servers with dozens of rapid fee requests when users
       // have a large number of items in their cart
       const { fee, amount } = await this.getZkSyncFeeAndAmount({
-        dest: '0x0000000000000000000000000000000000000001', // zero address throws, so use 1
+        dest: ethers.Wallet.createRandom().address, // gives an address that has never been used on zkSync
         name: tokenSymbol,
         amount: initialAmount
       });

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -2101,7 +2101,14 @@ Vue.component('grants-cart', {
           // Verify user has sufficient balances now that we account for transaction fees
           // Check tokens
           for (let i = 0; i < deposits.length; i += 1) {
-            const tokenContract = new web3.eth.Contract(token_abi, deposits[i][0]);
+            const tokenAddress = deposits[i][0];
+            
+            if (tokenAddress === ETH_ADDRESS) {
+              // Skip ETH because we check it later
+              continue;
+            }
+              
+            const tokenContract = new web3.eth.Contract(token_abi, tokenAddress);
             const requiredAmount = deposits[i][1];
             const userTokenBalance = await tokenContract.methods.balanceOf(this.userAddress).call({from: this.userAddress});
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1704,8 +1704,14 @@ Vue.component('grants-cart', {
      * and the corresponding total amount, after fees, that is needed to cover them.
      */
     async getTotalAmountToTransfer(tokenSymbol, initialAmount) {
-      // Number of transfers that will take place is number of donations, plus one initial transfer
-      const numberOfFees = 1 + this.donationInputs.filter((x) => x.name === tokenSymbol).length;
+      // Number of transfers that will take place is:
+      //   number of donations + 1 initial transfer + 1 final transfer + 1 for margin
+      //
+      // We are intentionally conservative here because we'd rather a user deposit too much
+      // and be successful than too little and fail. The downside to being conservative is that
+      // users are required to have enough margin in their accound balance to accomodate this, but
+      //  that is ok because it's similar to be required to have enough ETH for excess L1 gas limit
+      const numberOfFees = 3 + this.donationInputs.filter((x) => x.name === tokenSymbol).length;
 
       // Transfers to an address that has never used zkSync are more expensive, which is why we
       // use the zero address as the recipient -- this gives us a conservative estimate. We also

--- a/app/assets/v2/js/pages/results.js
+++ b/app/assets/v2/js/pages/results.js
@@ -145,10 +145,10 @@ $(document).ready(function() {
       });
     }
   });
-  setTimeout(function(){
+  setTimeout(function() {
     $('#leaderboard_nav .nav-link:first-child').click();
 
-    $("#tweets").html(`
+    $('#tweets').html(`
         <div class="row py-1">
           <div class="col-12 offset-md-0 d-flex justify-content-center align-items-center ">
             <blockquote class="twitter-tweet"><p lang="en" dir="ltr">And to <a href="https://twitter.com/owocki?ref_src=twsrc%5Etfw">@owocki</a> and the entire team at <a href="https://twitter.com/gitcoin?ref_src=twsrc%5Etfw">@gitcoin</a> <br><br>Thank you for making it so easy this time! You&#39;re everything that&#39;s good in this world 🌐😍 <a href="https://t.co/bVNIvUem01">pic.twitter.com/bVNIvUem01</a></p>&mdash; Mariano Conti | conti.eth (@nanexcool) <a href="https://twitter.com/nanexcool/status/1275513916714618882?ref_src=twsrc%5Etfw">June 23, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
@@ -209,7 +209,7 @@ $(document).ready(function() {
             <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Gitcoin grants quadratic funding is not just for funds allocation, it&#39;s also a great signaling tool!<br><br>For the last few rounds, going to <a href="https://t.co/F4VFg2s7LJ">https://t.co/F4VFg2s7LJ</a> (sort by top match) has led me to discover a lot of really cool Ethereum projects I previously did not know about.</p>&mdash; vitalik.eth (@VitalikButerin) <a href="https://twitter.com/VitalikButerin/status/1243284318987878401?ref_src=twsrc%5Etfw">March 26, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
           </div>
         </div>
-      `)
+      `);
 
-  },5000)
+  }, 5000);
 });


### PR DESCRIPTION
Current changes

### 1. POST Request Improvements

Fixes item 2 of https://github.com/gitcoinco/web/issues/7421, which says:

> POST request to save data is not sent until after all transactions, so if the donation tx fails this does not get logged and we don't have the contribution data for matching. Move this POST request to be sent after L1 tx (if applicable) and before the L2 txs are sent

For Flow A (pure zkSync) the POST request is now sent after the initial transfer from the nominal zkSync wallet to the Gitcoin zkSync wallet. This means if transfers fail we'll still have all the contribution data in a JSON Store and saved as contributions/subscriptions

For Flow B (L1 deposit) nothing is changed. The POST request is still sent after the deposit tx is sent, but before it is mined (and therefore before any L2 txs occur)

(Need to do more testing and updates of the tx validator locally, but this should be merged and deployed since there are a lot of other changes)

### 2. More conservative fees/amounts

Fixes item 1 of https://github.com/gitcoinco/web/issues/7421, which says:

> On some checkouts, the final zkSync transfer (the donation to Gitcoin) fails. This happens because insufficient balance remains

I'm not able to reproduce these locally, so for now we've worked around this by increasing the fee margin. This is analogous to raising the gas limit to ensure L1 txs don't fail

### 3. Ensure "new account" fee is used

Transfers to new accounts on zkSync are more costly than transfers to existing accounts. Previously we fetched the fee by just pretending we were sending to `0x0000000000000000000000000000000000000001`, since no one has sent to this address.

However, this code would "break" and give lower fee estimates if someone ever does send to this address. To remedy this, we now check the fee by generate a random address each time and pretending we're sending to that address. The address space is large enough that we are effectively guaranteed to always have a never-been-used address there

### 4. Fix for zero DAI donations to Gitcoin

Fixes item 5 of https://github.com/gitcoinco/web/issues/7421, which says:

> When you set the donation amount to zero, it naively tries to send a 0 DAI donation to Gitcoin, and the zkSync fee estimator seems to fail when you specify a zero value transfer. Source: https://twitter.com/YahsinHuang/status/1306238719104413697?s=20

### 5. Fix for batch zkSync checkouts using ETH

Fixes items 3 and 6 of https://github.com/gitcoinco/web/issues/7421, which are the same bug:

> Returned values aren't valid. Did it run out of gas?

The error was that in this situation we tried to check the ETH balance with `balanceOf`, which caused the error. 

### 6. Fix for final zkSync transfer

Fixes item 4 of https://github.com/gitcoinco/web/issues/7421, which says:

> When there is too little balance in the zkSync wallet to complete the final transfer back to the nominal wallet, the overflow bug happens so it's marked as incomplete. See image below.

### 7. Fix extra deposits not being included

This feature was broken in a previous PR, and now is resolved