### PR TITLE
Bring to one order gas costs notations.

### DIFF
--- a/docs/GRANTS.md
+++ b/docs/GRANTS.md
@@ -64,7 +64,7 @@ you elected to deposit into zkSync) are transferred back to your regular zkSync 
 ### Transfer Fees
 
 zkSync transfer costs can be found in their [documentation](https://zksync.io/faq/tokens.html#fee-costs).
-Right now it costs about 2000 gas per transfer, compared to ~60k gas to transfer DAI on L1, and
+Right now it costs about 2k gas per transfer, compared to ~60k gas to transfer DAI on L1, and
 ~180k gas to deposit funds into zkSync. Once zkSync 1.1 is released, these transfer fees will be
 reduced to about 400 gas per transfer.
 


### PR DESCRIPTION
I changed 2000 -> 2k, to use the same notation on one sentence.
At first look, it could read as "2000k gas", since you use the notation of 'k' in the rest numbers.
