### PR TITLE
Trust Bonus Cleanup and Improvments

### DIFF
--- a/app/dashboard/idena_utils.py
+++ b/app/dashboard/idena_utils.py
@@ -93,7 +93,10 @@ def next_validation_time():
         idena_validation_time = parse_datetime_from_iso(value)
 
         expiry = int(idena_validation_time.timestamp() - datetime.utcnow().timestamp()) # cache until next epoch
-        redis.set(key, value, expiry)
+
+        # during the validation window, the endpoint will return a date in the past
+        if expiry > 0:
+            redis.set(key, value, expiry)
     else:
         idena_validation_time = parse_datetime_from_iso(value)
 

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -2963,8 +2963,10 @@ class Profile(SuperModel):
             tb *= 1.05
         if self.sms_verification:
             tb *= 1.05
-        if self.is_idena_verified:
-            tb *= 1.25
+        if self.is_google_verified:
+            tb *= 1.05
+        if self.is_poap_verified:
+            tb *= 1.05
         return tb
 
 

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -64,41 +64,6 @@
           </active-trust-row-template>
 
           <active-trust-row-template
-            icon-type="markup"
-            title="Verify with SMS"
-            :match-percent=5
-            :is-verified="'{{is_sms_verified}}' === 'True'"
-            button-text="Verify"
-            @verify-button-pressed="showModal('sms-modal')"
-            >
-            <template v-slot:icon>
-              <i class="fa fa-mobile-alt fa-3x" aria-hidden="true"></i>
-            </template>
-            <template v-slot:description>
-              Verify your phone number through SMS. To protect your privacy, Gitcoin doesn't store your phone number.
-              <a href="https://twitter.com/owocki/status/1272149204287160320">Learn more.</a>
-            </template>
-          </active-trust-row-template>
-
-          <active-trust-row-template
-            icon-type="markup"
-            title="Verify With Twitter"
-            :match-percent=5
-            :is-verified="'{{is_twitter_verified}}' === 'True'"
-            button-text="Verify"
-            @verify-button-pressed="showModal('twitter-modal')"
-            >
-            <template v-slot:icon>
-              <span style="color: #00aced">
-                <i class="fab fa-twitter fa-3x" aria-hidden="true"></i>
-              </span>
-            </template>
-            <template v-slot:description>
-              Verify your Twitter account.
-            </template>
-          </active-trust-row-template>
-
-          <active-trust-row-template
             icon-type="image"
             icon-path="/static/v2/images/project_logos/google.png"
             title="Verify With Google"
@@ -132,7 +97,43 @@
               Verify your POAP badges.
             </template>
           </active-trust-row-template>
+
+          <active-trust-row-template
+            icon-type="markup"
+            title="Verify with SMS"
+            :match-percent=5
+            :is-verified="'{{is_sms_verified}}' === 'True'"
+            button-text="Verify"
+            @verify-button-pressed="showModal('sms-modal')"
+            >
+            <template v-slot:icon>
+              <i class="fa fa-mobile-alt fa-3x" aria-hidden="true"></i>
+            </template>
+            <template v-slot:description>
+              Verify your phone number through SMS. To protect your privacy, Gitcoin doesn't store your phone number.
+              <a href="https://twitter.com/owocki/status/1272149204287160320">Learn more.</a>
+            </template>
+          </active-trust-row-template>
+
+          <active-trust-row-template
+            icon-type="markup"
+            title="Verify With Twitter"
+            :match-percent=5
+            :is-verified="'{{is_twitter_verified}}' === 'True'"
+            button-text="Verify"
+            @verify-button-pressed="showModal('twitter-modal')"
+            >
+            <template v-slot:icon>
+              <span style="color: #00aced">
+                <i class="fab fa-twitter fa-3x" aria-hidden="true"></i>
+              </span>
+            </template>
+            <template v-slot:description>
+              Verify your Twitter account.
+            </template>
+          </active-trust-row-template>
         </div>
+
         <div class="container mt-4">
           <h5>Active Beta</h5>
           <p>

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -41,41 +41,6 @@
 
           <active-trust-row-template
             icon-type="image"
-            :icon-path="'{{is_idena_connected}}' === 'True' ? 'https://robohash.org/{{ idena_address }}' : '/static/v2/images/project_logos/idena.svg'"
-            :title="'{{is_idena_connected}}' === 'True' ? 'Idena {{ idena_address }}' : 'Connect with Idena'"
-            :match-percent=25
-            :is-verified="'{{is_idena_verified}}' === 'True'"
-          >
-            <template v-slot:description>
-              {% if is_idena_connected %}
-                {% if not is_idena_verified %}
-                  Take part in the Idena validation ceremony {{ idena_next_validation }} GMT <br>
-                {% endif %}
-                  {% if is_idena_verified %}
-                    <span style="color:limegreen"><i class="fas fa-circle"></i>
-                  {% else %}
-                    <span style="color:gray"><i class="fas fa-circle"></i>
-                  {% endif %}
-                  &nbsp; Status: {{ idena_status }}.
-                  <a href={{ recheck_idena_status }} id="recheck-idena-status" class="text-nowrap">Re-Check.</a>
-                  <a href={{ logout_idena_url }} id="disconnect-idena-link" class="text-nowrap">Disconnect.</a>
-              {% else %}
-                  Install <a href="https://idena.io/?view=download" target="_blank">Idena app</a> to verify your account.
-              {% endif %}
-            </template>
-            <template v-slot:verify>
-              {% if is_idena_connected %}
-                  {% if not is_idena_verified %}
-                    <span style="color:orange"><i class="fal fa-exclamation-circle"></i> Pending Validation</span>
-                  {% endif %}
-              {% else %}
-                <a href="{{ login_idena_url }}" role="button" id="connect-idena-link" class="button button--primary text-nowrap">Connect</a>
-              {% endif %}
-            </template>
-          </active-trust-row-template>
-
-          <active-trust-row-template
-            icon-type="image"
             icon-path="/static/v2/images/project_logos/brightid.png"
             :title="'{{brightid_status}}' === 'not_connected' ? 'Connect with BrightID' : 'Verify with BrightID'"
             :match-percent=25
@@ -167,6 +132,49 @@
               Verify your POAP badges.
             </template>
           </active-trust-row-template>
+        </div>
+        <div class="container mt-4">
+          <h5>Active Beta</h5>
+          <p>
+            Verifying with these services doesn't provide a matching bonus yet, but will in future CLR rounds. Get verified now
+            so you don't miss out on more matching bonuses!
+          </p>
+
+          <active-trust-row-template
+            icon-type="image"
+            :icon-path="'{{is_idena_connected}}' === 'True' ? 'https://robohash.org/{{ idena_address }}' : '/static/v2/images/project_logos/idena.svg'"
+            :title="'{{is_idena_connected}}' === 'True' ? 'Idena {{ idena_address }}' : 'Connect with Idena'"
+            :match-percent=0
+            :is-verified="'{{is_idena_verified}}' === 'True'"
+          >
+            <template v-slot:description>
+              {% if is_idena_connected %}
+                {% if not is_idena_verified %}
+                  Take part in the Idena validation ceremony {{ idena_next_validation }} GMT <br>
+                {% endif %}
+                  {% if is_idena_verified %}
+                    <span style="color:limegreen"><i class="fas fa-circle"></i>
+                  {% else %}
+                    <span style="color:gray"><i class="fas fa-circle"></i>
+                  {% endif %}
+                  &nbsp; Status: {{ idena_status }}.
+                  <a href={{ recheck_idena_status }} id="recheck-idena-status" class="text-nowrap">Re-Check.</a>
+                  <a href={{ logout_idena_url }} id="disconnect-idena-link" class="text-nowrap">Disconnect.</a>
+              {% else %}
+                  Install <a href="https://idena.io/?view=download" target="_blank">Idena app</a> to verify your account.
+              {% endif %}
+            </template>
+            <template v-slot:verify>
+              {% if is_idena_connected %}
+                  {% if not is_idena_verified %}
+                    <span style="color:orange"><i class="fal fa-exclamation-circle"></i> Pending Validation</span>
+                  {% endif %}
+              {% else %}
+                <a href="{{ login_idena_url }}" role="button" id="connect-idena-link" class="button button--primary text-nowrap">Connect</a>
+              {% endif %}
+            </template>
+          </active-trust-row-template>
+
         </div>
       </div>
     </active-trust-manager>

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -97,7 +97,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
               <div v-if="!isFullyVerified" class="grant-row-style">
                 <div class="row align-items-center justify-content-between">
                   <div class="col col-12 col-md-8 col-lg-9">
-                    <strong>Get up to 70% greater CLR Match Amount by improving your Trust Bonus</strong> <br />
+                    <strong>Get up to 45% greater CLR Match Amount by improving your Trust Bonus</strong> <br />
                     <font size="2">
                       Increase your CLR Match Amount by verifying your profile with various services, and help Gitcoin be more sybil-resistant.
                       Do this anytime before the end of the grants round to earn the match retroactively for all your contributions.

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -2168,9 +2168,9 @@ def grants_cart_view(request):
 
         is_brightid_verified = ( 'verified' == get_brightid_status(profile.brightid_uuid) )
 
-        context['is_fully_verified'] = (is_brightid_verified and profile.is_idena_verified and \
-                                            profile.sms_verification and profile.is_poap_verified and \
-                                            profile.is_twitter_verified and profile.is_google_verified)
+        context['is_fully_verified'] = (is_brightid_verified and profile.sms_verification and \
+                                            profile.is_poap_verified and profile.is_twitter_verified and \
+                                            profile.is_google_verified)
     else:
         return redirect('/login/github?next=' + request.get_full_path())
 


### PR DESCRIPTION
* Ensure Idena service on Trust Bonus doesn't break during active validation rounds
* Moves Idena to a new section on the Trust Bonus page for "Active Beta" services
* Alphabetize services on the Trust Bonus tab that have the same Bonus amount
* Remove Idena from the Trust Bonus calculation
* Add Google & POAP to the Trust Bonus calculation