### PR TITLE
Make verified twitter tooltip work on grants card

### DIFF
--- a/app/grants/templates/grants/components/card.html
+++ b/app/grants/templates/grants/components/card.html
@@ -134,11 +134,13 @@
       <div class="grant-item__content px-3">
         <h2 class="grant-item__title font-subheader">
           <a :href="grant.details_url" target="_blank">[[ grant.title | truncate(60) ]]</a>
-          <button v-if="grant.verified" class="btn btn-sm animate-verify p-0" data-container="body" data-toggle="popover" data-html="true" data-placement="bottom" data-trigger="hover click" data-content='
-             <p class="h6 my-2 text-left">Verified Ownership <img width="18" src="{% static "v2/images/badge-verify.svg" %}"></p>
-             <p>Grant owner has verified ownership of their twitter account.</p>
-             <a href="#">Learn more.</p>'
-            ><img width="13" clas="position-relative" style="top: -2px;" src="{% static 'v2/images/badge-verify.svg' %}" alt="">
+          <button v-if="grant.verified" class="btn btn-sm animate-verify p-0" id="tooltip-verify">
+            <b-tooltip target="tooltip-verify" triggers="hover click" variant="light" placement="bottom">
+              <p class="h6 my-2 text-left">Verified Ownership <img width="18" src="{% static "v2/images/badge-verify.svg" %}"></p>
+              <p class="text-left">Grant owner has verified ownership of their twitter account.</p>
+              <a href="#">Learn more.</a>
+            </b-tooltip>
+            <img width="13" src="{% static 'v2/images/badge-verify.svg' %}" alt="">
           </button>
         </h2>
         <p class="grant-item__pitch font-caption mb-2">[[ grant.description | truncate(145) ]]</p>


### PR DESCRIPTION
##### Description

Make verified twitter address tooltip work on grant cards

##### Refers/Fixes

Fixes #7387

##### Testing

No Python code was changed/added.  Just updated a tooltip component to work correctly.

![before](https://user-images.githubusercontent.com/17355484/105528682-46b37700-5cb3-11eb-8973-d2ca0294d215.gif)
![after](https://user-images.githubusercontent.com/17355484/105528813-706c9e00-5cb3-11eb-8b40-0ec7547efb3e.gif)





