### PR TITLE
Add a refresh button to update BrightID status on Trust tab

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -164,6 +164,11 @@ urlpatterns = [
     ),
     url(r'^api/v0.1/profile/(?P<handle>.*)/logout_idena', dashboard.views.logout_idena, name='logout_idena'),
     url(
+        r'^api/v0.1/profile/(?P<handle>.*)/brightid_status',
+        dashboard.views.recheck_brightid_status,
+        name='get_brightid_status'
+    ),
+    url(
         r'^api/v0.1/profile/(?P<handle>.*)/recheck_idena_status',
         dashboard.views.recheck_idena_status,
         name='recheck_idena_status'

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -114,7 +114,10 @@
 
                 <br><br>Connect
                 with other users and join groups to meet the threshold.
-                
+                <a href="https://brightid.org">Learn more.</a>
+                <br>
+                <br>
+                <a href={{ get_brightid_status }} class="text-nowrap">Refresh Status</a>
               {% elif brightid_status == 'verified' %}
                 You're verified with <a href="https://brightid.org" target="new">BrightID</a>, the unique, decentralized digital identity solution.
                 <br><br>

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -112,8 +112,8 @@
               {% elif brightid_status == 'not_verified' %}
                 Verify yourself on <a href="https://brightid.org" target="new">BrightID</a> by proving you're human to other humans. 
 
-                <br><br>Connect
-                with other users and join groups to meet the threshold.
+                <br><br>
+                <p class="mt-3">Connect with other users and join groups to meet the threshold.</p>
                 <a href="https://brightid.org">Learn more.</a>
                 <a href={{ get_brightid_status }} class="text-justify d-block mt-2">Refresh Status</a>
               {% elif brightid_status == 'verified' %}

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -115,9 +115,7 @@
                 <br><br>Connect
                 with other users and join groups to meet the threshold.
                 <a href="https://brightid.org">Learn more.</a>
-                <br>
-                <br>
-                <a href={{ get_brightid_status }} class="text-nowrap">Refresh Status</a>
+                <a href={{ get_brightid_status }} class="text-justify d-block mt-2">Refresh Status</a>
               {% elif brightid_status == 'verified' %}
                 You're verified with <a href="https://brightid.org" target="new">BrightID</a>, the unique, decentralized digital identity solution.
                 <br><br>

--- a/app/dashboard/templates/profiles/trust-vue.html
+++ b/app/dashboard/templates/profiles/trust-vue.html
@@ -111,8 +111,6 @@
 
               {% elif brightid_status == 'not_verified' %}
                 Verify yourself on <a href="https://brightid.org" target="new">BrightID</a> by proving you're human to other humans. 
-
-                <br><br>
                 <p class="mt-3">Connect with other users and join groups to meet the threshold.</p>
                 <a href="https://brightid.org">Learn more.</a>
                 <a href={{ get_brightid_status }} class="text-justify d-block mt-2">Refresh Status</a>

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3087,13 +3087,6 @@ def authenticate_idena(request, handle):
 
 @login_required
 def recheck_brightid_status(request, handle):
-    is_logged_in_user = request.user.is_authenticated and request.user.username.lower() == handle.lower()
-    if not is_logged_in_user:
-        return JsonResponse({
-            'ok': False,
-            'msg': f'Request must be for the logged in user'
-        })
-    
     profile = profile_helper(handle, True)
     user_brightid_status = get_brightid_status(profile.brightid_uuid)
     profile.is_brightid_verified = user_brightid_status == 'verified'


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

We may want to add more sophisticated styles to this link

##### Refers/Fixes

Addresses #8161 

This no longer creates a blocking loading situation with BrightID and instead gives the user an option to click a button to manually refresh the page that would update the backend.

##### Testing

Create a BrightID a new verified account while signed in and navigate to the trust tab. Before one hour has passed click the `Refresh Status` button and see that your status has updated to verified.
