### PR TITLE
fix expiry duration for qr bounties

### DIFF
--- a/app/dashboard/management/commands/sync_pending_fulfillments.py
+++ b/app/dashboard/management/commands/sync_pending_fulfillments.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
         if qr_pending_fulfillments:
             # Auto expire pending transactions
             timeout_period = timezone.now() - timedelta(minutes=20)
-            qr_pending_fulfillments.filter(created_on__lt=timeout_period).update(payout_status='expired')
+            qr_pending_fulfillments.filter(modified_on__lt=timeout_period).update(payout_status='expired')
 
             fulfillments = qr_pending_fulfillments.filter(payout_status='pending')
             for fulfillment in fulfillments.all():


### PR DESCRIPTION
##### Description

QR bounties have an expiry period of 20 minutes from created time. This is wrong as it should be from modified time.

##### Refers/Fixes

slack bug report

##### Testing

