### PR TITLE
fix: properly display project info in activity

### DIFF
--- a/app/retail/templates/shared/activity.html
+++ b/app/retail/templates/shared/activity.html
@@ -75,11 +75,11 @@
             <br>
           {% endif %}
           {% if row.project %}
-            <a href="{% if row.project.name %}
-                      {% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slugify %}
-                    {% else %}
-                      {% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id  %}
-                    {% endif %}" class="tag"   data-toggle="tooltip" title="Go to {{ row.project.name }}">via {{ row.project.name }}</a>
+            {% if row.project.name %}
+              <a href="{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slugify %}" class="tag"   data-toggle="tooltip" title="Go to {{ row.project.name }}">via {{ row.project.name }}</a>
+            {% else %}
+              <a href="{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id %}" class="tag"   data-toggle="tooltip" title="Go to project {{ row.project.id }}">via project {{ row.project.id }}</a>
+            {% endif %}
           {% endif %}
 
           {% if row.hackathonevent %}


### PR DESCRIPTION
##### Description

distortion in html if there's no project name, app/retail/templates/shared/activity.html - line 82

```
title="Go to {{ row.project.name }}">via {{ row.project.name }}</a>
```
will be

```
via
```

instead, display `via project <project id>`

##### Refers/Fixes

#7773 
