### PR TITLE
hotfix: grant_obj serialization in hackathon project

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -5254,7 +5254,18 @@ class HackathonProject(SuperModel):
             'paid': paid,
             'payment_date': date(submission.accepted_on, 'Y-m-d H:i') if paid else '',
             'winner': self.winner,
-            'grant_obj': self.grant_obj,
+            'grant_obj': {
+                'id': self.grant_obj.pk,
+                'title': self.grant_obj.title,
+                'logo': self.grant_obj.logo,
+                'logo_svg': self.grant_obj.logo_svg,
+                'description': self.grant_obj.description,
+                'description_rich': self.grant_obj.description_rich,
+                'reference_url': self.grant_obj.reference_url,
+                'github_project_url': self.grant_obj.github_project_url,
+                'region': self.grant_obj.region,
+                'grant_type': self.grant_obj.grant_type
+            },
             'extra': self.extra,
             'timestamp': submission.created_on.timestamp() if submission else 0
         }

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -5238,7 +5238,7 @@ class HackathonProject(SuperModel):
         if submission:
             paid = submission.payout_status == 'done'
 
-        return {
+        response = {
             'pk': self.pk,
             'name': self.name,
             'logo': self.logo.url if self.logo else '',
@@ -5254,21 +5254,23 @@ class HackathonProject(SuperModel):
             'paid': paid,
             'payment_date': date(submission.accepted_on, 'Y-m-d H:i') if paid else '',
             'winner': self.winner,
-            'grant_obj': {
-                'id': self.grant_obj.pk,
-                'title': self.grant_obj.title,
-                'logo': self.grant_obj.logo,
-                'logo_svg': self.grant_obj.logo_svg,
-                'description': self.grant_obj.description,
-                'description_rich': self.grant_obj.description_rich,
-                'reference_url': self.grant_obj.reference_url,
-                'github_project_url': self.grant_obj.github_project_url,
-                'region': self.grant_obj.region,
-                'grant_type': self.grant_obj.grant_type
-            },
+            'grant_obj': None,
             'extra': self.extra,
             'timestamp': submission.created_on.timestamp() if submission else 0
         }
+
+        if self.grant_obj:
+            response['grant_obj'] = {
+                'id': self.grant_obj.pk,
+                'title': self.grant_obj.title,
+                'description': self.grant_obj.description,
+                'reference_url': self.grant_obj.reference_url,
+                'github_project_url': self.grant_obj.github_project_url,
+                'region': self.grant_obj.region,
+                'grant_type': self.grant_obj.grant_type.label
+            }
+
+        return response
 
 
 class FeedbackEntry(SuperModel):


### PR DESCRIPTION
##### Description

this pr properly handles grant_obj field in `to_json` method for a hackathon project

which prevent lots of users from visiting binance sponsor dashboard.

##### Fixes

hackathon sponsor dashboard couldn't load because `/api/v1/hackathon/{hackathon}/prizes` was returning a 500 (`Object of type Grant is not JSON serializable`) caused by when `grant_obj` is linked for a hackathon project that was converted to a grant

##### Testing
https://www.loom.com/share/fbaea19094fe4b779ce371377dd97281

https://www.loom.com/share/c289762393314dc5b92632d813691046