### PR TITLE
Limit zkSync checkout to 45 items in cart

### DIFF
--- a/app/assets/v2/js/cart-ethereum-zksync.js
+++ b/app/assets/v2/js/cart-ethereum-zksync.js
@@ -11,6 +11,7 @@ Vue.component('grantsCartEthereumZksync', {
   props: {
     currentTokens: { type: Array, required: true }, // Array of available tokens for the selected web3 network
     donationInputs: { type: Array, required: true }, // donationInputs computed property from cart.js
+    grantsByTenant: { type: Array, required: true }, // Array of grants in cart
     network: { type: String, required: true } // web3 network to use
   },
 
@@ -27,7 +28,8 @@ Vue.component('grantsCartEthereumZksync', {
 
       cart: {
         tokenList: [], // array of tokens in the cart
-        unsupportedTokens: [] // tokens in cart which are not supported by zkSync
+        unsupportedTokens: [], // tokens in cart which are not supported by zkSync
+        maxItems: 45 // zkSync only supports up to 50 transfers in a batch, so we limit it to 45 cart items to account for automatic tips
       },
 
       user: {
@@ -152,7 +154,8 @@ Vue.component('grantsCartEthereumZksync', {
       // Emit event so cart.js can update state accordingly to display info to user
       this.$emit('zksync-data-updated', {
         zkSyncUnsupportedTokens: this.cart.unsupportedTokens,
-        zkSyncEstimatedGasCost: estimatedGasCost
+        zkSyncEstimatedGasCost: estimatedGasCost,
+        zkSyncMaxCartItems: this.cart.maxItems
       });
     },
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -59,6 +59,7 @@ Vue.component('grants-cart', {
       // Checkout, zkSync
       zkSyncUnsupportedTokens: [], // Used to inform user which tokens in their cart are not on zkSync
       zkSyncEstimatedGasCost: undefined, // Used to tell user which checkout method is cheaper
+      zkSyncMaxCartItems: 45, // Max supported items by zkSync, defaults to 45 unless zkSync component says otherwise
       isZkSyncDown: false, // disable zkSync when true
       // verification
       isFullyVerified: false,
@@ -337,6 +338,7 @@ Vue.component('grants-cart', {
     onZkSyncUpdate: function(data) {
       this.zkSyncUnsupportedTokens = data.zkSyncUnsupportedTokens;
       this.zkSyncEstimatedGasCost = data.zkSyncEstimatedGasCost;
+      this.zkSyncMaxCartItems = data.zkSyncMaxCartItems;
     },
 
     tabChange: async function(input) {

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -392,7 +392,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                                 on gas costs with [[ checkoutRecommendation.name ]]
                               </div>
                             </div>
-                            <div class="row align-items-center justify-content-between">
+                            <div class="row align-items-center justify-content-start">
                               <div v-if="!isZkSyncDown" class="col-auto">
                                 {% comment %} HTML Template for cart-ethereum-zksync.js {% endcomment %}
                                 <grants-cart-ethereum-zksync
@@ -400,6 +400,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                                   @zksync-data-updated="onZkSyncUpdate"
                                   :current-tokens="currentTokens"
                                   :donation-inputs="donationInputs"
+                                  :grants-by-tenant="grantsByTenant"
                                   :network="network"
                                 >
                                   <div>
@@ -407,7 +408,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                                     <button
                                       @click="zksync.showModal = true"
                                       class="btn btn-gc-blue button--full shadow-none py-3 mt-1"
-                                      :disabled="cart.unsupportedTokens.length > 0"
+                                      :disabled="cart.unsupportedTokens.length > 0 || grantsByTenant.length > cart.maxItems"
                                       id='js-zkSyncfundGrants-button'
                                       v-b-tooltip.hover.top="'zkSync is a scaling solution for Ethereum. It enables extremely low cost transfers of ETH and ERC20 tokens but requires locking funds in layer 2 (cheaper option).'"
                                     >
@@ -512,6 +513,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>. {% endcomme
                             </div>
                             <p v-if="isZkSyncDown" class="font-smaller-1 mt-2">
                               zkSync is down at the moment, so if you'd like to checkout now you'll have to use standard checkout!
+                            </p>
+                            <p v-else-if="grantsByTenant.length > zkSyncMaxCartItems" class="font-smaller-1 mt-2">
+                              Must have a maximum of [[zkSyncMaxCartItems]] items in your cart to checkout with zkSync
                             </p>
                           </div>
                         </div>


### PR DESCRIPTION
Closes #8114 and #8143

To test:
1. Either add 45 items to your cart, OR change `maxItems` in `cart-ethereum-zksync.js` to a number like 2. The number set there is the max allowed
2. If you change it to 2, add 2 items to your cart and things should look normal. Add a third and the zkSync button should be disabled with a message

The actual zkSync limit is 50, but we use 45 cart items to leave room for automatic tip contributions which are added as separate transfers