### PR TITLE
default gitcoin contrib 0 and hide

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -46,7 +46,7 @@ Vue.component('grants-cart', {
       adjustGitcoinFactor: false, // if true, show section for user to adjust Gitcoin's percentage
       tokenList: undefined, // array of all tokens for selected network
       isLoading: undefined,
-      gitcoinFactorRaw: 5, // By default, 5% of donation amount goes to Gitcoin
+      gitcoinFactorRaw: 0, // By default, 5% of donation amount goes to Gitcoin
       grantHeaders,
       grantData,
       comments: undefined,

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -276,7 +276,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                     </div> -->
 
                     {% comment %} Contribution to Gitcoin notice / adjustment {% endcomment %}
-                    <div class="flex-container text-left grant-header-row black">
+                    <div class="flex-container text-left grant-header-row black d-none"> 
                       <div style="width: 100%">
                         <div class="flex-container" style="justify-content: start">
                           <div id="gitcoin-grant-section" class="form__group-horizontal mt-2">
@@ -355,11 +355,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             <li>
                               You are contributing <span style="font-weight: bold">[[donationsToGrantsString]]</span>
                             </li>
-                            <li>
+                            <!-- <li>
                               You are additionally contributing
                               <span style="font-weight: bold">[[donationsToGitcoinString]]</span>
                               to the Gitcoin Maintainer Grant
-                            </li>
+                            </li> -->
                             <li>
                               Note: The exact checkout flow will depend on whether you use standard checkout or zkSync.
                               <a href="https://github.com/gitcoinco/web/blob/master/docs/GRANTS.md" target="_blank">


### PR DESCRIPTION
##### Description


- add d-none to hide UI
- defaults the number to 0

<img width="1665" alt="Screenshot 2020-12-10 at 8 54 13 PM" src="https://user-images.githubusercontent.com/5358146/101792033-3f347600-3b2a-11eb-95ab-74628929038e.png">
<img width="1667" alt="Screenshot 2020-12-10 at 8 54 57 PM" src="https://user-images.githubusercontent.com/5358146/101792046-43609380-3b2a-11eb-879b-0731373633a7.png">
