### PR TITLE
Fix Github Authentication Deprecation

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ google-api-python-client
 django-environ==0.4.5
 eth-utils==1.4.1
 jsondiff==1.1.1
-social-auth-app-django==3.1.0
+social-auth-app-django==4.0.0
 django-ipware==2.0.2
 geoip2==2.8.0
 django-silk==2.0.0


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
The Github auth process we currently use has been deprecated and would be removed completely in May 2021. So as to prevent our system from any any downtime or user's being unable to sign in, we're updating the social auth app to the latest version which still supports github authentication and doesn't break our current integration.
<!-- Describe your changes here. -->

##### Refers/Fixes
closes #8072
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
