### PR TITLE
Fix grant view/edit page

### DIFF
--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -123,6 +123,9 @@ $(document).ready(function() {
     }
 
     $('#edit-details').addClass('hidden');
+    $('.grant-read-widget').addClass('hidden');
+    $('.grant-write-widget').removeClass('hidden');
+    $('.grant-write-widget').css('height', 'auto');
     $('#save-details').removeClass('hidden');
     $('#cancel-details').removeClass('hidden');
     $('.grant__progress').addClass('hidden');
@@ -138,6 +141,9 @@ $(document).ready(function() {
   });
 
   $('#save-details').on('click', event => {
+    $('.grant-read-widget').removeClass('hidden');
+    $('.grant-write-widget').addClass('hidden');
+
     $('#edit-details').removeClass('hidden');
     $('#save-details').addClass('hidden');
     $('#cancel-details').addClass('hidden');

--- a/app/grants/templates/grants/detail/info.html
+++ b/app/grants/templates/grants/detail/info.html
@@ -64,7 +64,8 @@
     <div class="col-12 col-lg-7">
       <h1 class="font-title-xl my-4 font-weight-bold">
         {% if is_team_member %}
-          <textarea id="form--input__title" class="p-2 m-0 inline-edit font-body" maxlength="150" disabled>{{ grant.title }}</textarea>
+          <p class="py-auto grant-read-widget">{{ grant.title }} </p>
+          <textarea id="form--input__title" class="p-2 m-0 inline-edit font-body grant-write-widget hidden" maxlength="150" disabled>{{ grant.title }}</textarea>
         {% else %}
           {{ grant.title }}
         {% endif %}
@@ -87,7 +88,8 @@
           {% if is_team_member %}
             <div class="d-flex my-3">
               <i style="width: 14px;" class="fa fa-link mr-2 text-center my-auto"></i>
-              <textarea id="form--input__reference-url" class="p-2 m-0 inline-edit" disabled>{{ grant.reference_url }}</textarea>
+              <p class="grant-read-widget my-auto"> {{ grant.reference_url }} </p>
+              <textarea id="form--input__reference-url" class="p-2 m-0 inline-edit grant-write-widget hidden" disabled>{{ grant.reference_url }}</textarea>
             </div>
           {% else %}
             <i style="width: 14px;" class="fa fa-link mr-2 text-center"></i>
@@ -99,7 +101,8 @@
         {% if is_team_member %}
           <div class="d-flex my-3">
             <i style="width: 14px;" class="fab fa-twitter-square mr-2 text-center my-auto"></i>
-            <input id="form--twitter__account" placeholder="Twitter account" class="p-2 m-0 inline-edit font-body" maxlength="150" disabled value="{{ grant.twitter_handle_1 }}"></input>
+            <p class="my-auto grant-read-widget">{{grant.twitter_handle_1}}</p>
+            <input id="form--twitter__account" placeholder="Twitter account" class="p-2 m-0 inline-edit font-body grant-write-widget hidden" maxlength="150" disabled value="{{ grant.twitter_handle_1 }}"></input>
           </div>
         {% else %}
           <div class="font-body mb-2">


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
The grant page used to look a bit clumsy given that the display fonts don't fully reflect what content is being displayed, esp. for grant owner.
![image](https://user-images.githubusercontent.com/14205064/95856867-a57f6100-0d52-11eb-9ec0-d6f402e789d7.png)

<!-- Describe your changes here. -->
I fxed this by making grants display regular p tags by default and then switch them out for input fields when someone clicks to edit.
https://www.loom.com/share/65fd4bc275f940eeae4fdb99f4d8c7d7


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
