### PR TITLE
Bump zksync version

### DIFF
--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -757,7 +757,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
 
     {% comment %} ===================== START ZKSYNC SCRIPTS ====================== {% endcomment %}
     <script type="text/javascript" src="https://cdn.ethers.io/lib/ethers-5.0.umd.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/zksync-checkout@0.0.9/dist/main.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/zksync-checkout@0.0.10/dist/main.js"></script>
     {% comment %} ====================== END ZKSYNC SCRIPTS ======================= {% endcomment %}
 
     <script src="{% static "v2/js/lib/bootstrap-vue.min.js" %}"></script>


### PR DESCRIPTION
Only change is that zkSync checkout URL is updated from `https://checkout.zksync.dev` to `https://checkout.zksync.io`. The `*.dev` URL they use for testnets, and wanted to make it more clear that checkout is production code, not dev code