### PR TITLE
Update zksync to accomodate fee on setSigningKey

### DIFF
--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -906,7 +906,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
     {% comment %} ================================================================= {% endcomment %}
 
     <script type="text/javascript" src="https://cdn.ethers.io/lib/ethers-5.0.umd.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/zksync@0.7.4/dist/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/zksync@0.7.5/dist/main.js"></script>
     <script type="text/javascript">
     (async () => {
         // Loads and compiles wasm library


### PR DESCRIPTION
The first time an account uses zkSync, you must submit a signature to register your account. This has a mainnet gas cost, which zkSync used to subsidize. That is no longer the case, so we must account for that now. 

To test, complete a checkout using a new account that has never interacted with zkSync before