### PR TITLE
prefetch profile data, grant type (foreign keys) for grants loading via get_grants

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -707,7 +707,7 @@ def build_grants_by_type(request, grant_type='', sort='weighted_shuffle', networ
     if category:
         _grants = _grants.filter(Q(categories__category__icontains=category))
 
-    _grants = _grants.prefetch_related('categories', 'team_members', 'admin_profile')
+    _grants = _grants.prefetch_related('categories', 'team_members', 'admin_profile', 'grant_type')
 
     return _grants
 

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -707,7 +707,7 @@ def build_grants_by_type(request, grant_type='', sort='weighted_shuffle', networ
     if category:
         _grants = _grants.filter(Q(categories__category__icontains=category))
 
-    _grants = _grants.prefetch_related('categories')
+    _grants = _grants.prefetch_related('categories', 'team_members', 'admin_profile')
 
     return _grants
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR improves the performance of the get_grants view by lowering the number of database calls used to get information regarding the grant admin and team_members via prefetching in the `build_grants_by_type` method.

![Screen Shot 2020-12-03 at 8 00 44 PM](https://user-images.githubusercontent.com/869266/101001884-0aad4100-35a3-11eb-8dea-9af68a16a974.png)


##### Refers/Fixes

n/a

##### Testing

tested locally