### PR TITLE
Update validator to check for out of gas condition

### DIFF
--- a/app/economy/tx.py
+++ b/app/economy/tx.py
@@ -268,14 +268,30 @@ def grants_transaction_validator(contribution, w3):
 
     try:
         # Get receipt and set originator to msg.sender for reasons described above
-        receipt = w3.eth.getTransactionReceipt(tx_hash)
+        receipt = w3.eth.getTransactionReceipt(tx_hash) # equivalent to eth_getTransactionReceipt
+        tx_info = w3.eth.getTransaction(tx_hash) # equivalent to eth_getTransactionByHash
         response['originator'] = [ receipt['from'] ]
 
         if receipt.status == 0:
-            # Transaction was mined but it failed
+            # Transaction was mined but it failed, try to find out why
+            gas_limit = tx_info['gas']
+            gas_used = receipt['gasUsed']
+            if gas_limit == gas_used:
+                response['tx_cleared'] = True
+                response['split_tx_confirmed'] = True
+                response['validation']['comment'] = 'Transaction failed. Out of gas'
+                return response
+
+            if gas_used > 0.99 * gas_limit:
+                # Some out of gas failures don't use all gas, e.g. https://etherscan.io/tx/0xac37f5bc0e9b75dd0f296b8569f72181a066458b9bee1bbed088ec2298fb4344
+                response['tx_cleared'] = True
+                response['split_tx_confirmed'] = True
+                response['validation']['comment'] = 'Transaction failed. Likely out of gas. Check Etherscan or Tenderly for more details'
+                return response
+
             response['tx_cleared'] = True
             response['split_tx_confirmed'] = True
-            response['validation']['comment'] = 'Transaction failed. See Etherscan for more details'
+            response['validation']['comment'] = 'Transaction failed. Unknown reason. See Etherscan or Tenderly for more details'
             return response
 
         # If here, transaction was successful. This code block should never execute because it means


### PR DESCRIPTION
Adds two checks to the validator:
1. If transaction failed, and `gasUsed = gasLimit`, set validator comment to indicate transaction ran out of gas
2. If transaction failed, and the gas used is with 1% of the gas limit, set validator comment to indicate that "out of gas" is the likely failure reason. Sample transaction where that happens [here](0xac37f5bc0e9b75dd0f296b8569f72181a066458b9bee1bbed088ec2298fb4344)

cc @owocki 