### PR TITLE
Add zkSync popup message

### DIFF
--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -480,6 +480,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                                             <button @click="checkoutWithZksync" class="btn btn-gc-blue shadow-none">
                                             Proceed
                                             </button>
+                                            <div class="font-smaller-2 font-italic mt-2">
+                                              If the zkSync page does not open, your browser may have blocked it.
+                                              Please allow popups from https://gitcoin.co in your browser settings.
+                                            </div>
                                           </div>
                                         </div>
                                       </template>


### PR DESCRIPTION
Some browsers may block Gitcoin from opening other windows. This happened with Firefox, and the solution is for the user to update the browser settings to allow popups from Gitcoin. I added a message explaining this as shown below:

![image](https://user-images.githubusercontent.com/17163988/100795179-7d67c200-33d3-11eb-9327-5832e1408b4a.png)
