### PR TITLE
fix(onboard): link hackathon chat to discord

### DIFF
--- a/app/dashboard/templates/dashboard/hackathon/onboard.html
+++ b/app/dashboard/templates/dashboard/hackathon/onboard.html
@@ -276,7 +276,7 @@
                 <b class="counter">{% trans " Join the Hackathons Chat Workspace" %}</b>
                 {% blocktrans %}
                   <p class="">
-                    Chat with other hackers, ask sponsors and the Gitcoin team questions, find or create a team, and communicate real-time. <a target="_blank" href="https://chat.gitcoin.co/hackathons">Click here to join the party!</a>.
+                    Chat with other hackers, ask sponsors and the Gitcoin team questions, find or create a team, and communicate real-time. <a target="_blank" href="https://discord.com/invite/83BK5z55yB">Click here to join the party!</a>.
                   </p>
                 {% endblocktrans %}
             </div>


### PR DESCRIPTION
##### Description

change hackathon chat link in onboarding from gitcoin chat to discord.

##### Refers/Fixes

close #7856

##### Testing

