### PR TITLE
Implement post-checkout Grants Modal Redesign and Refactor

### DIFF
--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -1,22 +1,19 @@
-Vue.component("contribution-thanks-modal", {
-  delimiters: ["[[", "]]"],
-  data: function () {
+Vue.component('contribution-thanks-modal', {
+  delimiters: [ '[[', ']]' ],
+  data: function() {
     return {
       modalId: 'contribution-thanks',
       numberOfContributions: 0,
       donations: [],
-      tweetUrl: '',
+      tweetUrl: ''
     };
   },
-  mounted: function () {
-    const shouldShow = Boolean(
-      localStorage.getItem("contributions_were_successful")
-    );
-    this.numberOfContributions = Number(
-      localStorage.getItem("contributions_count")
-    );
+  mounted: function() {
+    const shouldShow = Boolean(localStorage.getItem('contributions_were_successful'));
 
-    this.tweetUrl = `https://twitter.com/intent/tweet?text=I just funded ${this.numberOfContributions} grants on @gitcoin ${CartData.share_url()}`;;
+    this.numberOfContributions = Number(localStorage.getItem('contributions_count'));
+
+    this.tweetUrl = `https://twitter.com/intent/tweet?text=I just funded ${this.numberOfContributions} grants on @gitcoin ${CartData.share_url()}`;
 
     if (shouldShow) {
       this.$bvModal.show(this.modalId);
@@ -29,25 +26,25 @@ Vue.component("contribution-thanks-modal", {
       this.$bvModal.hide(this.modalId);
     },
     handleHide() {
-      localStorage.removeItem("contributions_were_successful");
-      localStorage.removeItem("contributions_count");
+      localStorage.removeItem('contributions_were_successful');
+      localStorage.removeItem('contributions_count');
       CartData.setCart([]);
     },
     showSaveAsCollection() {
       this.$bvModal.show('create-collection');
     }
-  },
+  }
 });
 
-Vue.component("create-collection-modal", {
-  delimiters: ["[[", "]]"],
-  data: function () {
+Vue.component('create-collection-modal', {
+  delimiters: [ '[[', ']]' ],
+  data: function() {
     return {
       modalId: 'create-collection',
       collectionTitle: '',
       collectionDescription: '',
       collections: [],
-      selectedCollection: null,
+      selectedCollection: null
     };
   },
   computed: {
@@ -59,10 +56,10 @@ Vue.component("create-collection-modal", {
       }
 
       return false;
-    },
+    }
   },
   mounted: function() {
-    fetchData('/grants/v1/api/collections/').then( response => {
+    fetchData('/grants/v1/api/collections/').then(response => {
       console.log('COLLECTIONS', response);
       if (response.collections && response.collections.length > 0) {
         this.collections = response.collections;
@@ -114,17 +111,17 @@ Vue.component("create-collection-modal", {
 
 // DOCUMENT
 let allTokens;
-const fetchTokens = async () => {
-  const tokensResponse = await fetch("/api/v1/tokens");
+const fetchTokens = async() => {
+  const tokensResponse = await fetch('/api/v1/tokens');
 
   allTokens = await tokensResponse.json();
 };
 
 fetchTokens();
 
-$(document).ready(function () {
+$(document).ready(function() {
 
-  $("#js-addToCart-form").submit(function (event) {
+  $('#js-addToCart-form').submit(function(event) {
     event.preventDefault();
 
     // const formData = objectifySerialized($(this).serializeArray());
@@ -135,10 +132,10 @@ $(document).ready(function () {
     showSideCart();
   });
 
-  $(".infinite-container").on(
-    "submit",
-    ".js-addDetailToCart-form",
-    function (event) {
+  $('.infinite-container').on(
+    'submit',
+    '.js-addDetailToCart-form',
+    function(event) {
       event.preventDefault();
 
       const formData = objectifySerialized($(this).serializeArray());
@@ -149,15 +146,15 @@ $(document).ready(function () {
     }
   );
 
-  $("#close-side-cart").click(function () {
+  $('#close-side-cart').click(function() {
     hideSideCart();
   });
 
-  $("#side-cart-data").on("click", "#apply-to-all", async function () {
+  $('#side-cart-data').on('click', '#apply-to-all', async function() {
     // Get preferred cart data
     let cartData = CartData.loadCart();
-    const network = document.web3network || "mainnet";
-    const selected_grant_index = $(this).data("id");
+    const network = document.web3network || 'mainnet';
+    const selected_grant_index = $(this).data('id');
     const preferredAmount =
       cartData[selected_grant_index].grant_donation_amount;
     const preferredTokenName =
@@ -175,7 +172,7 @@ $(document).ready(function () {
     cartData.forEach((grant, index) => {
       const acceptsAllTokens =
         grant.grant_token_address ===
-        "0x0000000000000000000000000000000000000000";
+        '0x0000000000000000000000000000000000000000';
       const acceptsSelectedToken =
         grant.grant_token_address === preferredTokenAddress;
 
@@ -186,7 +183,7 @@ $(document).ready(function () {
       } else {
         // If the selected token is not available, fallback to ETH
         cartData[index].grant_donation_amount = fallbackAmount;
-        cartData[index].grant_donation_currency = "ETH";
+        cartData[index].grant_donation_currency = 'ETH';
       }
     }); // end cartData.forEach
 
@@ -238,47 +235,47 @@ function tokenOptionsForGrant(grant) {
   var network = document.web3network;
 
   if (!network) {
-    network = "mainnet";
+    network = 'mainnet';
   }
 
   // let tokenDataList = tokens(network);
   let tokenDataList = allTokens.filter(
-    (token) => token.network === networkName || "mainnet"
+    (token) => token.network === networkName || 'mainnet'
   );
-  let tokenDefault = "ETH";
+  let tokenDefault = 'ETH';
 
-  if (grant.tenants && grant.tenants.includes("ZCASH")) {
+  if (grant.tenants && grant.tenants.includes('ZCASH')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 123123);
-    tokenDefault = "ZEC";
+    tokenDefault = 'ZEC';
   }
-  if (grant.tenants && grant.tenants.includes("CELO")) {
+  if (grant.tenants && grant.tenants.includes('CELO')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 42220);
-    tokenDefault = "CELO";
-  } else if (grant.tenants && grant.tenants.includes("ZIL")) {
+    tokenDefault = 'CELO';
+  } else if (grant.tenants && grant.tenants.includes('ZIL')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 102);
-    tokenDefault = "ZIL";
-  } else if (grant.tenants && grant.tenants.includes("HARMONY")) {
+    tokenDefault = 'ZIL';
+  } else if (grant.tenants && grant.tenants.includes('HARMONY')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 1000);
-    tokenDefault = "ONE";
-  } else if (grant.tenants && grant.tenants.includes("BINANCE")) {
+    tokenDefault = 'ONE';
+  } else if (grant.tenants && grant.tenants.includes('BINANCE')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 56);
-    tokenDefault = "BNB";
-  } else if (grant.tenants && grant.tenants.includes("POLKADOT")) {
+    tokenDefault = 'BNB';
+  } else if (grant.tenants && grant.tenants.includes('POLKADOT')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 58);
-    tokenDefault = "DOT";
-  } else if (grant.tenants && grant.tenants.includes("KUSAMA")) {
+    tokenDefault = 'DOT';
+  } else if (grant.tenants && grant.tenants.includes('KUSAMA')) {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 59);
-    tokenDefault = "KSM";
+    tokenDefault = 'KSM';
   } else {
     tokenDataList = tokenDataList.filter((token) => token.chainId === 1);
   }
 
   const acceptsAllTokens =
     grant.grant_token_address ===
-      "0x0000000000000000000000000000000000000000" ||
-    grant.grant_token_address === "0x0";
+      '0x0000000000000000000000000000000000000000' ||
+    grant.grant_token_address === '0x0';
 
-  let options = "";
+  let options = '';
 
   if (!acceptsAllTokens) {
     options += `
@@ -309,7 +306,7 @@ function tokenOptionsForGrant(grant) {
 
 function showSideCart() {
   // Remove elements in side cart
-  $("#side-cart-data").find("div.side-cart-row").remove();
+  $('#side-cart-data').find('div.side-cart-row').remove();
 
   // Add all elements in side cart
   let cartData = CartData.loadCart();
@@ -317,18 +314,18 @@ function showSideCart() {
   cartData.forEach((grant, index) => {
     const cartRowHtml = sideCartRowForGrant(grant, index);
 
-    $("#side-cart-data").append(cartRowHtml);
+    $('#side-cart-data').append(cartRowHtml);
 
     // Register remove click handler
-    $(`#side-cart-row-remove-${grant.grant_id}`).click(function () {
-      if (typeof appGrants !== "undefined") {
+    $(`#side-cart-row-remove-${grant.grant_id}`).click(function() {
+      if (typeof appGrants !== 'undefined') {
         appGrants.grants.filter((grantSingle) => {
           if (Number(grantSingle.id) === Number(grant.grant_id)) {
             grantSingle.isInCart = false;
           }
         });
       } else if (
-        typeof appGrantDetails !== "undefined" &&
+        typeof appGrantDetails !== 'undefined' &&
         appGrantDetails.grant.id === Number(grant.grant_id)
       ) {
         appGrantDetails.grant.isInCart = false;
@@ -339,12 +336,12 @@ function showSideCart() {
     });
 
     // Register change amount handler
-    $(`#side-cart-amount-${grant.grant_id}`).change(function () {
+    $(`#side-cart-amount-${grant.grant_id}`).change(function() {
       const newAmount = parseFloat($(this).val());
 
       CartData.updateCartItem(
         grant.grant_id,
-        "grant_donation_amount",
+        'grant_donation_amount',
         newAmount
       );
     });
@@ -355,10 +352,10 @@ function showSideCart() {
     );
 
     // Register currency change handler
-    $(`#side-cart-currency-${grant.grant_id}`).change(function () {
+    $(`#side-cart-currency-${grant.grant_id}`).change(function() {
       CartData.updateCartItem(
         grant.grant_id,
-        "grant_donation_currency",
+        'grant_donation_currency',
         $(this).val()
       );
     });
@@ -366,7 +363,7 @@ function showSideCart() {
     $(`#side-cart-currency-${grant.grant_id}`).select2();
   });
 
-  const isShowing = $("#side-cart").hasClass("col-12");
+  const isShowing = $('#side-cart').hasClass('col-12');
 
   if (!isShowing) {
     toggleSideCart();
@@ -374,14 +371,14 @@ function showSideCart() {
 
   // Scroll To top on mobile
   if (window.innerWidth < 768) {
-    const cartTop = $("#side-cart").position().top;
+    const cartTop = $('#side-cart').position().top;
 
     window.scrollTo(0, cartTop);
   }
 }
 
 function hideSideCart() {
-  const isShowing = $("#side-cart").hasClass("col-12");
+  const isShowing = $('#side-cart').hasClass('col-12');
 
   if (!isShowing) {
     return;
@@ -391,19 +388,19 @@ function hideSideCart() {
 }
 
 function toggleSideCart() {
-  $("#grants-details > div").toggleClass(
-    "col-12 col-md-8 col-lg-9 d-none d-md-inline-flex"
+  $('#grants-details > div').toggleClass(
+    'col-12 col-md-8 col-lg-9 d-none d-md-inline-flex'
   );
 
-  $("#side-cart").toggle();
-  $("#side-cart").toggleClass("col-12 col-md-4 col-lg-3");
-  $("#funding-card").toggleClass("mr-md-5 mr-md-3 d-none d-lg-block");
+  $('#side-cart').toggle();
+  $('#side-cart').toggleClass('col-12 col-md-4 col-lg-3');
+  $('#funding-card').toggleClass('mr-md-5 mr-md-3 d-none d-lg-block');
 }
 
-if (document.getElementById("grant-thanks-app")) {
+if (document.getElementById('grant-thanks-app')) {
   const grantThanksApp = new Vue({
-    delimiters: ["[[", "]]"],
-    el: "#grant-thanks-app",
-    data: {},
+    delimiters: [ '[[', ']]' ],
+    el: '#grant-thanks-app',
+    data: {}
   });
 }

--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -8,12 +8,6 @@ Vue.component("contribution-thanks-modal", {
       tweetUrl: '',
     };
   },
-  props: {},
-  computed: {
-    tweetURLPath: function() {
-      // TBD
-    }
-  },
   mounted: function () {
     const shouldShow = Boolean(
       localStorage.getItem("contributions_were_successful")
@@ -56,7 +50,6 @@ Vue.component("create-collection-modal", {
       selectedCollection: null,
     };
   },
-  props: {},
   computed: {
     isValidCollection() {
       if (this.selectedCollection !== null) {
@@ -77,6 +70,9 @@ Vue.component("create-collection-modal", {
     });
   },
   methods: {
+    close() {
+      this.$bvModal.hide(this.modalId);
+    },
     createCollection: async function() {
       const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
       const cart = CartData.loadCart();
@@ -102,6 +98,7 @@ Vue.component("create-collection-modal", {
         this.cleanCollectionModal();
 
         this.$bvModal.hide(this.modalId);
+        this.$bvModal.hide('contribution-thanks'); // triggers cart clear
         window.location = redirect;
 
       } catch (e) {

--- a/app/assets/v2/js/grants/funding.js
+++ b/app/assets/v2/js/grants/funding.js
@@ -1,3 +1,47 @@
+Vue.component('contribution-thanks-modal', {
+  delimiters: [ '[[', ']]' ],
+  data: function() {
+    return {
+      modalId: 'contribution-thanks',
+      numberOfContributions: 0,
+    };
+  },
+  props: {
+  },
+  mounted: function () {
+    const shouldShow = Boolean(localStorage.getItem('contributions_were_successful'));
+    this.numberOfContributions = Number(localStorage.getItem('contributions_count'));
+
+    if (shouldShow) {
+      this.$bvModal.show(this.modalId);
+    }
+
+    const allDonations = CartData.loadCart();
+
+    console.log('All donations: ', allDonations);
+  },
+  methods: {
+    close() {
+      this.$bvModal.hide(this.modalId);
+    },
+    handleHide() {
+      localStorage.removeItem('contributions_were_successful');
+      localStorage.removeItem('contributions_count');
+    },
+  },
+});
+
+/*
+TODO:
+  * Move close x out of header or otherwise get ride of the separator line
+  * Improve spacing around image
+  * Show based on the local storage data
+  * Show cart data from load cart
+  * Clear local storage after load
+  * Implement twitter share button action
+  * Implement save collection button (but how?)
+  * Research image generation
+*/
 
 // DOCUMENT
 let allTokens;
@@ -22,9 +66,9 @@ $(document).ready(function() {
     const message = `You have successfully funded ${numberOfContributions} ${grantWord}. Thank you for your contribution!`;
 
     _alert(message, 'success');
-    localStorage.removeItem('contributions_were_successful');
-    localStorage.removeItem('contributions_count');
-    $('#tweetModal').bootstrapModal('show');
+    // localStorage.removeItem('contributions_were_successful');
+    // localStorage.removeItem('contributions_count');
+    // $('#tweetModal').modal('show');
 
     const allDonations = CartData.loadCart();
     const ethereumDonations = allDonations.filter((grant) => grant.tenants[0] === 'ETH');
@@ -306,4 +350,14 @@ function toggleSideCart() {
   $('#side-cart').toggle();
   $('#side-cart').toggleClass('col-12 col-md-4 col-lg-3');
   $('#funding-card').toggleClass('mr-md-5 mr-md-3 d-none d-lg-block');
+}
+
+
+if (document.getElementById('grant-thanks-app')) {
+
+  const grantThanksApp = new Vue({
+    delimiters: [ '[[', ']]' ],
+    el: '#grant-thanks-app',
+    data: { }
+  });
 }

--- a/app/retail/templates/shared/grant_thanks_modal.html
+++ b/app/retail/templates/shared/grant_thanks_modal.html
@@ -16,7 +16,60 @@
 
 {% endcomment %}
 {% load i18n static %}
-    <div class="modal fade" id="tweetModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div id="grant-thanks-app" v-cloak>
+  <contribution-thanks-modal inline-template>
+    <b-modal id="contribution-thanks"
+      @hide="handleHide()"
+      size="lg"
+      center
+      hide-header
+      hide-footer>
+        <div class="mt-3 mb-5 mx-5">
+          <div class="mb-5 row justify-content-end">
+              <b-button @click="close()" type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
+                <span aria-hidden="true">&times;</span>
+              </b-button>
+          </div>
+          <div class="text-center">
+            <h3>Thank you for your contribution to open source!</h3>
+            <img class="w-25" src="{% static "v2/images/grants/torchbearer.svg" %}" />
+          </div>
+          <div class="my-4">
+            You've successfull contributed to [[numberOfContributions]] grants:
+          </div>
+          <hr />
+          <div>
+            <p>
+              First grant that is awesome <br />
+              10 DAI
+            </p>
+
+            <p>
+              Another awesome grant <br />
+              12 DAI
+            </p>
+
+            <p>
+              One more super cool grant <br />
+              12 DAI
+            </p>
+          </div>
+          <hr />
+          <div class="float-right mt-2 mb-4">
+            <b-button variant="light">Save as Collection</b-button>
+            <b-button variant="primary">
+              <i class="fab fa-twitter" aria-hidden="true"></i>
+              Share on Twitter
+            </b-button>
+          </div>
+        </div>
+    </b-modal>
+  </contribution-thanks-modal>
+</div>
+
+
+
+    <div class="modal" id="tweetModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-scrollable" role="document">
         <div class="modal-content">
           <div class="modal-header border-0">

--- a/app/retail/templates/shared/grant_thanks_modal.html
+++ b/app/retail/templates/shared/grant_thanks_modal.html
@@ -96,7 +96,13 @@
             <b-form-select v-model="selectedCollection" text-field="title" value-field="id" :options="collections" size="md" class="mt-3"></b-form-select>
           </div>
 
-          <b-button @click="createCollection()" class="btn-gc-blue mt-2 mb-2" size="lg" :disabled="!isValidCollection">Save Collection</b-button>
+          <b-button
+            @click="createCollection()"
+            variant="primary"
+            :disabled="!isValidCollection"
+          >
+            Save Collection
+          </b-button>
           <br>
         </div>
       </template>

--- a/app/retail/templates/shared/grant_thanks_modal.html
+++ b/app/retail/templates/shared/grant_thanks_modal.html
@@ -70,19 +70,13 @@
   </contribution-thanks-modal>
   <create-collection-modal inline-template>
     <b-modal id="create-collection" hide-header hide-footer>
-      <template v-slot:modal-header="{ close }">
-        <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          aria-label="Close"
-          @click=""
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </template>
       <template>
-        <div class="mx-5 my-5 ">
+        <div class="mt-3 mb-5 mx-5">
+          <div class="mb-5 row justify-content-end">
+            <b-button @click="close()" type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
+              <span aria-hidden="true">&times;</span>
+            </b-button>
+          </div>
           <div class="mb-3 text-center">
             <h1 class="mb-5 font-bigger-4 font-weight-bold">Save Cart as Collection</h1>
           </div>

--- a/app/retail/templates/shared/grant_thanks_modal.html
+++ b/app/retail/templates/shared/grant_thanks_modal.html
@@ -35,29 +35,32 @@
             <img class="w-25" src="{% static "v2/images/grants/torchbearer.svg" %}" />
           </div>
           <div class="my-4">
-            You've successfull contributed to [[numberOfContributions]] grants:
+            You've successfully contributed to [[numberOfContributions]] grants:
           </div>
           <hr />
           <div>
-            <p>
-              First grant that is awesome <br />
-              10 DAI
-            </p>
-
-            <p>
-              Another awesome grant <br />
-              12 DAI
-            </p>
-
-            <p>
-              One more super cool grant <br />
-              12 DAI
-            </p>
+            <template v-for="donation in donations">
+              <div class="my-3">
+                [[donation.grant_title]]<br />
+                [[donation.grant_donation_amount]] [[donation.grant_donation_currency]]
+                <span v-if="donation.grant_donation_clr_match > 0" class="text-success"> + [[donation.grant_donation_clr_match]] DAI matching</span>
+              </div>
+            </template>
           </div>
           <hr />
-          <div class="float-right mt-2 mb-4">
-            <b-button variant="light">Save as Collection</b-button>
-            <b-button variant="primary">
+          <div class="mt-2 mb-4 px-1 row justify-content-end">
+            <b-button
+              class="mt-2 mx-2 col-md-4 col-sm-12"
+              variant="outline-primary"
+              @click="showSaveAsCollection()"
+            >
+              Save as Collection
+            </b-button>
+            <b-button
+              class="mt-2 mx-2 col-md-4 col-sm-12"
+              variant="primary"
+              :href="tweetUrl"
+            >
               <i class="fab fa-twitter" aria-hidden="true"></i>
               Share on Twitter
             </b-button>
@@ -65,50 +68,44 @@
         </div>
     </b-modal>
   </contribution-thanks-modal>
-</div>
-
-
-
-    <div class="modal" id="tweetModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-scrollable" role="document">
-        <div class="modal-content">
-          <div class="modal-header border-0">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+  <create-collection-modal inline-template>
+    <b-modal id="create-collection" hide-header hide-footer>
+      <template v-slot:modal-header="{ close }">
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+          @click=""
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </template>
+      <template>
+        <div class="mx-5 my-5 ">
+          <div class="mb-3 text-center">
+            <h1 class="mb-5 font-bigger-4 font-weight-bold">Save Cart as Collection</h1>
           </div>
-          <div class="modal-body mt-4 mx-5 font-body">
-            <div class="row mb-1 justify-content-center">
-              {% if not fund_reward %}
-                <img class="icon w-75 h-75" src="{% static "v2/images/grants/torchbearer.svg" %}" />
-                <h5>Thanks for Contributing!</h5>
-                <span class="copy">{% trans "Tell your network about these Gitcoin Grants. If they fund a grant, the grant owner will get even more Matching Funds!" %}</span>
-              {% else %}
-                <img class="icon w-75 h-75" src="{{fund_reward.token.preview_img_url}}" />
-                <h5>Thanks for Contributing! You Earned a Kudos</h5>
-                <span>Have a <strong>{{fund_reward.token.ui_name}}</strong> Kudos on us.  When you click 'redeem kudos' your kudos will be transfered to your Ethereum wallet. </span>
-              {% endif %}
-            </div>
+          <div class="mb-3">
+            <p class="font-subheader">Collection Name.</p>
+            <b-form-input v-model="collectionTitle" placeholder="What would your collection be called?"></b-form-input>
           </div>
-          <div class="row mt-1 mb-4 justify-content-center">
-            {% if fund_reward %}
-              <a class="button button--primary" role="button" href="{{fund_reward.url}}?tweet=I just funded a grant on @gitcoin (https://{{ request.META.HTTP_HOST }}{% url 'grants:details' grant.id grant.slug %}) and got this sweet Kudos! => "
-                target="_blank" rel="noopener noreferrer" >
-                {% trans "Redeem Kudos" %} 🌈
-              </a> |
-            {% elif grant.id %}
-              <a class="button button--primary" role="button" href="https://twitter.com/intent/tweet?text=I just funded this grant on @gitcoin => https://{{ request.META.HTTP_HOST }}/{% url 'grants:details' grant.id grant.slug %}"
-                target="_blank" rel="noopener noreferrer" OnClick="ga('send', 'event', 'Tweet Button', 'click', 'Grant Funder')">
-                {% trans "Tweet About this Grant" %} 🐦
-              </a>
-            {% else %}
-              <a class="button button--primary" role="button"
-                href="/grants/new"
-                target="_blank" rel="noopener noreferrer" OnClick="ga('send', 'event', 'Fund New Grant', 'click', 'Grant Funder')">
-                {% trans "Fund a New Grant" %}
-              </a>
-            {% endif %}
+          <div class="mb-2">
+            <p class="font-subheader">Description (Optional)</p>
+            <b-form-textarea rows="3" max-rows="6" :state=" collectionDescription.length == 0 ? null : collectionDescription.length < 140" v-model="collectionDescription" placeholder="Short description about your collection"></b-form-textarea>
+            <p class="text-right">[[ collectionDescription.length ]]/140</p>
           </div>
+
+          <div class="mb-3" v v-if="collections.length">
+            <h2 class="middle-line mb-3"><span class="text-muted font-body">or</span></h2>
+            <p class="font-subheader mt-3 mb-0">Save to existing collection</p>
+            <b-form-select v-model="selectedCollection" text-field="title" value-field="id" :options="collections" size="md" class="mt-3"></b-form-select>
+          </div>
+
+          <b-button @click="createCollection()" class="btn-gc-blue mt-2 mb-2" size="lg" :disabled="!isValidCollection">Save Collection</b-button>
+          <br>
         </div>
-      </div>
-    </div>
+      </template>
+    </b-modal>
+  </create-collection-modal>
+</div>


### PR DESCRIPTION
Implements the redesigned "Thank You" modal after grants checkout, with one major limitation:

Currently the image on the modal is an old-school Gitcoin robot, left as a placeholder. The updated design calls for a collections-like image with four quandrants for grant images, plus the user's photo in the middle. However, since the user's cart is not yet a collection at this screen, I don't believe the endpoint for generating these images is set up for this use case. I was wondering if the GPG folks would have some thoughts on how to address this. Alternatively, we could use an updated static image for a version 1.

<img width="876" alt="Screen Shot 2021-02-22 at 4 49 51 PM" src="https://user-images.githubusercontent.com/1479802/108777657-2553de00-7532-11eb-92f5-91dba228a261.png">

<img width="427" alt="Screen Shot 2021-02-22 at 4 50 10 PM" src="https://user-images.githubusercontent.com/1479802/108777670-2b49bf00-7532-11eb-91f8-3546a5660913.png">

<img width="860" alt="Screen Shot 2021-02-22 at 4 58 53 PM" src="https://user-images.githubusercontent.com/1479802/108777711-3b619e80-7532-11eb-973d-1d5abe81a1be.png">

<img width="424" alt="Screen Shot 2021-02-22 at 4 59 08 PM" src="https://user-images.githubusercontent.com/1479802/108777722-40bee900-7532-11eb-8c06-6408016c171c.png">

