### PR TITLE
zkSync UX Improvements

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1261,10 +1261,20 @@ Vue.component('grants-cart', {
       const txHash = json.deposit_tx_hash;
 
       if (txHash.length === 66 && txHash.startsWith('0x')) {
-        // Valid transaction hash, return it
+        // Valid transaction hash. Check if tx failed
+        const receipt = await this.ethersProvider.getTransactionReceipt(txHash);
+
+        if (receipt.status === 0) {
+          // Transaction failed, user must start over so mark them as not interrupted
+          await this.setInterruptStatus(null, this.userAddress);
+          return false;
+        }
+
+        // Transaction was mined, user must complete checkout
         return txHash;
       }
-      // Otherwise, user was not interrupted
+
+      // User was not interrupted
       return false;
     },
 

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -769,7 +769,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                       </div>
                     </div>
                     {% comment %} Step 3 {% endcomment %}
-                    <div class="row align-items-center justify-content-between mb-4 text-left">
+                    <div class="row align-items-center justify-content-between mb-2 text-left">
                       <div class="col-8">
                         <div class="font-weight-bold">
                           Step 3
@@ -803,6 +803,25 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             Completed
                           </span>
                         </div>
+                      </div>
+                    </div>
+                    {% comment %} Fees {% endcomment %}
+                    <div v-if="!hasSufficientZkSyncBalance" class="row align-items-center justify-content-between mb-4 text-left font-smaller-2">
+                      {% comment %}
+                      If user has sufficient zkSync balance, fees are shown when signing the message.
+                      If user does not have sufficient zkSync balance, the fees are hidden so 
+                      in that case we display them here.
+                      {% endcomment %}
+                      <div class="col-12">
+                        Amount in cart: [[ donationsTotalString ]]
+                      </div>
+                      <div class="col-12">
+                        Estimated fees: [[ zkSyncFeesString ]]
+                      </div>
+                      <div class="col-12">
+                        <a href="https://github.com/gitcoinco/web/blob/master/docs/GRANTS.md" target="_blank">
+                          Read more about fees and the zkSync checkout process.
+                        </a>
                       </div>
                     </div>
                   </div>

--- a/docs/GRANTS.md
+++ b/docs/GRANTS.md
@@ -68,6 +68,18 @@ Right now it costs about 2000 gas per transfer, compared to ~60k gas to transfer
 ~180k gas to deposit funds into zkSync. Once zkSync 1.1 is released, these transfer fees will be
 reduced to about 400 gas per transfer.
 
+These transfers support what zkSync calls [gasless meta-transactions](https://zksync.io/faq/tokens.html#how-fees-are-payed),
+where all transaction fees are paid in the token being transferred. For example, if you want to
+transfer 5 DAI, there may be a fee of, say, 0.10 DAI, resulting in a total cost of 5.10 DAI.
+
+When checking out with Gitcoin grants, fees are additive. If you have 20 DAI in your cart, the
+total cost will be 20 DAI plus transaction fees. Transfers to new recipients in zkSync cost
+more than transfers to users who have previously used zkSync. Gitcoin takes a conservative approach
+and assumes all transfers are to new users to ensure you don't run out of fees when transferring
+funds. As a result, the "Estimated fees" shown are checkout may be much higher than
+the actual fees you will pay. Any leftover fees are transferred from your Gitcoin zkSync account
+back to your regular zkSync account.
+
 ## Round 6
 
 In round 6 we transitioned away from the [EIP 1337](https://1337alliance.org) contract and replaced


### PR DESCRIPTION
Resolves #7397, #7469

### Changes

1. To fix https://github.com/gitcoinco/web/issues/7397: When the cart loads we check the DB for a deposit tx hash from the user to see if their checkout was interrupted. If it was, we now have a check to see if the transaction failed. If it did fail, we mark the user as "not interrupted" so they can try checking out again

2. To fix https://github.com/gitcoinco/web/issues/7469: During zkSync checkout Flow B (user makes L1 deposit), the zkSync fees were not shown to the user anywhere, so we now show them at the bottom of the modal along with a link to the docs/GRANTS.md file to learn more about fees and how the checkout flow works. The modal is shown in the screenshot below. (Note that we don't need to show these fees in Flow A since the user signs a message containing the fee amount and that wallet should show that message to the user)

![image](https://user-images.githubusercontent.com/17163988/93799625-3fd90280-fbf4-11ea-83c9-92fe6e96cdc6.png)

cc @willsputra