### PR TITLE
Finish zkSync recovery page

### DIFF
--- a/app/grants/templates/grants/zksync-recovery.html
+++ b/app/grants/templates/grants/zksync-recovery.html
@@ -87,7 +87,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                 </div>
                 <div class="col-4">
                   <button v-if="zkSyncCheckoutStep1Status === 'not-started'"
-                    class="btn btn-gc-blue button--full shadow-none" @click="zkSyncLoginGitcoinFlow"
+                    class="btn btn-gc-blue button--full shadow-none" @click="zkSyncLoginGitcoinFlowRecovery"
                   >
                     Sign in
                   </button>
@@ -112,16 +112,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                     Step 2
                   </div>
                   <div>
-                    Claim your funds
+                    That's it! Hang tight while we do the rest
                   </div>
                 </div>
                 <div class="col-4">
-                  <button v-if="zkSyncCheckoutStep3Status === 'not-started'"
-                    class="btn btn-gc-blue button--full shadow-none" @click="returnZkSyncFunds"
-                  >
-                    Claim
-                  </button>
-                  <div v-else-if="zkSyncCheckoutStep3Status === 'pending'">
+                  <div v-if="zkSyncCheckoutStep3Status === 'pending'">
                     <span class="text-medium-dark-grey">
                       <i class="fas fa-spinner fa-spin"></i>
                       Processing
@@ -146,9 +141,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                     Due to bugs during the checkout process, occasionally zkSync contributions
                     did not make it to the grant receipients and instead were left in your 
                     <a href="https://github.com/gitcoinco/web/blob/master/docs/GRANTS.md" target="_blank">Gitcoin zkSync wallet</a>.
-                    We've covered the lost funds (maybe???????????) to make sure that
-                    grant receipients received those contributions, so you can use this tool
-                    to claim the remaining funds. Afterwards they will be accessible to you at
+                    Use this tool to send the stuck funds to the grant recipients, and any
+                    leftover funds will be accessible to you
                     <a href="https://wallet.zksync.io" target="_blank">https://wallet.zksync.io</a>.
                   </p>
               </div>

--- a/app/grants/urls.py
+++ b/app/grants/urls.py
@@ -25,7 +25,7 @@ from grants.views import (
     grant_new, grant_new_whitelabel, grants, grants_addr_as_json, grants_bulk_add, grants_by_grant_type,
     grants_cart_view, grants_clr, grants_stats_view, invoice, leaderboard, new_matching_partner, profile, quickstart,
     remove_grant_from_collection, save_collection, subscription_cancel, toggle_grant_favorite, verify_grant,
-    zksync_get_interrupt_status, zksync_set_interrupt_status, grants_zksync_recovery_view
+    zksync_get_interrupt_status, zksync_set_interrupt_status, grants_zksync_recovery_view, get_interrupted_contributions
 )
 
 app_name = 'grants'
@@ -68,6 +68,7 @@ urlpatterns = [
     path('cart/bulk-add/<str:grant_str>', grants_bulk_add, name='grants_bulk_add'),
     path('cart', grants_cart_view, name='cart'),
     path('zksync-recovery', grants_zksync_recovery_view, name='zksync_recovery'),
+    path('get-interrupted-contributions', get_interrupted_contributions, name='get_interrupted_contributions'),
     path('<slug:grant_type>', grants_by_grant_type, name='grants_by_category2'),
     path('<slug:grant_type>/', grants_by_grant_type, name='grants_by_category'),
     path('v1/api/clr', grants_clr, name='grants_clr'),

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -343,6 +343,24 @@ def clr_grants(request, round_num):
 
     return grants_by_grant_clr(request, clr_round)
 
+@login_required
+def get_interrupted_contributions(request):
+    all_contributions = Contribution.objects.filter(profile_for_clr=request.user.profile)
+    user_contributions = []
+
+    for contribution in all_contributions:
+        validator_comment = contribution.validator_comment
+        is_zksync = "zkSync" in validator_comment
+        tx_not_found = "Transaction not found, unknown reason" in validator_comment
+        deposit_no_transfer = "Found deposit but no transfer" in validator_comment
+        if is_zksync and (tx_not_found or deposit_no_transfer):
+            user_contributions.append(contribution.normalized_data)
+
+    return JsonResponse({
+        'success': True,
+        'contributions': user_contributions
+    })
+
 
 def get_grants(request):
     grants = []


### PR DESCRIPTION
## Steps to test

1. Checkout using zkSync + L1 transaction
2. Close the page immediately after confirming your deposit tx
3. Wait for it to be mined, then wait ~1-2 minutes for zkSync to recognize it (1 confirmation on Rinkeby, 10 on mainnet)
4. Run `docker-compose exec -e DJANGO_SETTINGS_MODULE="app.settings" web python3 app/manage.py update_tx_status`. The validator comment for your contributions should now have either `Transaction not found, unknown reason` OR `Found deposit but no transfer`. This depends on the status of your zkSync account. Either one is ok
5. Go to the `/grants/zksync-recovery` page
6. Read the copy, use the button to send the rest of your transactions
7. Page should redirect when complete and show a modal like the screenshot below (the `undefined` text is expected because we aren't using the user's actual cart data, but instead are pulling a fake, minimal cart from the database)
8. Run `docker-compose exec -e DJANGO_SETTINGS_MODULE="app.settings" web python3 app/manage.py update_tx_status`. The contributions should now be marked as successful

![image](https://user-images.githubusercontent.com/17163988/95224684-d2120680-07af-11eb-926b-084160884d80.png)
