### PR TITLE
(townsquare) fix/show only mainnet bounty activities in prod

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -187,6 +187,16 @@ class BountyQuerySet(models.QuerySet):
         return self.filter(idx_status__in=Bounty.FUNDED_STATUSES)
 
 
+class BountyManager(models.Manager):
+    """Enables changing the default queryset function for bounties."""
+
+    def get_queryset(self):
+        if settings.ENV == 'prod':
+            return super().get_queryset().filter(network='mainnet')
+        else:
+            return super().get_queryset()
+
+
 """Fields that bonties table should index together."""
 def get_bounty_index_together():
     import copy
@@ -393,8 +403,8 @@ class Bounty(SuperModel):
         default=False, help_text=_('This bounty will be part of the hypercharged bounties')
     )
     hyper_next_publication = models.DateTimeField(null=True, blank=True)
-    # Bounty QuerySet Manager
-    objects = BountyQuerySet.as_manager()
+    # Bounty Manager from QuerySet
+    objects = BountyManager.from_queryset(BountyQuerySet)()
 
     class Meta:
         """Define metadata associated with Bounty."""
@@ -2207,6 +2217,16 @@ class ActivityQuerySet(models.QuerySet):
         return posts
 
 
+class ActivityManager(models.Manager):
+    """Enables changing the default queryset function for Activities."""
+
+    def get_queryset(self):
+        if settings.ENV == 'prod':
+            return super().get_queryset().filter(Q(bounty=None) | Q(bounty='') | Q(bounty__network='mainnet'))
+        else:
+            return super().get_queryset()
+
+
 class Activity(SuperModel):
     """Represent Start work/Stop work event.
 
@@ -2356,7 +2376,7 @@ class Activity(SuperModel):
     cached_view_props = JSONField(default=dict, blank=True)
 
     # Activity QuerySet Manager
-    objects = ActivityQuerySet.as_manager()
+    objects = ActivityManager.from_queryset(ActivityQuerySet)()
 
     def __str__(self):
         """Define the string representation of an interested profile."""

--- a/app/townsquare/views.py
+++ b/app/townsquare/views.py
@@ -384,6 +384,8 @@ def town_square(request):
     tab = request.GET.get('tab', request.COOKIES.get('tab', 'connect'))
     try:
         pinned = PinnedPost.objects.get(what=tab)
+        if settings.ENV == 'prod' and pinned.activity.bounty and pinned.activity.bounty != 'mainnet':
+            pinned = None
     except PinnedPost.DoesNotExist:
         pinned = None
     title, desc, page_seo_text_insert, avatar_url, is_direct_link, admin_link = get_param_metadata(request, tab)


### PR DESCRIPTION
##### Description

Rinkeby bounty activity was being displayed in production

![image](https://user-images.githubusercontent.com/6025509/94853101-c676b680-0422-11eb-8a79-e5d5ecd43734.png)

This PR ensures only mainnet bounty activities are shown in production.

##### Testing

