### PR TITLE
Send a single email for all grant  items in cart

### DIFF
--- a/app/grants/sync/helpers.py
+++ b/app/grants/sync/helpers.py
@@ -59,7 +59,7 @@ def record_contribution_activity(contribution):
         # successful_contribution(grant, subscription, contribution)
         # update_grant_metadata.delay(grant.pk)
         new_supporter(grant, subscription)
-        thank_you_for_supporting(grant, subscription)
+        thank_you_for_supporting([grant.pk], subscription.contributor_profile)
 
     except Exception as e:
         logger.error(f"error in record_contribution_activity: {e} - {contribution}")

--- a/app/grants/tasks.py
+++ b/app/grants/tasks.py
@@ -186,9 +186,6 @@ def process_grant_contribution(self, grant_id, grant_slug, profile_id, package, 
 
         # emails to grant owner
         new_supporter(grant, subscription)
-        # emails to contributor
-        thank_you_for_supporting(grant, subscription)
-
         update_grant_metadata.delay(grant_id)
 
 @app.shared_task(bind=True, max_retries=1)

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -1841,7 +1841,7 @@ def bulk_fund(request):
             'text': _('Funding for this grant was successfully processed and saved.'),
             'success': True
         })
-        batch_grants_mail.append((grant_id, payload))
+        batch_grants_mail.append(grant_id)
 
     thank_you_for_supporting(batch_grants_mail, profile)
 

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -25,7 +25,6 @@ import logging
 import random
 import re
 import time
-from celery import chord
 from decimal import Decimal
 
 from django.conf import settings

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -29,6 +29,7 @@ from django.utils.translation import gettext_lazy as _
 
 import sendgrid
 from app.utils import get_profiles_from_text
+from grants.models import Subscription
 from marketing.utils import func_name, get_or_save_email_subscriber, should_suppress_notification_email
 from python_http_client.exceptions import HTTPError, UnauthorizedError
 from retail.emails import (
@@ -302,7 +303,7 @@ def new_supporter(grant, subscription):
 
 def thank_you_for_supporting(grants, contributor):
     subscriptions = []
-    for grant_id in grants:
+    for (grant_id, payload) in grants:
         subscription = Subscription.objects.filter(grant_id=grant_id, contributor_profile=contributor).first()
         if subscription and subscription.negative:
             continue

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -303,7 +303,7 @@ def new_supporter(grant, subscription):
 
 def thank_you_for_supporting(grants, contributor):
     subscriptions = []
-    for (grant_id, payload) in grants:
+    for grant_id in grants:
         subscription = Subscription.objects.filter(grant_id=grant_id, contributor_profile=contributor).first()
         if subscription and subscription.negative:
             continue

--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -300,18 +300,24 @@ def new_supporter(grant, subscription):
         translation.activate(cur_language)
 
 
-def thank_you_for_supporting(grant, subscription):
-    if subscription and subscription.negative:
-        return
+def thank_you_for_supporting(grants, contributor):
+    subscriptions = []
+    for grant_id in grants:
+        subscription = Subscription.objects.filter(grant_id=grant_id, contributor_profile=contributor).first()
+        if subscription and subscription.negative:
+            continue
+        subscriptions.append(subscription)
+
     from_email = settings.CONTACT_EMAIL
-    to_email = subscription.contributor_profile.email
+    to_email = contributor.email
     if not to_email:
         to_email = subscription.contributor_profile.user.email
+        to_email = contributor.user.email
     cur_language = translation.get_language()
 
     try:
         setup_lang(to_email)
-        html, text, subject = render_thank_you_for_supporting_email(grant, subscription)
+        html, text, subject = render_thank_you_for_supporting_email(subscriptions)
 
         if not should_suppress_notification_email(to_email, 'thank_you_for_supporting'):
             send_mail(from_email, to_email, subject, text, html, categories=['transactional', func_name()])

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -231,8 +231,8 @@ def support_cancellation(request):
 @staff_member_required
 def thank_you_for_supporting(request):
     grant = Grant.objects.first()
-    subscription = Subscription.objects.filter(grant__pk=grant.pk).first()
-    response_html, __, __ = render_thank_you_for_supporting_email(grant, subscription)
+    subscription = Subscription.objects.all()[:5]
+    response_html, __, __ = render_thank_you_for_supporting_email(subscription)
     return HttpResponse(response_html)
 
 

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -132,8 +132,8 @@ def render_new_supporter_email(grant, subscription):
     return response_html, response_txt, subject
 
 
-def render_thank_you_for_supporting_email(grant, subscription):
-    params = {'grant': grant, 'subscription': subscription}
+def render_thank_you_for_supporting_email(subscriptions):
+    params = {'subscriptions': subscriptions}
     response_html = premailer_transform(render_to_string("emails/grants/thank_you_for_supporting.html", params))
     response_txt = render_to_string("emails/grants/thank_you_for_supporting.txt", params)
     subject = _("Thank you for supporting Grants on Gitcoin!")

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.html
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.html
@@ -20,6 +20,10 @@
 {% block content %}
 
 <style>
+  #footer {
+    background-color: #15003E !important;
+  }
+
   hr {
     width: 80%;
     height: 2px;
@@ -46,6 +50,10 @@
     line-height: 1.5em;
   }
 
+  p {
+    margin-top: 0;
+  }
+
   .grant-info {
     padding-top: 30px;
     padding-bottom: 1%;
@@ -57,7 +65,7 @@
   }
 
   .grant-info-name {
-    font-size: 20px;
+    font-size: 18px;
     color: #0D0764;
   }
 
@@ -77,19 +85,22 @@
   }
 
   #grow-oss {
-    margin-top: 50px;
-    margin-bottom: 50px;
+    display: none !important;
   }
 
   #grant-logo {
     max-width: 25rem;
-    width: 100%;
+    width: 90px;
   }
 
   @media (min-width : 1386px) {
     .left-grant-header > img {
       transform: translateY(13.5%);
     }
+  }
+
+  .robot {
+    height: 150px;
   }
 
   @media screen and (min-width: 598px) {
@@ -112,42 +123,33 @@
     </h2>
   </div>
 </div>
-
 <hr>
 <br>
+{% for sub in subscriptions %}
 <div class="grant-info">
   <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img id="grant-logo" src="{% if grant.logo and grant.logo.url %}{{ grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
+    <img id="grant-logo" src="{% if sub.grant.logo and sub.grant.logo.url %}{{ sub.grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
   </a>
   <br>
-  <a class="grant-info-name" href="{% url 'grants:details' grant.id grant.slug %}">
-    {{ grant.title }}
+  <a class="grant-info-name" href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">
+    {{ sub.grant.title }}
   </a>
   <p class="grant-description">
-    {{ grant.description|truncatechars:300 }}
+    {{ sub.grant.description|truncatechars:300 }}
   </p>
   <p>
     {% trans "You have agreed to give" %}
   </p>
   <p>
-    <strong>{{ subscription.amount_per_period|floatformat:4|intcomma }} {{ subscription.token_symbol }} </strong>
-      {% if subscription.num_tx_approved > 1 %}
-        {% trans "every" %} {{ subscription.frequency }} {{ subscription.frequency_unit }}
+    <strong>{{ sub.amount_per_period|floatformat:4|intcomma }} {{ sub.token_symbol }} </strong>
+      {% if sub.num_tx_approved > 1 %}
+        {% trans "every" %} {{ sub.frequency }} {{ sub.frequency_unit }}
       {% endif %}
-    <strong> {{subscription.num_tx_approved|floatformat}} time{{ subscription.num_tx_approved|pluralize }}</strong>
-
-  </p>
-  <p>{% trans "You can see all the grants you support and your transaction history " %}
-      <a href="{% url 'grants:profile' %}">{% trans "here." %}</a>
+    <strong> {{sub.num_tx_approved|floatformat}} time{{ sub.num_tx_approved|pluralize }}</strong>
+    <a class="grant-button" href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">{% trans "View on Gitcoin.co" %}</a>
   </p>
 </div>
-
-<br>
-<a class="grant-button" href="{% url 'grants:details' grant.id grant.slug %}">{% trans "View Updates" %}</a>
 <br>
 <br>
-<p>{% trans "If you ever need to, you can cancel your support" %}
-  <a href="{% url 'grants:subscription_cancel' grant.id grant.slug subscription.id %}">{% trans "here." %}</a>
-</p>
-<hr>
+{% endfor %}
 {% endblock %}

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.html
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.html
@@ -23,7 +23,6 @@
   #footer {
     background-color: #15003E !important;
   }
-
   hr {
     width: 80%;
     height: 2px;
@@ -80,7 +79,7 @@
     border-radius: 3px;
     font-size: 14px;
     text-decoration: none;
-    background-color: #0D0764;
+    background-color: #3E01FF;
     color: white;
   }
 
@@ -99,10 +98,6 @@
     }
   }
 
-  .robot {
-    height: 150px;
-  }
-
   @media screen and (min-width: 598px) {
     .right-grant-header {
       padding-left: 40px;
@@ -111,45 +106,41 @@
     }
   }
 
+  .robot {
+    height: 150px;
+  }
 </style>
 <div class="grant-header">
-  <div class="left-grant-header">
-    <img src="{% static "v2/images/heart-robot.png" %}" alt="{% trans "Gitcoin Heart Robot" %}" title="{% trans "Gitcoin Heart Robot" %}">
+
+  <div>
+    <h1 style="text-transform: none;">{% trans "Your Grant Contributions are Successful!" %}</h1>
   </div>
-  <div class="right-grant-header">
-    <h1 style="text-transform: none;">{% trans "Thank you for supporting" %} {{ grant.title }}!
-    </h1>
-    <h2 style="text-transform: none;">{% trans "The world of open source is a better place because of you." %}
-    </h2>
+  <div>
+    <img class="robot" src="{% static "v2/images/heart-robot.png" %}" alt="{% trans "Gitcoin Heart Robot" %}" title="{% trans "Gitcoin Heart Robot" %}">
   </div>
 </div>
-<hr>
 <br>
+<br>
+
 {% for sub in subscriptions %}
-<div class="grant-info">
-  <a href="{% url 'grants:details' grant.id grant.slug %}">
-    <img id="grant-logo" src="{% if sub.grant.logo and sub.grant.logo.url %}{{ sub.grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
-  </a>
-  <br>
-  <a class="grant-info-name" href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">
-    {{ sub.grant.title }}
-  </a>
-  <p class="grant-description">
-    {{ sub.grant.description|truncatechars:300 }}
-  </p>
-  <p>
-    {% trans "You have agreed to give" %}
-  </p>
-  <p>
-    <strong>{{ sub.amount_per_period|floatformat:4|intcomma }} {{ sub.token_symbol }} </strong>
-      {% if sub.num_tx_approved > 1 %}
+  <div class="grant-info">
+    <a href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">
+      <img id="grant-logo" src="{% if sub.grant.logo and sub.grant.logo.url %}{{ sub.grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=sub.grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}" />
+    </a>
+    <br>
+    <a class="grant-info-name font-weight-bold" href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">
+      {{ sub.grant.title }}
+    </a>
+    <p>
+      {{ sub.amount_per_period|floatformat:4|intcomma }} {{ sub.token_symbol }}
+      {% if subscription.num_tx_approved > 1 %}
         {% trans "every" %} {{ sub.frequency }} {{ sub.frequency_unit }}
       {% endif %}
-    <strong> {{sub.num_tx_approved|floatformat}} time{{ sub.num_tx_approved|pluralize }}</strong>
+    </p>
     <a class="grant-button" href="{% url 'grants:details' sub.grant.id sub.grant.slug %}">{% trans "View on Gitcoin.co" %}</a>
-  </p>
-</div>
-<br>
-<br>
+  </div>
+  <br>
+  <br>
 {% endfor %}
+
 {% endblock %}

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.txt
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.txt
@@ -2,6 +2,7 @@
 
 {% trans "Gitcoin Heart Robot" %}
 
+{% for grant, subscription in cart %}
 {% trans "Thank you for supporting" %} {{ grant.title }}
 
 {% trans "The world of open source is a better place because of you." %}
@@ -24,3 +25,4 @@
 {% trans "View Updates" %}
 
 {% trans "If you ever need to you can cancel your support" %} {% trans "here." %}
+{% endfor %}

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.txt
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.txt
@@ -3,11 +3,11 @@
 {% trans "Gitcoin Heart Robot" %}
 
 {% for subscription in subscriptions %}
-{% trans "Thank you for supporting" %} {{ subscriptions.grant.title }}
+{% trans "Thank you for supporting" %} {{ subscription.grant.title }}
 
 {% trans "The world of open source is a better place because of you." %}
 
-{{ grant.description }}
+{{ subscription.grant.description }}
 
 {% trans "You have agreed to give" %}
 

--- a/app/retail/templates/emails/grants/thank_you_for_supporting.txt
+++ b/app/retail/templates/emails/grants/thank_you_for_supporting.txt
@@ -2,8 +2,8 @@
 
 {% trans "Gitcoin Heart Robot" %}
 
-{% for grant, subscription in cart %}
-{% trans "Thank you for supporting" %} {{ grant.title }}
+{% for subscription in subscriptions %}
+{% trans "Thank you for supporting" %} {{ subscriptions.grant.title }}
 
 {% trans "The world of open source is a better place because of you." %}
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This allows it so that a single email is sent when a user funds a list of grants

Still working on improvements: 

- [x] Not sending an email containing the grant with negative contributions
- [x] Removing dead code
- [x] Performance in the double retrieval of the subscription obj from the database (not sure how to do this when only submitting grant_ids that have successfully completed the checkout task

##### Refers/Fixes

Closes #7755 

##### Testing

No tests currently, still investigating where to add since haven't seen any integrations with SendGrid. 


I also had trouble viewing the email (it won't show it up in my inbox including spam) on my end but I think it has to do with protonmail policy and my SendGrid accounts trust level so would appreciate if someone could test this branch with their creds and post the screenshot here. There definitely is some work to be done for the styling because right now it's reusing existing HTML. 

<img width="723" alt="Screen Shot 2020-11-17 at 5 58 21 PM" src="https://user-images.githubusercontent.com/7246942/99481299-cf1a4200-2927-11eb-8ada-31aa9135aaf1.png">

