### PR TITLE
Bump zksync version, prevent user from clicking standard checkout but…

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -55,6 +55,7 @@ Vue.component('grants-cart', {
       include_for_clr: true,
       windowWidth: window.innerWidth,
       userAddress: undefined,
+      isCheckoutOngoing: false, // true once user clicks "Standard checkout" button
       // Checkout, zkSync
       zkSyncUnsupportedTokens: [], // Used to inform user which tokens in their cart are not on zkSync
       zkSyncEstimatedGasCost: undefined, // Used to tell user which checkout method is cheaper
@@ -538,6 +539,7 @@ Vue.component('grants-cart', {
         message = err;
 
       _alert(message, 'error');
+      this.isCheckoutOngoing = false;
       indicateMetamaskPopup(true);
     },
 
@@ -764,6 +766,7 @@ Vue.component('grants-cart', {
     async standardCheckout() {
       try {
         // Setup -----------------------------------------------------------------------------------
+        this.isCheckoutOngoing = true;
         const userAddress = await this.initializeStandardCheckout();
 
         // Token approvals and balance checks (just checks data, does not execute approavals)

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -491,7 +491,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                                 {% comment %} End HTML Template for cart-ethereum-zksync.js {% endcomment %}
                                 </div>
                               <div class="col-auto">
-                                <button class="btn btn-outline-gc-blue shadow-none py-3 mt-1" id='js-fundGrants-button' @click="standardCheckout">
+                                <button class="btn btn-outline-gc-blue shadow-none py-3 mt-1" id='js-fundGrants-button' @click="standardCheckout" :disabled="isCheckoutOngoing">
                                   Standard Checkout
                                 </button>
                               </div>
@@ -749,7 +749,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
 
     {% comment %} ===================== START ZKSYNC SCRIPTS ====================== {% endcomment %}
     <script type="text/javascript" src="https://cdn.ethers.io/lib/ethers-5.0.umd.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/zksync-checkout@0.0.7/dist/main.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/zksync-checkout@0.0.8/dist/main.js"></script>
     {% comment %} ====================== END ZKSYNC SCRIPTS ======================= {% endcomment %}
 
     <script src="{% static "v2/js/lib/bootstrap-vue.min.js" %}"></script>


### PR DESCRIPTION
Changes:
- Adds a flag to disable the "Standard checkout" button after it's clicked. A few times in previous rounds users would click this twice if MetaMask loads slowly, then they'd have a failed transaction which causes confusion
- Bump zksync package to latest version
