### PR TITLE
Prevent past expiration date in redis for Idena validation ceremony time

### DIFF
--- a/app/dashboard/idena_utils.py
+++ b/app/dashboard/idena_utils.py
@@ -93,7 +93,10 @@ def next_validation_time():
         idena_validation_time = parse_datetime_from_iso(value)
 
         expiry = int(idena_validation_time.timestamp() - datetime.utcnow().timestamp()) # cache until next epoch
-        redis.set(key, value, expiry)
+
+        # during the validation window, the endpoint will return a date in the past
+        if expiry > 0:
+            redis.set(key, value, expiry)
     else:
         idena_validation_time = parse_datetime_from_iso(value)
 


### PR DESCRIPTION
During the Idena network's validation window itself, the endpoint used for the "next" validation window returns the one currently going on. This was causing a 500 because we were attempting to set an expiration date in the past for redis.

With this change, the Trust Bonus may show a window in the past until the network itself gives us an updated value.