### PR TITLE
pToken fix for who can Complete a request

### DIFF
--- a/app/dashboard/templates/board/ptokens.html
+++ b/app/dashboard/templates/board/ptokens.html
@@ -171,7 +171,7 @@
                     </div>
                   </div>
                   <div>
-                    <button @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCompleteModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" >Complete</button>
+                    <button v-if="token.requester == current_user" @click="setSelectedRequest(token)" data-toggle="modal" data-target="#redemptionCompleteModal" class="btn btn-sm m-2 btn-gc-blue" :disabled="key === disabledBtn" >Complete</button>
                     <button @click="cancel(token.id)" class="btn btn-sm btn-outline-gc-blue m-2" :disabled="key === disabledBtn">Cancel</button>
                   </div>
                 </div>


### PR DESCRIPTION
Fix: A token creator was able to click 'Complete' on a request, but this should not be possible. Only requestors should mark it as complete

This fix is copied from https://github.com/gitcoinco/web/pull/7896, but that PR is pretty old so it was easier to replace that as opposed to rebasing