### PR TITLE
fix(hackathon): replace flyout panel with chat window

### DIFF
--- a/app/dashboard/templates/dashboard/index-vue.html
+++ b/app/dashboard/templates/dashboard/index-vue.html
@@ -530,11 +530,10 @@
                                       <span class="font-body">Looking for a project</span>
                                   </div>
                                   <div class="text-center mt-2">
-                                    <b-button class="btn btn-sm btn-gc-blue font-caption font-weight-semibold button--full" @click="chatWindow(user.handle, $event);">
-                                      <i class="fas fa-comment-dots mr-2"></i> Chat
-                                    </b-button>
+                                    <button class="btn btn-sm btn-gc-blue font-caption font-weight-semibold button--full" data-openchat="{{user}}">
+                                      <i class="fas fa-comment-dots mr-2" data-placement="bottom" data-toggle="tooltip" data-html="true"></i> Chat
+                                    </button>
                                   </div>
-
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
##### Description

Use new window frame instead of flyout panel for chat in hackathon participants tab.

Here's a recording https://drive.google.com/file/d/1kKMIA_ciZUqPZI-CGJM9XDHqLWuY3Y56/view?usp=sharing

