### PR TITLE
Fix Subcategories count

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -746,10 +746,10 @@ def get_grant_types(network, filtered_grants=None):
     for grant_type in grant_types:
         _keyword = grant_type['keyword']
         grant_type['sub_categories'] = [{
-            'label': tuple[0],
-            'count': get_category_size(tuple[0]),
+            'label': _tuple[0],
+            'count': get_category_size(grant_type, _tuple[0]),
             # TODO: add in 'funding'
-            } for tuple in basic_grant_categories(_keyword)]
+            } for _tuple in basic_grant_categories(_keyword)]
 
     return grant_types
 
@@ -781,10 +781,11 @@ def get_grant_clr_types(clr_round, active_grants=None, network='mainnet'):
 
     for grant_type in grant_types: # TODO : Tweak to get only needed categories
         _keyword = grant_type['keyword']
+        print("hahha")
         grant_type['sub_categories'] = [{
-            'label': tuple[0],
-            'count': get_category_size(tuple[0]),
-            } for tuple in basic_grant_categories(_keyword)]
+            'label': _tuple[0],
+            'count': get_category_size(grant_type, _tuple[0]),
+            } for _tuple in basic_grant_categories(_keyword)]
 
     return grant_types
 
@@ -2268,8 +2269,8 @@ def grants_cart_view(request):
     return response
 
 
-def get_category_size(category):
-    key = f"grant_category_{category}"
+def get_category_size(grant_type, category):
+    key = f"grant_category_{grant_type.get('keyword')}_{category}"
     redis = RedisService().redis
     try:
         return int(redis.get(key))

--- a/app/perftools/management/commands/create_page_cache.py
+++ b/app/perftools/management/commands/create_page_cache.py
@@ -35,7 +35,7 @@ from avatar.models import AvatarTheme, CustomAvatar
 from dashboard.models import Activity, HackathonEvent, Profile
 from dashboard.utils import set_hackathon_event
 from economy.models import EncodeAnything, SuperModel
-from grants.models import Contribution, Grant, GrantCategory
+from grants.models import Contribution, Grant, GrantCategory, GrantType
 from grants.utils import generate_leaderboard
 from grants.views import next_round_start, round_types
 from marketing.models import Stat
@@ -127,11 +127,13 @@ def create_hack_event_cache():
 
 def create_grant_category_size_cache():
     print('create_grant_category_size_cache')
+    grant_types = GrantType.objects.all()
     redis = RedisService().redis
-    for category in GrantCategory.objects.all():
-        key = f"grant_category_{category.category}"
-        val = Grant.objects.filter(categories__category__contains=category.category).count()
-        redis.set(key, val)
+    for g_type in grant_types:
+        for category in GrantCategory.objects.all():
+            key = f"grant_category_{g_type.name}_{category.category}"
+            val = Grant.objects.filter(grant_type=g_type, categories__category__contains=category.category).count()
+            redis.set(key, val)
 
 def create_top_grant_spenders_cache():
     for round_type in round_types:


### PR DESCRIPTION

##### Description
When you toggle the dropdown for ZCash grants (or any grant category), the counts on the subcategories are showing total count for that subcategory not just the count of Zcash grant in that subcategory, The solution was to fix the query that inerts the count to Redis and JSONStore.

##### Refers/Fixes
closes #7795 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
