### PR TITLE
Make computed properties reactive to document.web3network changes

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -329,11 +329,13 @@ Vue.component('grants-cart', {
 
     // Array of supported tokens
     zkSyncSupportedTokens() {
+      const mainnetTokens = [ 'ETH', 'DAI', 'USDC', 'USDT', 'LINK', 'WBTC', 'PAN', 'SNT' ];
+      
       if (!this.selectedNetwork)
-        return [];
+        return mainnetTokens;
       if (this.selectedNetwork === 'rinkeby')
         return [ 'ETH', 'USDT', 'LINK' ];
-      return [ 'ETH', 'DAI', 'USDC', 'USDT', 'LINK', 'WBTC', 'PAN' ];
+      return mainnetTokens;
     },
 
     // Estimated gas limit for zkSync checkout

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -69,6 +69,7 @@ Vue.component('grants-cart', {
       maxPossibleSignatures: 4, // for Flow A, start by assuming 4 -- two logins, set signing key, one transfer
       isZkSyncModalLoading: false, // modal requires async actions before loading, so show loading spinner to improve UX
       zkSyncWalletState: undefined, // state of user's nominal zkSync wallet
+      selectedNetwork: undefined, // use to force computed properties to update when document.web3network changes
       // SMS validation
       csrf: $("input[name='csrfmiddlewaretoken']").val(),
       validationStep: 'intro',
@@ -313,24 +314,24 @@ Vue.component('grants-cart', {
     zkSyncBlockExplorerUrl() {
       // Flow A, zkScan link
       if (this.hasSufficientZkSyncBalance) {
-        if (document.web3network === 'rinkeby')
-          return `https://${document.web3network}.zkscan.io/explorer/accounts/${this.userAddress}`;
+        if (this.selectedNetwork === 'rinkeby')
+          return `https://${this.selectedNetwork}.zkscan.io/explorer/accounts/${this.userAddress}`;
         return `https://zkscan.io/explorer/accounts/${this.userAddress}`;
       }
 
       // Flow B, etherscan link
       if (!this.zkSyncDepositTxHash)
         return undefined;
-      if (document.web3network === 'rinkeby')
-        return `https://${document.web3network}.etherscan.io/tx/${this.zkSyncDepositTxHash}`;
+      if (this.selectedNetwork === 'rinkeby')
+        return `https://${this.selectedNetwork}.etherscan.io/tx/${this.zkSyncDepositTxHash}`;
       return `https://etherscan.io/tx/${this.zkSyncDepositTxHash}`;
     },
 
     // Array of supported tokens
     zkSyncSupportedTokens() {
-      if (!document.web3network)
+      if (!this.selectedNetwork)
         return [];
-      if (document.web3network === 'rinkeby')
+      if (this.selectedNetwork === 'rinkeby')
         return [ 'ETH', 'USDT', 'LINK' ];
       return [ 'ETH', 'DAI', 'USDC', 'USDT', 'LINK', 'WBTC', 'PAN' ];
     },
@@ -2487,6 +2488,11 @@ Vue.component('grants-cart', {
     window.addEventListener('dataWalletReady', async(e) => {
       try {
         await needWalletConnection();
+
+        // Force re-render so computed properties are updated (some are dependent on
+        // document.web3network, and Vue cannot watch document.web3network for an update)
+        this.selectedNetwork = document.web3network;
+        
         // Setup zkSync and check balances
         this.userAddress = (await web3.eth.getAccounts())[0];
         await this.setupZkSync();


### PR DESCRIPTION
### Problem

The list of supported zkSync tokens is stored as a computed property called `zkSyncSupportedTokens`. It's dependent on `document.web3network`. Vue cannot react to changes in `document`, so when the network changed this was not updated.

This means if a user visits the cart, then connects their wallet, the network change would not be detected, and `zkSyncSupportedTokens` would return an empty list. As a result, they would not be able to checkout with zkSync.

### Solution

We fix this by adding a new property to the component. Vue can watch and react to changes in this new property, and we update this new property when the `dataWalletReady` event is detected. We also make the mainnet token list the default when nothing is detected

cc @octavioamu @thelostone-mc 