### PR TITLE
Always keep JSON store cart backup

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -959,13 +959,13 @@ Vue.component('grants-cart', {
       const res = await fetch(url, saveSubscriptionParams);
       const json = await res.json();
 
-      if (json.failures.length > 0) {
-        // Something went wrong, so we create a backup of the users cart
-        await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save');
-      }
+      // if (json.failures.length > 0) {
+      //   // Something went wrong, so we create a backup of the users cart
+      //   await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save');
+      // }
 
-      // Clear JSON Store
-      await this.manageEthereumCartJSONStore(userAddress, 'delete');
+      // // Clear JSON Store
+      // await this.manageEthereumCartJSONStore(userAddress, 'delete');
     },
 
     /**


### PR DESCRIPTION
Helps resolve https://github.com/gitcoinco/web/issues/7744

Last round there were contributions user's made that did not show up in the database and we weren't sure why. Previously I assumed this meant the POST request silently failed somehow. However, contributions/subscriptions are created from a celery task, so this assumption was wrong. As a result, there's no easy way for us to ensure contributions were created successfully when the POST request succeeds. 

Therefore I think we should always keep the JSON store that backs up a user's cart data. Previously we save this at the beginning, and delete it when the POST request succeeded. By always keeping it, we can, if needed, later write a script that pulls from the JSON store to ingest missing contributions/subscriptions without requesting any info from the user.