### PR TITLE
Drops a Grants Twitter verification if the user modifies the twitter_handle_1 field

### DIFF
--- a/app/assets/v2/js/grants/_detail-component.js
+++ b/app/assets/v2/js/grants/_detail-component.js
@@ -97,6 +97,10 @@ Vue.mixin({
             vm.grant.description_rich = JSON.stringify(vm.$refs.myQuillEditor.quill.getContents());
             vm.grant.description = vm.$refs.myQuillEditor.quill.getText();
             vm.grant.image_css = `background-color: ${vm.logoBackground};`;
+            if (vm.grant_twitter_handle_1 != vm.grant.twitter_handle_1) {
+              vm.grant.verified = false;
+            }
+            vm.grant_twitter_handle_1 = vm.grant.twitter_handle_1;
             vm.$root.$emit('bv::toggle::collapse', 'sidebar-grant-edit');
             _alert('Updated grant.', 'success');
 
@@ -532,7 +536,7 @@ Vue.component('grant-details', {
   },
   mounted: function() {
     let vm = this;
-
+    vm.grant_twitter_handle_1 = vm.grant.twitter_handle_1;
     vm.grant.description_rich_edited = vm.grant.description_rich;
     if (vm.grant.description_rich_edited) {
       vm.editor.updateContents(JSON.parse(vm.grant.description_rich));

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -1623,7 +1623,12 @@ def grant_edit(request, grant_id):
             response['message'] = 'error: enter your twitter handle e.g @georgecostanza'
             return JsonResponse(response)
 
-        grant.twitter_handle_1 = twitter_handle_1
+        if grant.twitter_handle_1 != twitter_handle_1:
+            grant.twitter_verified = False
+            grant.twitter_verified_by = None
+            grant.twitter_verified_at = None
+            grant.twitter_handle_1 = twitter_handle_1
+            
         grant.twitter_handle_2 = twitter_handle_2
 
         reference_url = request.POST.get('reference_url', None)


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

https://gitcoin.co/grants/1924/gitcoin-grants-round-9-dev-fund
https://gitcoin.co/grants/1927/gitcoin-grants-official-matching-pool-fund-round-

Users are able to modify a Grants twitter handle after the verification process. 

Replicated here: https://gitcoin.co/grants/1930/test-2

This pull will clear the verification if the twitter_handle_1 field is modified.

##### Refers/Fixes

clsoes https://github.com/gitcoinco/web/issues/8303

##### Testing

Untested - I don't have my local instance set-up with a twitter_access_token yet, I can't see anything going wrong, but let me know if you want me to test it 👍 
