### PR TITLE
supress debug toolbar in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ jobs:
       env:
         - PYTHONPATH="${TRAVIS_BUILD_DIR}/app/"
         - DJANGO_SETTINGS_MODULE="app.settings"
+        - SUPRESS_DEBUG_TOOLBAR=1
       deploy:
         provider: pages
         skip-cleanup: true


### PR DESCRIPTION
##### Description

Supress debug toolbar in travis configuration. Django debug_toolbar isn't required while running tests.

`/grants/categories/` and `/quests/new` return `Internal Server Error` which causes travis checks to fail

debug_toolbar produces this error `FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/build/gitcoinco/web/assets'`
