### PR TITLE
Fix overflowing grant-data element

### DIFF
--- a/app/grants/templates/grants/detail/template-grant-details.html
+++ b/app/grants/templates/grants/detail/template-grant-details.html
@@ -3,7 +3,7 @@
   <div>
     <slot></slot>
     <div class="container grid grid-template-sidebar mb-5">
-      <div class="grant-data">
+      <div class="grant-data w-100">
         <div class="d-flex align-items-baseline">
           <h1 class="h3">
             [[grant.title]]
@@ -577,7 +577,6 @@
 
   .grant-data {
     grid-area: grant-data;
-    width: 100%;
   }
 
 

--- a/app/grants/templates/grants/detail/template-grant-details.html
+++ b/app/grants/templates/grants/detail/template-grant-details.html
@@ -577,6 +577,7 @@
 
   .grant-data {
     grid-area: grant-data;
+    width: 100%;
   }
 
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This will fix the .grant-data elements sizing issue on Firefox, without a width it was defaulting to auto which was filling the whole container.

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/8310

##### Testing

Before:

<img width="1160" alt="Screenshot 2021-01-27 at 17 11 10" src="https://user-images.githubusercontent.com/5897836/106027385-c2059600-60c2-11eb-9d41-4a9e8055216b.png">

After:

<img width="1165" alt="Screenshot 2021-01-27 at 17 04 43" src="https://user-images.githubusercontent.com/5897836/106027032-676c3a00-60c2-11eb-8401-29220677ab25.png">