### PR TITLE
Fix pToken dashboard permissions

### DIFF
--- a/app/assets/v2/js/board.js
+++ b/app/assets/v2/js/board.js
@@ -710,6 +710,7 @@ if (document.getElementById('gc-board')) {
     el: '#gc-board',
     data: {
       network: document.web3network,
+      has_ptoken_auth: document.has_ptoken_auth,
       user_has_token: document.user_has_token,
       bounties: bounties,
       openBounties: [],

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4988,7 +4988,7 @@ def board(request):
     """Handle the board view."""
 
     user = request.user if request.user.is_authenticated else None
-    has_ptoken_auth = user.has_perm('auth.user.add_pToken_auth')
+    has_ptoken_auth = user.has_perm('auth.add_pToken_auth')
     keywords = user.profile.keywords
     ptoken = PersonalToken.objects.filter(token_owner_profile=user.profile).first()
 

--- a/app/ptokens/views.py
+++ b/app/ptokens/views.py
@@ -205,7 +205,7 @@ def ptoken(request, token_id='me'):
                 {'error': _('You must be authenticated via github to use this feature!')},
                 status=401)
 
-        if not user.has_perm('auth.user.add_pToken_auth'):
+        if not user.has_perm('auth.add_pToken_auth'):
             return JsonResponse(
                 {'error': _('You are not allowed to use this feature!')},
                 status=403)


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This updates the Vue context with the correct variable to toggle the create pToken modal as well as fixes the permissions check as the string used was incorrect.

##### Testing

Give a user staff role to view the pToken tab, then run the management command: `docker-compose exec web python3 app/manage.py setup_ptoken_launch`

Navigate to the users menu in the Django admin and add the user to the newly create pToken group along with the `add_pToken_auth` permission. 

<img width="911" alt="Screen Shot 2021-02-22 at 1 48 59 PM" src="https://user-images.githubusercontent.com/7246942/108785430-643c6080-753f-11eb-8383-33e1bb6f4136.png">
<img width="1653" alt="Screen Shot 2021-02-22 at 3 11 56 PM" src="https://user-images.githubusercontent.com/7246942/108785445-6acad800-753f-11eb-9eab-af7454a1afba.png">
