### PR TITLE
Copy tweaks

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -419,7 +419,7 @@ Vue.component('grants-cart', {
       window.location.href = `${window.location.origin}/login/github/?next=/grants/cart`;
     },
     confirmClearCart() {
-      if (confirm('are you sure')) {
+      if (confirm('Are you sure you want to clear your cart?')) {
         this.clearCart();
       }
     },

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -169,6 +169,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                               <img src="{% static 'v2/images/diamonds_high_fiving.gif' %}" alt="Diamonds high-fiving"
                               width="20">
                             </div>
+                            <div v-else-if="grant.is_on_team" class="clr-match-box font-caption font-weight-semibold d-flex flex-nowrap align-items-center">
+                              Cannot match own grant
+                            </div>
                             <div v-else class="clr-match-box font-caption font-weight-semibold d-flex flex-nowrap align-items-center">
                               Not Eligible for CLR
                             </div>


### PR DESCRIPTION
Changes:
- Change message from "Not eligible for CLR" to "Cannot match own grant" when a grant you are a team member of is in the cart
- Change copy when clearing cart from "are you sure" to "Are you sure you want to clear your cart?"

@ceresstation @vs77bb Open to suggestions on for the cart match amount copy. Trying to keep it short so it doesn't impact the UI. Also want to make it clear that you can fund your own grant if you want to, but it just won't get matched