### PR TITLE
Add NY geofence for pTokens

### DIFF
--- a/app/app/context.py
+++ b/app/app/context.py
@@ -115,6 +115,15 @@ def preprocess(request):
 
         ptoken = PersonalToken.objects.filter(token_owner_profile=profile).first()
 
+    # Check if user's location supports pTokens
+    try:
+        current_location = profile.locations[-1]
+        is_location_blocked_for_ptokens = current_location['country_code'] == settings.PTOKEN_BLOCKED_REGION['country_code'] \
+            and current_location['region'] == settings.PTOKEN_BLOCKED_REGION['region']
+    except:
+        # If user is not logged in
+        is_location_blocked_for_ptokens = False
+
     # handles marketing callbacks
     if request.GET.get('cb'):
         callback = request.GET.get('cb')
@@ -181,6 +190,7 @@ def preprocess(request):
         'ptoken_factory_abi': settings.PTOKEN_FACTORY_ABI,
         'ptoken_address': ptoken.token_address if ptoken else '',
         'ptoken_id': ptoken.id if ptoken else None,
+        'is_location_blocked_for_ptokens': is_location_blocked_for_ptokens,
         'match_payouts_abi': settings.MATCH_PAYOUTS_ABI,
         'match_payouts_address': settings.MATCH_PAYOUTS_ADDRESS,
     }

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -843,6 +843,7 @@ TIP_PAYOUT_PRIVATE_KEY = env('TIP_PAYOUT_PRIVATE_KEY', default='0x00De4B13153673
 
 
 ELASTIC_SEARCH_URL = env('ELASTIC_SEARCH_URL', default='')
+PTOKEN_BLOCKED_REGION = { 'country_code': 'US', 'region': 'NY' }
 PTOKEN_ABI_PATH = env('PTOKEN_ABI_PATH', default='assets/v2/js/ptokens/ptoken-abi.json')
 PTOKEN_FACTORY_ABI_PATH = env('PTOKEN_FACTORY_ABI_PATH', default='assets/v2/js/ptokens/factory-abi.json')
 PTOKEN_FACTORY_ADDRESS = env('PTOKEN_FACTORY_ADDRESS', default='0x75589C2e56095c80f63EC773509f033aC595c34e')

--- a/app/dashboard/templates/board/ptokens.html
+++ b/app/dashboard/templates/board/ptokens.html
@@ -18,278 +18,292 @@
 {% load i18n static add_url_schema avatar_tags %}
 
 <div class="tab-pane fade " id="nav-ptokens" role="tabpanel" aria-labelledby="nav-ptokens-tab">
-  <header class="container position-relative">
-    <div class="row mb-2">
-      <div class="col-12">
-        <div class="bg-white rounded d-flex p-3 font-smaller-3">
-
-          <div class="my-3 mx-4 head-number">
-            <span class="head-number_title">OPEN</span>
-            <span class="head-number_value">[[ pTokens.request ? pTokens.request.length : '0' ]]</span>
-          </div>
-          <div class="my-3 mx-4 head-number">
-            <span class="head-number_title">IN PROGRESS</span>
-            <span class="head-number_value">[[ pTokens.accepted ? pTokens.accepted.length : '0' ]]</span>
-          </div>
-          <div class="my-3 mx-4 head-number">
-            <span class="head-number_title">COMPLETED</span>
-            <span class="head-number_value">[[ pTokens.completed ? pTokens.completed.length : '0' ]]</span>
-          </div>
-          <div class="my-3 mx-4 head-number">
-            <span class="head-number_title">DENIED</span>
-            <span class="head-number_value">[[ pTokens.denied ? pTokens.denied.length : '0' ]]</span>
+  {% if is_location_blocked_for_ptokens %}
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="text-center" style="margin: 7rem auto;">
+              Sorry, this functionality is not available for New York users!
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </header>
+    </section>
+  {% else %}
+    <header class="container position-relative">
+      <div class="row mb-2">
+        <div class="col-12">
+          <div class="bg-white rounded d-flex p-3 font-smaller-3">
 
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="d-flex justify-content-between align-items-center p-4 border-bottom">
-            <template v-if="!user_has_token">
-              <div>
-                Create a personal token to get paid today for work tomorrow <a href="{% url 'ptoken_quickstart' %}" class="underline">Learn more</a>
-              </div>
-              <div id="showCreationSuccessModal" hidden data-toggle="modal" data-target="#createTokenSuccessModal"></div>
-              <button class="btn btn-sm btn-outline-gc-blue m-2" data-toggle="modal" data-target="#createTokenModal">
-                Create
-              </button>
-            </template>
-            <template v-else-if="pToken.tx_status === 'pending'">
-              <div>Please wait for your transaction to be confirmed</div>
-              <button class="btn btn-sm  m-2" type="button" disabled>
-                <span class="spinner-border btn-gc-green spinner-border-sm" role="status" aria-hidden="true"></span>
-                  Mining...
-              </button>
-            </template>
-            <template v-else-if="pToken.tx_status === 'success'">
-              <div>Modify your Personal Token</div>
-              <button class="btn btn-sm btn-outline-gc-blue m-2" data-toggle="modal" data-target="#editpTokenModal">
-                Edit
-              </button>
-            </template>
-            <template v-else>
-              <div>An error occurred trying to create your pToken</div>
-              <button class="btn btn-sm btn-gc-outline-red m-2" data-toggle="modal" data-target="#createTokenModal">
-                Please try again or contact support@gitcoin.co
-              </button>
-            </template>
-
+            <div class="my-3 mx-4 head-number">
+              <span class="head-number_title">OPEN</span>
+              <span class="head-number_value">[[ pTokens.request ? pTokens.request.length : '0' ]]</span>
+            </div>
+            <div class="my-3 mx-4 head-number">
+              <span class="head-number_title">IN PROGRESS</span>
+              <span class="head-number_value">[[ pTokens.accepted ? pTokens.accepted.length : '0' ]]</span>
+            </div>
+            <div class="my-3 mx-4 head-number">
+              <span class="head-number_title">COMPLETED</span>
+              <span class="head-number_value">[[ pTokens.completed ? pTokens.completed.length : '0' ]]</span>
+            </div>
+            <div class="my-3 mx-4 head-number">
+              <span class="head-number_title">DENIED</span>
+              <span class="head-number_value">[[ pTokens.denied ? pTokens.denied.length : '0' ]]</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </header>
 
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.request">[[ pTokens.request.length ]] Open</div>
-
-          <ul class="list-unstyled list-bounty">
-            <li v-for="(token, key) in pTokens.request" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
-              <span class="fa-stack mr-2">
-                <i class="fas fa-circle fa-stack-2x green"></i>
-                <i class="fas fa-user fa-stack-1x fa-inverse"></i>
-              </span>
-              <span v-if="token.requester == current_user">You are redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
-              <span v-else>@[[ token.requester ]] is requesting to redeem <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from you.</span>
-              <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
-                <div class="list-bounty-item_content my-auto">
-                  <div class="d-flex flex-column flex-md-row">
-                    <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
-                    <div class="d-flex flex-column w-100 ml-md-3">
-                      <a href="{% url 'dashboard' %}?tab=ptoken" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
-                      <div class="d-flex flex-column flex-md-row justify-content-between font-smaller-4 col-md-3 px-0">
-                        <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="d-flex justify-content-between align-items-center p-4 border-bottom">
+              <template v-if="!user_has_token">
                 <div>
-                  <button @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionAcceptModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" v-if="token.requester != current_user">Accept</button>
-                  <button v-if="token.requester == current_user" @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCancelModal" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Cancel</button>
-                  <button v-else @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionDenyModal" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Deny</button>
+                  Create a personal token to get paid today for work tomorrow <a href="{% url 'ptoken_quickstart' %}" class="underline">Learn more</a>
                 </div>
-              </div>
-            </li>
-            <li class="text-center my-5" :class="{'d-none': false}" v-if="!pTokens.request || pTokens.request.length == 0" v-cloak>
-              <img src="{% static 'v2/images/ptoken.png' %}" alt="" width="169" height="169">
-              <h4 class="h5 font-weight-semibold my-3">
-                  [[ error.open || 'You don’t have any open requests' ]]
-              </h4>
-              <p class="text-black-70">Have any questions? Chat with us on <a href="{% url 'slack' %}">Slack</a>!</p>
-              <a href="{% url 'users_directory' %}?ptokens=true" title="Browse tokens" class="btn btn-gc-blue">Browse tokens</a>
-            </li>
-          </ul>
-          <loading-screen v-if="isLoading.request"></loading-screen>
+                <div id="showCreationSuccessModal" hidden data-toggle="modal" data-target="#createTokenSuccessModal"></div>
+                <button class="btn btn-sm btn-outline-gc-blue m-2" data-toggle="modal" data-target="#createTokenModal">
+                  Create
+                </button>
+              </template>
+              <template v-else-if="pToken.tx_status === 'pending'">
+                <div>Please wait for your transaction to be confirmed</div>
+                <button class="btn btn-sm  m-2" type="button" disabled>
+                  <span class="spinner-border btn-gc-green spinner-border-sm" role="status" aria-hidden="true"></span>
+                    Mining...
+                </button>
+              </template>
+              <template v-else-if="pToken.tx_status === 'success'">
+                <div>Modify your Personal Token</div>
+                <button class="btn btn-sm btn-outline-gc-blue m-2" data-toggle="modal" data-target="#editpTokenModal">
+                  Edit
+                </button>
+              </template>
+              <template v-else>
+                <div>An error occurred trying to create your pToken</div>
+                <button class="btn btn-sm btn-gc-outline-red m-2" data-toggle="modal" data-target="#createTokenModal">
+                  Please try again or contact support@gitcoin.co
+                </button>
+              </template>
+
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="p-4 border-bottom font-weight-bold">[[ pTokens.in_progress ? pTokens.in_progress.length : '' ]] In Progress</div>
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.request">[[ pTokens.request.length ]] Open</div>
 
-          <ul class="list-unstyled list-bounty">
-            <li v-for="(token, key) in pTokens.accepted" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
-              <span class="fa-stack mr-2">
-                <i class="fas fa-circle fa-stack-2x green"></i>
-                <i class="fas fa-user fa-stack-1x fa-inverse"></i>
-              </span>
-              <span v-if="token.requester == current_user">You are redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
-              <span v-else>@[[token.requester]] is redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from You</span>
-              <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
-                <div class="list-bounty-item_content my-auto">
-                  <div class="d-flex flex-column flex-md-row">
-                    <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
-                    <div class="d-flex flex-column w-100 ml-md-3">
-                      <a href="{% url 'dashboard' %}?tab=ptoken" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
-                      <div class="d-flex flex-column flex-md-row justify-content-between font-smaller-2 col-md-3 px-0">
-                        <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+            <ul class="list-unstyled list-bounty">
+              <li v-for="(token, key) in pTokens.request" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
+                <span class="fa-stack mr-2">
+                  <i class="fas fa-circle fa-stack-2x green"></i>
+                  <i class="fas fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <span v-if="token.requester == current_user">You are redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
+                <span v-else>@[[ token.requester ]] is requesting to redeem <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from you.</span>
+                <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
+                  <div class="list-bounty-item_content my-auto">
+                    <div class="d-flex flex-column flex-md-row">
+                      <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
+                      <div class="d-flex flex-column w-100 ml-md-3">
+                        <a href="{% url 'dashboard' %}?tab=ptoken" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
+                        <div class="d-flex flex-column flex-md-row justify-content-between font-smaller-4 col-md-3 px-0">
+                          <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <button @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionAcceptModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" v-if="token.requester != current_user">Accept</button>
+                    <button v-if="token.requester == current_user" @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCancelModal" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Cancel</button>
+                    <button v-else @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionDenyModal" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Deny</button>
+                  </div>
+                </div>
+              </li>
+              <li class="text-center my-5" :class="{'d-none': false}" v-if="!pTokens.request || pTokens.request.length == 0" v-cloak>
+                <img src="{% static 'v2/images/ptoken.png' %}" alt="" width="169" height="169">
+                <h4 class="h5 font-weight-semibold my-3">
+                    [[ error.open || 'You don’t have any open requests' ]]
+                </h4>
+                <p class="text-black-70">Have any questions? Chat with us on <a href="{% url 'slack' %}">Slack</a>!</p>
+                <a href="{% url 'users_directory' %}?ptokens=true" title="Browse tokens" class="btn btn-gc-blue">Browse tokens</a>
+              </li>
+            </ul>
+            <loading-screen v-if="isLoading.request"></loading-screen>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="p-4 border-bottom font-weight-bold">[[ pTokens.in_progress ? pTokens.in_progress.length : '' ]] In Progress</div>
+
+            <ul class="list-unstyled list-bounty">
+              <li v-for="(token, key) in pTokens.accepted" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
+                <span class="fa-stack mr-2">
+                  <i class="fas fa-circle fa-stack-2x green"></i>
+                  <i class="fas fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <span v-if="token.requester == current_user">You are redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
+                <span v-else>@[[token.requester]] is redeeming <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from You</span>
+                <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
+                  <div class="list-bounty-item_content my-auto">
+                    <div class="d-flex flex-column flex-md-row">
+                      <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
+                      <div class="d-flex flex-column w-100 ml-md-3">
+                        <a href="{% url 'dashboard' %}?tab=ptoken" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
+                        <div class="d-flex flex-column flex-md-row justify-content-between font-smaller-2 col-md-3 px-0">
+                          <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <button @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCompleteModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" >Complete</button>
+                    <button @click="cancel(token.id)" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Cancel</button>
+                  </div>
+                </div>
+              </li>
+              <li class="text-center my-5" :class="{'d-none': isLoading.accepted || pTokens.accepted && pTokens.accepted.length > 0}" v-cloak>
+                <p>[[ error.in_progress || 'You don’t have any requests in progress' ]]</p>
+              </li>
+            </ul>
+            <loading-screen v-if="isLoading.in_progress"></loading-screen>
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="p-4 border-bottom font-weight-bold"  v-if="pTokens.completed">[[ pTokens.completed ? pTokens.completed.length : '0' ]] Completed</div>
+
+            <ul class="list-unstyled list-bounty">
+              <li v-for="(token, key) in pTokens.completed" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
+                <span class="fa-stack mr-2">
+                  <i class="fas fa-circle fa-stack-2x light-blue"></i>
+                  <i class="fas fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <span v-if="token.requester == current_user">You redeemed <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
+                <span v-else>You completed a redemption for <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from @[[ token.requester ]].</span>
+                <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
+                  <div class="list-bounty-item_content my-auto">
+                    <div class="d-flex flex-column flex-md-row">
+                      <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
+                      <div class="d-flex flex-column w-100 ml-md-3">
+                        <a :href="token.absolute_url" title="View token details" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
+                        <div class="d-flex flex-column flex-md-row font-smaller-2 col-md-3 px-0">
+                          <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-                <div>
-                  <button @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCompleteModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" >Complete</button>
-                  <button @click="cancel(token.id)" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Cancel</button>
-                </div>
-              </div>
-            </li>
-            <li class="text-center my-5" :class="{'d-none': isLoading.accepted || pTokens.accepted && pTokens.accepted.length > 0}" v-cloak>
-              <p>[[ error.in_progress || 'You don’t have any requests in progress' ]]</p>
-            </li>
-          </ul>
-          <loading-screen v-if="isLoading.in_progress"></loading-screen>
+              </li>
+              <li class="text-center my-5" :class="{'d-none': isLoading.completed || pTokens.completed && pTokens.completed.length > 0}" v-cloak>
+                <p>[[ error.completed || "You don’t have any completed requests." ]]</p>
+              </li>
+            </ul>
+            <loading-screen v-if="isLoading.completed"></loading-screen>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.denied">[[ pTokens.denied ? pTokens.denied.length : '0' ]] Denied</div>
 
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="p-4 border-bottom font-weight-bold"  v-if="pTokens.completed">[[ pTokens.completed ? pTokens.completed.length : '0' ]] Completed</div>
-
-          <ul class="list-unstyled list-bounty">
-            <li v-for="(token, key) in pTokens.completed" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
-              <span class="fa-stack mr-2">
-                <i class="fas fa-circle fa-stack-2x light-blue"></i>
-                <i class="fas fa-user fa-stack-1x fa-inverse"></i>
-              </span>
-              <span v-if="token.requester == current_user">You redeemed <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]].</span>
-              <span v-else>You completed a redemption for <span class="font-weight-bold"> [[ token.amount ]] [[ token.token_symbol ]] </span> from @[[ token.requester ]].</span>
-              <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
-                <div class="list-bounty-item_content my-auto">
-                  <div class="d-flex flex-column flex-md-row">
-                    <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
-                    <div class="d-flex flex-column w-100 ml-md-3">
-                      <a :href="token.absolute_url" title="View token details" class="font-weight-semibold text-truncate mb-2 text-dark">[[ token.reason ]]</a>
-                      <div class="d-flex flex-column flex-md-row font-smaller-2 col-md-3 px-0">
-                        <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+            <ul class="list-unstyled list-bounty">
+              <li v-for="(token, key) in pTokens.denied" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
+                <span class="fa-stack mr-2">
+                  <i class="fas fa-circle fa-stack-2x light-blue"></i>
+                  <i class="fas fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <span v-if="token.requester == current_user">Your request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]] was denied. Please try redeeming again with feedback from the Creator.</span>
+                <span v-else>You denied a request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> from @[[ token.requester ]].</span>
+                <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
+                  <div class="list-bounty-item_content my-auto">
+                    <div class="d-flex flex-column flex-md-row">
+                      <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
+                      <div class="d-flex flex-column w-100 ml-md-3">
+                        <a :href="token.absolute_url" title="View token details" class="text-truncate mb-2 text-dark font-weight-semibold">[[ token.reason ]]</a>
+                        <div class="d-flex flex-column flex-md-row font-smaller-2  col-md-3 px-0">
+                          <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li class="text-center my-5" :class="{'d-none': isLoading.completed || pTokens.completed && pTokens.completed.length > 0}" v-cloak>
-              <p>[[ error.completed || "You don’t have any completed requests." ]]</p>
-            </li>
-          </ul>
-          <loading-screen v-if="isLoading.completed"></loading-screen>
+              </li>
+              <li class="text-center my-5" :class="{'d-none': isLoading.denied || pTokens.denied && pTokens.denied.length > 0}" v-cloak>
+                <p>[[ error.denied || "You do not have any denied requests" ]]</p>
+              </li>
+            </ul>
+            <loading-screen v-if="isLoading.denied"></loading-screen>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.denied">[[ pTokens.denied ? pTokens.denied.length : '0' ]] Denied</div>
+    <section class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="bg-white rounded border my-4">
+            <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.cancelled">[[ pTokens.cancelled ? pTokens.cancelled.length : '0' ]] Cancelled</div>
 
-          <ul class="list-unstyled list-bounty">
-            <li v-for="(token, key) in pTokens.denied" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
-              <span class="fa-stack mr-2">
-                <i class="fas fa-circle fa-stack-2x light-blue"></i>
-                <i class="fas fa-user fa-stack-1x fa-inverse"></i>
-              </span>
-              <span v-if="token.requester == current_user">Your request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> for work from @[[ token.creator ]] was denied. Please try redeeming again with feedback from the Creator.</span>
-              <span v-else>You denied a request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> from @[[ token.requester ]].</span>
-              <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
-                <div class="list-bounty-item_content my-auto">
-                  <div class="d-flex flex-column flex-md-row">
-                    <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
-                    <div class="d-flex flex-column w-100 ml-md-3">
-                      <a :href="token.absolute_url" title="View token details" class="text-truncate mb-2 text-dark font-weight-semibold">[[ token.reason ]]</a>
-                      <div class="d-flex flex-column flex-md-row font-smaller-2  col-md-3 px-0">
-                        <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+            <ul class="list-unstyled list-bounty">
+              <li v-for="(token, key) in pTokens.cancelled" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
+                <span class="fa-stack mr-2">
+                  <i class="fas fa-circle fa-stack-2x light-blue"></i>
+                  <i class="fas fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <span v-if="token.requester == current_user && token.canceller == current_user">You cancelled a request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> from @[[token.creator]].</span>
+                <span v-else-if="token.requester == current_user && token.canceller != current_user">@[[token.creator]] cancelled your request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span>.</span>
+                <span v-else-if="token.requester != current_user && token.canceller == current_user">You cancelled a request from @[[token.requester]] to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span>.</span>
+                <span v-else-if="token.requester != current_user && token.canceller != current_user">@[[token.requester]] cancelled their request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span> from you.</span>
+                <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
+                  <div class="list-bounty-item_content my-auto">
+                    <div class="d-flex flex-column flex-md-row">
+                      <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
+                      <div class="d-flex flex-column w-100 ml-md-3">
+                        <a :href="token.absolute_url" title="View token details" class="text-truncate mb-2 text-dark font-weight-semibold">[[ token.reason ]]</a>
+                        <div class="d-flex flex-column flex-md-row font-smaller-2  col-md-3 px-0">
+                          <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li class="text-center my-5" :class="{'d-none': isLoading.denied || pTokens.denied && pTokens.denied.length > 0}" v-cloak>
-              <p>[[ error.denied || "You do not have any denied requests" ]]</p>
-            </li>
-          </ul>
-          <loading-screen v-if="isLoading.denied"></loading-screen>
+              </li>
+              <li class="text-center my-5" :class="{'d-none': isLoading.cancelled || pTokens.cancelled && pTokens.cancelled.length > 0}" v-cloak>
+                <p>[[ error.denied || "You do not have any cancelled requests" ]]</p>
+              </li>
+            </ul>
+            <loading-screen v-if="isLoading.cancelled"></loading-screen>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
-
-  <section class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="bg-white rounded border my-4">
-          <div class="p-4 border-bottom font-weight-bold" v-if="pTokens.cancelled">[[ pTokens.cancelled ? pTokens.cancelled.length : '0' ]] Cancelled</div>
-
-          <ul class="list-unstyled list-bounty">
-            <li v-for="(token, key) in pTokens.cancelled" :key="token.id" class="position-relative font-smaller-1 mt-3 p-3 list-bounty-item">
-              <span class="fa-stack mr-2">
-                <i class="fas fa-circle fa-stack-2x light-blue"></i>
-                <i class="fas fa-user fa-stack-1x fa-inverse"></i>
-              </span>
-              <span v-if="token.requester == current_user && token.canceller == current_user">You cancelled a request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]] </span> from @[[token.creator]].</span>
-              <span v-else-if="token.requester == current_user && token.canceller != current_user">@[[token.creator]] cancelled your request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span>.</span>
-              <span v-else-if="token.requester != current_user && token.canceller == current_user">You cancelled a request from @[[token.requester]] to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span>.</span>
-              <span v-else-if="token.requester != current_user && token.canceller != current_user">@[[token.requester]] cancelled their request to redeem <span class="font-weight-bold">[[ token.amount ]] [[ token.token_symbol ]]</span> from you.</span>
-              <div class="d-flex flex-column flex-lg-row justify-content-between border p-3 my-2 ml-5 rounded">
-                <div class="list-bounty-item_content my-auto">
-                  <div class="d-flex flex-column flex-md-row">
-                    <img :src="token.avatar_url" alt="" width="60" height="60" class="rounded-circle flex-shrink-0 m-auto list-bounty-item_logo">
-                    <div class="d-flex flex-column w-100 ml-md-3">
-                      <a :href="token.absolute_url" title="View token details" class="text-truncate mb-2 text-dark font-weight-semibold">[[ token.reason ]]</a>
-                      <div class="d-flex flex-column flex-md-row font-smaller-2  col-md-3 px-0">
-                        <span class="my-1">[[ token.amount ]] [[ token.token_symbol ]]</span> <span class="d-md-block d-none mx-2 my-auto">&bull;</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li class="text-center my-5" :class="{'d-none': isLoading.cancelled || pTokens.cancelled && pTokens.cancelled.length > 0}" v-cloak>
-              <p>[[ error.denied || "You do not have any cancelled requests" ]]</p>
-            </li>
-          </ul>
-          <loading-screen v-if="isLoading.cancelled"></loading-screen>
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
+  {% endif %}
 
   {% include 'shared/create_ptoken.html' %}
   {% include 'shared/create_ptoken_success.html' %}

--- a/app/dashboard/templates/profiles/scorecard_ptoken.html
+++ b/app/dashboard/templates/profiles/scorecard_ptoken.html
@@ -35,14 +35,14 @@
               <a class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" href="{% url 'ptoken_quickstart' %}">CREATE A PERSONAL TOKEN</a>
             {% endif %}
           {% else %}
-            {% comment %} Redeem button: Disable it if user holds no tokens {% endcomment %}
-            {% if ptoken.total_available == 0 %}
+            {% comment %} Buy button: Disable it if user holds no tokens or is not in a valid region {% endcomment %}
+            {% if ptoken.total_available == 0 or is_location_blocked_for_ptokens %}
               <button disabled style="cursor: default; pointer-events: none;" class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5">BUY</button>
             {% else %}
               <button class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#buyTokenModal">BUY</button>
             {% endif %}
             {% comment %} Redeem button: Disable it if user holds no tokens {% endcomment %}
-            {% if available_to_redeem == 0  %}
+            {% if available_to_redeem == 0 or is_location_blocked_for_ptokens %}
               <button id="redeemPToken" disabled style="cursor: default; pointer-events: none;" class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#redeemTokenModal">REDEEM</button>
             {% else %}
               <button id="redeemPToken" class="btn btn-outline-gc-blue btn-sm flex-grow-1 font-smaller-5" data-toggle="modal" data-target="#redeemTokenModal">REDEEM</button>

--- a/app/retail/helpers.py
+++ b/app/retail/helpers.py
@@ -16,6 +16,7 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
+from django.conf import settings
 
 
 def get_ip(request):
@@ -24,4 +25,5 @@ def get_ip(request):
         ip_addr = forward_for.split(',')[0]
     else:
         ip_addr = request.META.get('REMOTE_ADDR')
-    return ip_addr
+    # Docker uses private IP addresses, so hardcode a real one for development
+    return '24.210.224.38' if settings.DEBUG else ip_addr


### PR DESCRIPTION
Hides fields and forms for pToken interaction if the user's IP is in NY. Works as follows
- Adds `is_location_blocked_for_ptokens` flag to context
- On the dashboard page, we show the ptokens tab but show a message indicating it's not available for NY users
- On the profile page, the pToken scorecard disables the buy and redeem buttons if you are in NY

To test:
- The debug IP address has a location of Ohio, United States. Therefore everything should be enabled by default
- Open settings.py and make the change below. This will make Ohio the blocked region to simulate being a NY user

```diff
- PTOKEN_BLOCKED_REGION = { 'country_code': 'US', 'region': 'NY' }
+ PTOKEN_BLOCKED_REGION = { 'country_code': 'US', 'region': 'OH' }
```