### PR TITLE
Allow bounty onwer to stop worker.

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -588,7 +588,7 @@ Vue.mixin({
       }
       return;
     },
-    stopWork: function(isOwner) {
+    stopWork: function(isOwner, handle) {
       let text = isOwner ?
         'Are you sure you would like to stop this user from working on this bounty ?' :
         'Are you sure you would like to stop working on this bounty ?';
@@ -603,9 +603,9 @@ Vue.mixin({
         'X-CSRFToken': csrftoken
       };
 
-      const apiUrlBounty = `/actions/bounty/${vm.bounty.pk}/interest/remove/`;
-
-      fetchData(apiUrlBounty, 'POST', {}, headers).then(response => {
+      let apiUrlBounty = `/actions/bounty/${vm.bounty.pk}/interest/remove/`;
+      
+      fetchData(apiUrlBounty, 'POST', {handle}, headers).then(response => {
         if (200 <= response.status && response.status <= 204) {
           this.fetchBounty();
           let text = isOwner ?

--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -603,8 +603,8 @@ Vue.mixin({
         'X-CSRFToken': csrftoken
       };
 
-      let apiUrlBounty = `/actions/bounty/${vm.bounty.pk}/interest/remove/`;
-      
+      const apiUrlBounty = `/actions/bounty/${vm.bounty.pk}/interest/remove/`;
+
       fetchData(apiUrlBounty, 'POST', {handle}, headers).then(response => {
         if (200 <= response.status && response.status <= 204) {
           this.fetchBounty();

--- a/app/assets/v2/js/vue-filters.js
+++ b/app/assets/v2/js/vue-filters.js
@@ -68,6 +68,7 @@ Vue.filter('stringReplace', function(activity_type) {
     new_bounty: gettext('Bounty Created'),
     start_work: gettext('Work Started'),
     stop_work: gettext('Work Stopped'),
+    stop_worker: gettext('Stopped worker'),
     work_submitted: gettext('Work Submitted'),
     work_done: gettext('Work Done'),
     worker_approved: gettext('Approved'),

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1365,6 +1365,7 @@ class BountyEvent(SuperModel):
         ('cancel_bounty', 'Cancel Bounty'),
         ('submit_work', 'Submit Work'),
         ('stop_work', 'Stop Work'),
+        ('stop_worker', 'Worker stopped'),
         ('express_interest', 'Express Interest'),
         ('payout_bounty', 'Payout Bounty'),
         ('expire_bounty', 'Expire Bounty'),

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -853,7 +853,7 @@
                       </a>
                     </template>
                     <template v-else-if="isOwner">
-                      <button class="btn btn-sm btn-outline-gc-blue m-2 px-3 font-smaller-2 font-weight-semibold" @click="stopWork(isOwner)">
+                      <button class="btn btn-sm btn-outline-gc-blue m-2 px-3 font-smaller-2 font-weight-semibold" @click="stopWork(isOwner, interest.profile.handle)">
                         <i class="far fa-hand-paper mr-1 font-caption"></i> Stop Worker
                       </button>
                     </template>
@@ -919,7 +919,7 @@
                     <div v-if="activity.activity_type === 'new_kudos'">
                       show value
                     </div>
-                    <a v-if="activity.activity_type === 'worker_approved'" :href="`/profile/${activity.metadata.worker_handle}`" class="user-popover" :data-usercard="[[ activity.metadata.worker_handle ]]"
+                    <a v-if="activity.activity_type === 'worker_approved' || activity.activity_type === 'stop_worker'" :href="`/profile/${activity.metadata.worker_handle}`" class="user-popover" :data-usercard="[[ activity.metadata.worker_handle ]]"
                       data-html="true" data-toggle="popover" data-container="body"
                     >
                       [[ activity.metadata.worker_handle ]]


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
Currently, when the bounty owner tries to stop a worker who has been approved to work on a bounty, it doesn't happen and he simply gets an error. This happens because the endpoint for removing an interest from a bounty (stop worker) only does a worker check and not bounty owner check. This PR allows a worker to remove himself from a bounty and a bounty owner to stop a worker as well. It doesn't introduce a new functionality, only fixes a functionality that is broken.

<!-- Describe your changes here. -->

##### Refers/Fixes
closes #8331

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing
https://www.loom.com/share/8f269920f1f94ad09c980da5f6f05fed