### PR TITLE
Enable SMS Verification directly from Trust Bonus tab

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -445,6 +445,8 @@ Vue.component('grants-cart', {
   },
 
   methods: {
+    // TODO: SMS related methos and state should be removed and refactored into the component that
+    // should be shared between the cart and the Trust Bonus tab
     dismissVerification() {
       localStorage.setItem('dismiss-sms-validation', true);
       this.showValidation = false;

--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -139,3 +139,231 @@ let show_brightid_verify_modal = function(brightid_uuid) {
   $(content).appendTo('body');
   $('#verify_brightid_modal').bootstrapModal('show');
 };
+
+Vue.component('sms-verify-modal', {
+  delimiters: [ '[[', ']]' ],
+  data: function() {
+    return {
+      csrf: $("input[name='csrfmiddlewaretoken']").val(),
+      validationStep: 'intro',
+      showValidation: false,
+      phone: '',
+      validNumber: false,
+      errorMessage: '',
+      verified: document.verified,
+      code: '',
+      timePassed: 0,
+      timeInterval: 0,
+      display_email_option: false,
+      countDownActive: false
+    };
+  },
+  mounted: function() {
+    $(document).on('click', '#verify-sms-link', function(event) {
+      event.preventDefault();
+      this.showValidation = true;
+    }.bind(this));
+  },
+  template: `<b-modal id="sms-modal" @hide="dismissVerification()" :visible="showValidation" center hide-header hide-footer>
+              <template v-slot:default="{ hide }">
+                <div class="mx-5 mt-5 mb-4 text-center" v-if="validationStep == 'intro'">
+                  <div class="mb-3">
+                    <h1 class="font-bigger-4 font-weight-bold">Verify your phone number</h1>
+                  </div>
+                  <br />
+                  <p class="mb-4 font-subheader text-left">We'd like to verify your phone number to get your contribution matched. Phone number verification is optional.</p>
+                  <br />
+                  <p class="mb-4 font-subheader text-left">Verifying increases your trust level and impact of your contributions. You can still contribute to grants without
+                  verifying your phone number, but your contribution impact will be reduced.</p>
+                  <br />
+                  <p class="mb-4 font-subheader text-left">Gitcoin does NOT store your phone number.</p>
+                  <br />
+                  <p class="mb-4 font-subheader text-left">read more about <a target="_blank" rel="noopener noreferrer" class="gc-text-blue font-smaller-1"
+                    href="https://twitter.com/owocki/status/1271088915982675974">why we are asking for your phone number</a> or how Gitcoin <a target="_blank" rel="noopener noreferrer" class="gc-text-blue font-smaller-1"
+                      href="https://twitter.com/owocki/status/1271088915982675974">preserves your privacy.</a></p>
+                  <b-button @click="validationStep='requestVerification'" class="btn-gc-blue mb-2" size="lg">Verify
+                  Phone Number</b-button>
+                  <div class="mb-1 font-subheader text-center">
+                    <a id="verify_offline" href="#">
+                    <br />
+                    Verify Offline or</a>  <a href="#" @click="dismissVerification()" variant="link">Skip</a>
+                    <div id='verify_offline_target' style="display:none">
+                      <strong>Verify Offline</strong>
+                      <br />
+                      <a href="mailto:kyc@gitcoin.co">Email Gitcoin</a> or <a href="https://keybase.io/gitcoin_verify">Message Gitcoin on Keybase</a>, and we will verify your information within 1-2 business days.
+                      <br />
+                      IMPORTANT: Be sure to include (1) your gitcoin username (2) proof of ownership of a SMS number.
+                    </div>
+                  </div>
+                </div>
+                <div class="mx-5 my-5 text-center" v-if="validationStep == 'requestVerification'">
+                  <div class="mb-3">
+                    <h1 class="font-bigger-4 font-weight-bold">Verify your phone number</h1>
+                  </div>
+                  <p class="mb-5 font-subheader">We will send you a verification code.</p>
+                  <vue-tel-input ref="tel-input" :validCharactersOnly="true" @validate="isValidNumber" v-model="phone"
+                    :enabledCountryCode="true" :autofocus="true" :required="true" mode="international"
+                    inputClasses="form-control" placeholder="+1 8827378273"
+                    :inputOptions="{showDialCode: true}"
+                  ></vue-tel-input>
+                  <div v-if="timeInterval > timePassed">
+                    <span class="label-warning">Wait [[ timeInterval - timePassed ]] second before request another
+                      code</span>
+                  </div>
+                  <div v-if="errorMessage">
+                    <span class="label-warning">[[ errorMessage ]]</span>
+                  </div>
+                  <b-button @click="requestVerification()" class="btn-gc-blue mt-5 mb-2" size="lg">Send verification
+                    code</b-button>
+                  <br />
+                  <b-button @click="hide()" variant="link">Cancel</b-button>
+                </div>
+                <div class="mx-5 my-5 text-center" v-if="validationStep == 'verifyNumber'">
+                  <div class="mb-3">
+                    <h1 class="font-bigger-4 font-weight-bold">Verify your phone number</h1>
+                  </div>
+                  <p class="mb-5 font-subheader">Enter the verification code sent to your number.</p>
+
+                  <input class="form-control" type="number" required v-model="code">
+                  <div v-if="timeInterval > timePassed">
+                    <span class="label-warning">Wait [[ timeInterval - timePassed ]] second before request another
+                      code</span>
+                  </div>
+                  <div v-if="errorMessage">
+                    <span class="label-warning">[[ errorMessage ]]</span>
+                  </div>
+                  <b-button @click="validateCode()" class="btn-gc-blue mt-5" size="lg">Submit</b-button>
+                  <br />
+                  <b-button @click="startVerification()" variant="link">Change number</b-button>
+                  <b-button @click="resendCode()" variant="link">Resend Code</b-button>
+                    <b-button @click="resendCode('email')" variant="link" v-if="display_email_option">Send email</b-button>
+                </div>
+              </template>
+            </b-modal>`,
+  methods: {
+    dismissVerification() {
+      localStorage.setItem('dismiss-sms-validation', true);
+      this.showValidation = false;
+    },
+    // VALIDATE
+    validateCode() {
+      const vm = this;
+
+      if (vm.code) {
+        const verificationRequest = fetchData('/sms/validate/', 'POST', {
+          code: vm.code,
+          phone: vm.phone
+        }, {'X-CSRFToken': vm.csrf});
+
+        $.when(verificationRequest).then(response => {
+          vm.verificationEnabled = false;
+          vm.verified = true;
+          vm.validationStep = 'verifyNumber';
+          vm.showValidation = false;
+          _alert('You have been verified', 'success');
+        }).catch((e) => {
+          vm.errorMessage = e.responseJSON.msg;
+        });
+      }
+    },
+    startVerification() {
+      this.phone = '';
+      this.validationStep = 'requestVerification';
+      this.validNumber = false;
+      this.errorMessage = '';
+      this.code = '';
+      this.timePassed = 0;
+      this.timeInterval = 0;
+      this.display_email_option = false;
+    },
+    countdown() {
+      const vm = this;
+
+      if (!vm.countDownActive) {
+        vm.countDownActive = true;
+
+        setInterval(() => {
+          vm.timePassed += 1;
+        }, 1000);
+      }
+    },
+    resendCode(delivery_method) {
+      const e164 = this.phone.replace(/\s/g, '');
+      const vm = this;
+
+      vm.errorMessage = '';
+
+      if (vm.validNumber) {
+        const verificationRequest = fetchData('/sms/request', 'POST', {
+          phone: e164,
+          delivery_method: delivery_method || 'sms'
+        }, {'X-CSRFToken': vm.csrf});
+
+        vm.errorMessage = '';
+
+        $.when(verificationRequest).then(response => {
+          // set the cooldown time to one minute
+          this.timePassed = 0;
+          this.timeInterval = 60;
+          this.countdown();
+          this.display_email_option = response.allow_email;
+        }).catch((e) => {
+          vm.errorMessage = e.responseJSON.msg;
+        });
+      }
+    },
+    // REQUEST VERIFICATION
+    requestVerification(event) {
+      const e164 = this.phone.replace(/\s/g, '');
+      const vm = this;
+
+      if (vm.validNumber) {
+        const verificationRequest = fetchData('/sms/request', 'POST', {
+          phone: e164
+        }, {'X-CSRFToken': vm.csrf});
+
+        vm.errorMessage = '';
+
+        $.when(verificationRequest).then(response => {
+          vm.validationStep = 'verifyNumber';
+          this.timePassed = 0;
+          this.timeInterval = 60;
+          this.countdown();
+          this.display_email_option = response.allow_email;
+        }).catch((e) => {
+          vm.errorMessage = e.responseJSON.msg;
+        });
+      }
+    },
+    isValidNumber(validation) {
+      console.log(validation);
+      this.validNumber = validation.isValid;
+    }
+  }
+});
+
+$(document).ready(function() {
+  $(document).on('keyup', 'input[name=telephone]', function(e) {
+    var number = $(this).val();
+
+    if (number[0] != '+') {
+      number = '+' + number;
+      $(this).val(number);
+    }
+  });
+
+
+  $(document).on('click', '#verify_offline', function(e) {
+    $(this).remove();
+    $('#verify_offline_target').css('display', 'block');
+  });
+});
+
+if (document.getElementById('gc-sms-modal')) {
+
+  const app = new Vue({
+    delimiters: [ '[[', ']]' ],
+    el: '#gc-sms-modal',
+    data: { }
+  });
+}

--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -140,6 +140,9 @@ let show_brightid_verify_modal = function(brightid_uuid) {
   $('#verify_brightid_modal').bootstrapModal('show');
 };
 
+// TODO: This component consists primarily of code taken from the SMS verification flow in the cart.
+// This approach is not DRY, and after Grants Round 7 completes, the cart should be refactored to include
+// this as a shared component, rather than duplicating the code.
 Vue.component('sms-verify-modal', {
   delimiters: [ '[[', ']]' ],
   data: function() {

--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -260,7 +260,7 @@ Vue.component('sms-verify-modal', {
           vm.verified = true;
           vm.validationStep = 'verifyNumber';
           vm.showValidation = false;
-          _alert('You have been verified', 'success');
+          _alert('You have been verified. <a href="" style="color: white; text-decoration: underline;">Refresh Page</a>.', 'success');
         }).catch((e) => {
           vm.errorMessage = e.responseJSON.msg;
         });

--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -364,7 +364,7 @@ $(document).ready(function() {
 
 if (document.getElementById('gc-sms-modal')) {
 
-  const app = new Vue({
+  const smsVerificationApp = new Vue({
     delimiters: [ '[[', ']]' ],
     el: '#gc-sms-modal',
     data: { }

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -115,6 +115,7 @@
     <script src="{% static "v2/js/pages/profile.js" %}"></script>
     <script src="{% static "v2/js/pages/tribe_title.js" %}"></script>
     <script src="{% static "v2/js/pages/profile-edit.js" %}"></script>
+    <script src="{% static "v2/js/lib/vue-tel-input.min.js" %}"></script>
     <script src="{% static "v2/js/pages/profile-trust.js" %}"></script>
     <script src="{% static "v2/js/lib/qrcode.js" %}"></script>
     <script src="{% static "v2/js/rating.js" %}"></script>

--- a/app/dashboard/templates/profiles/tab_trust.html
+++ b/app/dashboard/templates/profiles/tab_trust.html
@@ -2,6 +2,9 @@
 
 {% if not profile.is_org and is_my_profile %}
   <div id="gc-trust-bonus-tab">
+    <div id="gc-sms-modal">
+      <sms-verify-modal></sms-verify-modald>
+    </div>
     <h3 class="py-3 font-weight-bold">Trust Bonus</h3>
     The higher the Trust
     Bonus of a user is, the more we can be confident that the user is real. Higher
@@ -40,7 +43,7 @@
           {% if is_sms_verified %}
             <span style="color:limegreen"><i class="fas fa-check"></i> Verified</span>
           {% else %}
-            <a href="/grants/cart?verify=true" role="button" class="button button--primary text-nowrap" target="_blank">Verify</a>
+            <a href="/grants/cart?verify=true" role="button" id="verify-sms-link" class="button button--primary text-nowrap" target="_blank">Verify</a>
           {% endif %}
         </div>
       </div>
@@ -156,6 +159,4 @@
   <script>
     const calendarData = JSON.parse(document.getElementById('calendarData').textContent);
   </script>
-  <script src="{% static "v2/js/lib/vue-tel-input.min.js" %}"></script>
-  <script src="{% static "v2/js/lib/bootstrap-vue.min.js" %}"></script>
 {% endif %}

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -448,8 +448,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
               </div>
 
             </div>
-
-            {% comment %} SMS Verification Modal {% endcomment %}
+            {% comment %}
+              SMS Verification Modal
+              TODO: Much of this code is repeated in the Trust Bonus tab, specifically as a standalone component in
+              profile-trust.js. After Grants Round 7, this should be refactored to use a shared component between the
+              cart and the Trust Bonus tab.
+            {% endcomment %}
             <b-modal id="sms-modal" @hide="dismissVerification()" :visible="showValidation" center hide-header hide-footer>
               <template v-slot:default="{ hide }">
                 <div class="mx-5 mt-5 mb-4 text-center" v-if="validationStep == 'intro'">

--- a/docs/RUNNING_LOCALLY_DOCKER.md
+++ b/docs/RUNNING_LOCALLY_DOCKER.md
@@ -337,7 +337,7 @@ Add `import ipdb;ipdb.set_trace()` to the method you want to inspect, you then r
 
 `Q: How can I access the Django shell, similar to: python manage.py shell ?`
 
-Simply run: `make get_django_shell` or `docker-compose exec web python app/manage.py shell`
+Simply run: `make get_django_shell` or `docker-compose exec web python3 app/manage.py shell`
 
 #### Access BASH
 


### PR DESCRIPTION
Instead of kicking users over to the cart to verify their SMS, they can now do it directly from the Trust Bonus tab.

<img width="1201" alt="Screen Shot 2020-09-17 at 2 55 31 PM" src="https://user-images.githubusercontent.com/1479802/93515124-19664f00-f8f6-11ea-8ee5-bd1e532c8a2b.png">

Note: This PR extracts and modifies code from the cart to create a vue component used on the Trust Bonus tab. The component is NOT currently shared with the cart, but should be, to DRY things up. This needed refactoring is noted in TODO comments, and should be tackled post Round 7.