### PR TITLE
feat(grants): allow update of github project url

### DIFF
--- a/app/assets/v2/css/grants/detail.css
+++ b/app/assets/v2/css/grants/detail.css
@@ -154,6 +154,7 @@ textarea.editable {
 #form--input__description,
 #form--input__reference-url,
 #form--twitter__account,
+#form--input__github-project-url,
 #form--input__title,
 #contract_owner_address {
   width: 100%;

--- a/app/assets/v2/js/grants/detail.js
+++ b/app/assets/v2/js/grants/detail.js
@@ -1,5 +1,6 @@
 const editableFields = [
   '#form--input__title',
+  '#form--input__github-project-url',
   '#form--twitter__account',
   '#form--input__reference-url',
   '#contract_owner_address',
@@ -139,6 +140,7 @@ $(document).ready(function() {
     $('#section-nav-description .ql-container').css('border-color', 'transparent');
 
     let edit_title = $('#form--input__title').val();
+    let edit_github_project_url = $('#form--input__github-project-url').val();
     let edit_reference_url = $('#form--input__reference-url').val();
     let twitter_account = $('#form--twitter__account').val().replace('@', '');
     let edit_grant_members = $('#grant-members').val();
@@ -146,6 +148,7 @@ $(document).ready(function() {
 
     let data = {
       'edit-title': edit_title,
+      'edit-github_project_url': edit_github_project_url,
       'edit-reference_url': edit_reference_url,
       'edit-twitter_account': twitter_account,
       'edit-grant_members[]': edit_grant_members,
@@ -217,12 +220,20 @@ const makeEditable = (input) => {
   $(input).addClass('editable');
   $(input).prop('readonly', false);
   $(input).prop('disabled', false);
+  if (input === '#form--input__github-project-url') {
+    $(input).attr('type', 'text');
+    $('#form--a__github-project-url').hide();
+  }
 };
 
 const disableEdit = (input) => {
   $(input).removeClass('editable');
   $(input).prop('readonly', true);
   $(input).prop('disabled', true);
+  if (input === '#form--input__github-project-url') {
+    $(input).attr('type', 'hidden');
+    $('#form--a__github-project-url').show();
+  }
 };
 
 const copyDuplicateDetails = () => {

--- a/app/grants/templates/grants/detail/info.html
+++ b/app/grants/templates/grants/detail/info.html
@@ -120,11 +120,12 @@
           </div>
         {% endif %}
         {% if grant.github_project_url %}
-        <div class="font-body mb-2">
-          <i style="width: 14px;" class="fab fa-github-square mr-2 text-center"></i>
+        <div class="d-flex my-3">
+          <i style="width: 14px;" class="fab fa-github-square mr-2 text-center my-auto"></i>
+          <input type="hidden" id="form--input__github-project-url" placeholder="Github Project URL" class="p-2 m-0 inline-edit font-body" maxlength="150" value="{{ grant.github_project_url }}"></input>
           <p class="d-inline-block mb-0">
-            <a href="{{ grant.github_project_url }}" target="_blank" rel="" data-toggle="tooltip" data-html="true" data-placement="top" for="github_project_url"
-            title="Project Github URL">
+            <a href="{{ grant.github_project_url }}" target="_blank" id="form--a__github-project-url" rel="" data-toggle="tooltip" data-html="true" data-placement="top" for="github_project_url"
+            title="Github Project URL">
               {{ grant.github_project_url }}
             </a>
           </p>

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -1269,6 +1269,7 @@ def grant_details(request, grant_id, grant_slug):
             record_grant_activity_helper('killed_grant', grant, profile)
         elif 'edit-title' in request.POST:
             grant.title = request.POST.get('edit-title')
+            grant.github_project_url = request.POST.get('edit-github_project_url')
             grant.reference_url = request.POST.get('edit-reference_url')
             team_members = request.POST.getlist('edit-grant_members[]')
             team_members.append(str(grant.admin_profile.id))

--- a/scripts/debug/run_perftools.py
+++ b/scripts/debug/run_perftools.py
@@ -1,2 +1,3 @@
 from perftools.management.commands.create_page_cache import create_results_cache
+
 create_results_cache()


### PR DESCRIPTION
##### Description

Users are not able to edit github repo URL of a grant after creation.

This PR makes the github repo URL editable when "Edit Info" is clicked

##### Fixes

#7788 

##### Testing

https://www.loom.com/share/dfb001c16bb44aac92bcf2914c71b672