### PR TITLE
Tweak validator comments

### DIFF
--- a/app/grants/models.py
+++ b/app/grants/models.py
@@ -1386,6 +1386,20 @@ class Contribution(SuperModel):
                         self.success = transaction['success']
                         break
 
+                if not is_correct_recipient or not is_correct_token or not is_correct_amount:
+                    # Transaction was not found, let's find out why
+                    if len(transactions) == 0:
+                        # No transfers were found for user
+                        self.validator_comment = f"{self.validator_comment}. No transactions found"
+                    else:
+                        # Could not find expected transfer, so try list specifics about why. We
+                        # Ascannot find exactly what went wrong because: We cycle through a list of
+                        # transactions. Some may have correct recipient and token but wrong amount.
+                        # Others may have correct token and amount but wrong recipient. In such a
+                        # case we cannot distinguish exactly what the cause was for not finding the
+                        # desired transasction.
+                        self.validator_comment = f"{self.validator_comment}. Transaction not found, unknown reason"
+
             if self.success:
                 print("TODO: do stuff related to successful contribs, like emails")
             else:

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -1476,8 +1476,6 @@ def zksync_set_interrupt_status(request):
 
     user_address = request.POST.get('user_address')
     deposit_tx_hash = request.POST.get('deposit_tx_hash')
-    print('deposit_tx_hash')
-    print(deposit_tx_hash)
 
     try:
         # Look for existing entry, and if present we overwrite it
@@ -1507,8 +1505,6 @@ def zksync_get_interrupt_status(request):
     try:
         result = JSONStore.objects.get(key=user_address, view='zksync_checkout')
         deposit_tx_hash = result.data
-        print('deposit_tx_hash')
-        print(deposit_tx_hash)
     except JSONStore.DoesNotExist:
         # If there's no entry for this user, assume they haven't been interrupted
         deposit_tx_hash = False


### PR DESCRIPTION
In 044f877931eca4cc70971ed533710c6546a1e13f @owocki changed one of the contribution fields to use 18 decimals. The previous value of 4 decimals was causing the tx validator to incorrectly report some txs as failed.

This PR builds on that to just tweak the validator comments so that when they do fail we can get a little bit more info as to why

cc @octavioamu @thelostone-mc 