### PR TITLE
manual fallback to binance address autofill for new bounty

### DIFF
--- a/app/assets/v2/js/pages/hackathon_new_bounty.js
+++ b/app/assets/v2/js/pages/hackathon_new_bounty.js
@@ -62,6 +62,15 @@ Vue.mixin({
       });
 
     },
+    getBinanceSelectedAccount: async function() {
+      let vm = this;
+
+      try {
+        vm.form.funderAddress = await binance_utils.getSelectedAccount();
+      } catch (error) {
+        vm.funderAddressFallback = true;
+      }
+    },
     getAmount: function(token) {
       let vm = this;
 
@@ -364,6 +373,11 @@ Vue.mixin({
       if (!provider && val === '1') {
         await onConnect();
       }
+
+      if (val === '56') {
+        this.getBinanceSelectedAccount();
+      }
+
       this.getTokens();
       await this.checkForm();
     }

--- a/app/assets/v2/js/pages/hackathon_new_bounty.js
+++ b/app/assets/v2/js/pages/hackathon_new_bounty.js
@@ -62,11 +62,6 @@ Vue.mixin({
       });
 
     },
-    getBinanceSelectedAccount: async function() {
-      let vm = this;
-
-      vm.form.funderAddress = await binance_utils.getSelectedAccount();
-    },
     getAmount: function(token) {
       let vm = this;
 

--- a/app/assets/v2/js/pages/hackathon_new_bounty.js
+++ b/app/assets/v2/js/pages/hackathon_new_bounty.js
@@ -396,6 +396,7 @@ if (document.getElementById('gc-hackathon-new-bounty')) {
         tokens: [],
         network: 'mainnet',
         chainId: '',
+        funderAddressFallback: false,
         terms: false,
         hackathonSlug: document.hackathon.slug,
         hackathonEndDate: document.hackathon.endDate,

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -74,11 +74,6 @@ Vue.mixin({
       });
 
     },
-    getBinanceSelectedAccount: async function() {
-      let vm = this;
-
-      vm.form.funderAddress = await binance_utils.getSelectedAccount();
-    },
     getAmount: function(token) {
       let vm = this;
 
@@ -696,11 +691,6 @@ Vue.mixin({
       if (!provider && val === '1') {
         await onConnect();
       }
-
-      if (val === '56') {
-        this.getBinanceSelectedAccount();
-      }
-
       this.getTokens();
     }
   }

--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -74,6 +74,15 @@ Vue.mixin({
       });
 
     },
+    getBinanceSelectedAccount: async function() {
+      let vm = this;
+
+      try {
+        vm.form.funderAddress = await binance_utils.getSelectedAccount();
+      } catch (error) {
+        vm.funderAddressFallback = true;
+      }
+    },
     getAmount: function(token) {
       let vm = this;
 
@@ -691,6 +700,11 @@ Vue.mixin({
       if (!provider && val === '1') {
         await onConnect();
       }
+
+      if (val === '56') {
+        this.getBinanceSelectedAccount();
+      }
+
       this.getTokens();
     }
   }
@@ -709,6 +723,7 @@ if (document.getElementById('gc-hackathon-new-bounty')) {
         tokens: [],
         network: 'mainnet',
         chainId: '',
+        funderAddressFallback: false,
         checkboxes: {'terms': false, 'termsPrivacy': false, 'neverExpires': true, 'hiringRightNow': false },
         expandedGroup: {'reserve': [], 'featuredBounty': []},
         errors: {},

--- a/app/dashboard/templates/bounty/new_bounty.html
+++ b/app/dashboard/templates/bounty/new_bounty.html
@@ -417,11 +417,15 @@
                 </div>
               </div>
 
-              <div class="funder-address-container mt-4" v-show="chainId !== '1' && chainId !== '56'">
+              <div class="funder-address-container mt-4" v-show="(chainId !== '1' && chainId !== '56') || funderAddressFallback === true">
                 <label class="font-caption letter-spacing text-black-60 text-uppercase" for="funderAddress">Funder Address</label>
+                <p class="font-body" v-show="funderAddressFallback === true">Please enter your Binance Wallet address. We are unable to validate a Binance address. Please confirm that you are using the correct Binance address.</p>
                 <input name="funderAddress" id="funderAddress" class="form__input" type="text" placeholder="Address with which the bounty will be paid out" v-model="form.funderAddress">
                 <div class="text-danger" v-if="errors.funderAddress && (!form.funderAddress || chainId === '0')">
                   [[errors.funderAddress]]
+                </div>
+                <div class="text-danger" v-if="funderAddressFallback === true">
+                  Looks like you don't have the Binance Wallet Extension or the extension is disabled.
                 </div>
               </div>
 

--- a/app/dashboard/templates/dashboard/hackathon/new_bounty.html
+++ b/app/dashboard/templates/dashboard/hackathon/new_bounty.html
@@ -438,11 +438,15 @@
                 </div>
               </div>
 
-              <div class="funder-address-container" v-show="chainId !== '1' && chainId !== '56'">
-                <label class="font-caption letter-spacing text-black-60" for="funderAddress">Funder Address</label>
+              <div class="funder-address-container mt-4" v-show="(chainId !== '1' && chainId !== '56') || funderAddressFallback === true">
+                <label class="font-caption letter-spacing text-black-60 text-uppercase" for="funderAddress">Funder Address</label>
+                <p class="font-body" v-show="funderAddressFallback === true">Please enter your Binance Wallet address. We are unable to validate a Binance address. Please confirm that you are using the correct Binance address.</p>
                 <input name="funderAddress" id="funderAddress" class="form__input" type="text" placeholder="Address with which the bounty will be paid out" v-model="form.funderAddress">
                 <div class="text-danger" v-if="errors.funderAddress && !form.funderAddress">
                   [[errors.funderAddress]]
+                </div>
+                <div class="text-danger" v-if="funderAddressFallback === true">
+                  Looks like you don't have the Binance Wallet Extension or the extension is disabled.
                 </div>
               </div>
             </div>


### PR DESCRIPTION
##### Description

Allow manual filling of binance address as a fallback to autofilling when user doesn't have Binance Wallet Extension installed.

##### Refers/Fixes

#8249 

##### Testing

![image](https://user-images.githubusercontent.com/6025509/104974013-df699e80-59f6-11eb-86b8-e710c3aa602e.png)
