### PR TITLE
extra quote on "you've stopped work" text

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -523,8 +523,8 @@ Vue.mixin({
         if (200 <= response.status && response.status <= 204) {
           this.fetchBounty();
           let text = isOwner ?
-            "'You\'ve stopped the user from working on this bounty ?" :
-            "'You\'ve stopped work on this bounty";
+            "You\'ve stopped the user from working on this bounty ?" :
+            "You\'ve stopped work on this bounty";
 
           _alert(text, 'success');
         } else {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

I'm pretty sure this was unintentionally done 

There is a quote <code> ' </code> at the begin of the text

![quote](https://user-images.githubusercontent.com/41552663/97813490-f520c080-1c5e-11eb-8e58-7c85c43d0540.png)


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
