### PR TITLE
More zkSync UX updates

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -72,6 +72,7 @@ Vue.component('grants-cart', {
       selectedNetwork: undefined, // used to force computed properties to update when document.web3network changes
       zkSyncFeeTotals: {}, // used to dispaly a string showing the total zkSync fees when checking out with Flow B
       zkSyncFeesString: undefined, // string generated from the above property
+      isZkSyncDown: true, // true if zkSync is having issues with their servers
       // SMS validation
       csrf: $("input[name='csrfmiddlewaretoken']").val(),
       validationStep: 'intro',

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1732,17 +1732,18 @@ Vue.component('grants-cart', {
           // Get worst case fee amount
           this.zkSyncFeeTotals[tokenSymbol] = await this.getMaxFee(tokenSymbol);
           this.setZkSyncFeesString();
-
+          
+          // Note: Don't `break` out of the if statements if insufficient balance, because we
+          // also use this function to set the fee string shown to the user on the checkout modal
+          
           // Balance will be undefined if the user does not have that token, so we can break
           if (!balance) {
             this.hasSufficientZkSyncBalance = false;
-            break;
           }
 
           // Otherwise, we compare their balance against the required amount
           if (ethers.BigNumber.from(balance).lt(totalRequiredAmount)) {
             this.hasSufficientZkSyncBalance = false;
-            break;
           }
         }
       } catch (e) {

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -553,6 +553,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                 </button>
               </template>
               <template v-if="isZkSyncModalLoading" v-slot:default="{ hide }">
+                <div v-if="isZkSyncDown" class="p-2" style="background-color: #FFF6CF; width: 100%;">
+                  The zkSync servers are currently having some issues. If you are stuck on this
+                  loading screen, try refreshing the page. If that does not resolve the issue,
+                  you may want to proceed with Standard Checkout or try again later.
+                </div>
                 <div class="my-5 py-5">
                   <loading-screen></loading-screen>
                   <div class="text-center my-5">Loading...</div>


### PR DESCRIPTION
## Changes

1. `cart.js` now has an `isZkSyncDown` flag. This PR sets it to true. When true the modal looks like the screenshot below when loading. **We must remember to set this back to false when things are ok!**

2. Fixes a bug in https://github.com/gitcoinco/web/pull/7489 where the full fee string was not always displayed at checkout

![image](https://user-images.githubusercontent.com/17163988/94036636-5f4d6800-fd79-11ea-99fb-cfdb27632a5d.png)

@owocki 