### PR TITLE
hotfix: Fixes scss imported into emails/shared_template_head (will also fix the build and system emails sent from gitcoin)

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -197,35 +197,6 @@ TEMPLATES = [{
     },
 }]
 
-# Sass precompiler settings
-COMPRESS_PRECOMPILERS = (
-    ('text/x-scss', 'django_libsass.SassCompiler'),
-)
-STATICFILES_FINDERS = [
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder'
-]
-# number of demicals allowed in sass numbers
-LIBSASS_PRECISION = 8
-# minify sass output in production (offline)
-if ENV not in ['local', 'test', 'staging', 'preview']:
-    # compress offline (use './manage.py compress' to build manifest.json)
-    COMPRESS_OFFLINE = True
-    # Allow for the full path (url) to be included in the manifest
-    COMPRESS_INCLUDE_URLS = True
-    # Allow the placeholder insertion to be skipped
-    COMPRESS_SKIP_PLACEHOLDER = True
-    # use content based hashing so that we always match between servers
-    COMPRESS_CSS_HASHING_METHOD = 'content'
-    # minification of sass output
-    COMPRESS_CSS_FILTERS = [
-        'compressor.filters.css_default.CssAbsoluteFilter',
-        'compressor.filters.cssmin.rCSSMinFilter'
-    ]
-    # drop line comments
-    LIBSASS_SOURCE_COMMENTS = False
-
 SITE_ID = env.int('SITE_ID', default=1)
 WSGI_APPLICATION = env('WSGI_APPLICATION', default='app.wsgi.application')
 
@@ -453,6 +424,36 @@ else:
     # Handle local media file storage
     MEDIA_ROOT = root('media')
     MEDIA_URL = env('MEDIA_URL', default=f'/{MEDIAFILES_LOCATION}/')
+
+
+# Sass precompiler settings
+COMPRESS_PRECOMPILERS = (
+    ('text/x-scss', 'django_libsass.SassCompiler'),
+)
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder'
+]
+# number of demicals allowed in sass numbers
+LIBSASS_PRECISION = 8
+# minify sass output in production (offline)
+if ENV not in ['local', 'test', 'staging', 'preview']:
+    # compress offline (use './manage.py compress' to build manifest.json)
+    COMPRESS_OFFLINE = True
+    # Allow for the full path (url) to be included in the manifest
+    COMPRESS_INCLUDE_URLS = True
+    # Allow the placeholder insertion to be skipped
+    COMPRESS_SKIP_PLACEHOLDER = True
+    # use content based hashing so that we always match between servers
+    COMPRESS_CSS_HASHING_METHOD = 'content'
+    # minification of sass output
+    COMPRESS_CSS_FILTERS = [
+        'compressor.filters.css_default.CssAbsoluteFilter',
+        'compressor.filters.cssmin.rCSSMinFilter'
+    ]
+    # drop line comments
+    LIBSASS_SOURCE_COMMENTS = False
 
 COMPRESS_OUTPUT_DIR = "v2"
 COMPRESS_ROOT = STATIC_ROOT

--- a/app/assets/v2/scss/gitcoin.scss
+++ b/app/assets/v2/scss/gitcoin.scss
@@ -21,7 +21,7 @@ h4,
 .sticky-top {
   position: sticky!important;
   top: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 .lighter {
@@ -65,7 +65,7 @@ h4,
 }
 
 .header {
-  background-image: url('/static/v2/images/header-bg.png');
+  background-image: url(static('v2/images/header-bg.png'));
   background-color: #0d023b;
   background-size: cover;
   background-position: 0px 0px;
@@ -93,12 +93,12 @@ h4,
 }
 
 .header-contributor {
-  background-image: url('/static/v2/images/landing/contributor/hero_header_bg.jpg');
+  background-image: url(static('v2/images/landing/contributor/hero_header_bg.jpg'));
   background-color: #3f00ff;
 }
 
 .gitcoin-background {
-  background: url("/static/v2/images/header-bg.png") #0d023b;
+  background: url(static("v2/images/header-bg.png")) #0d023b;
   background-attachment: fixed;
   background-position: center 0;
 }
@@ -264,7 +264,7 @@ div.button-pink {
 
 .light-bg {
   background-color: rgba(239, 243, 238, 0.7);
-  background-image: url('/static/v2/images/light-bg.png');
+  background-image: url(static('/v2/images/light-bg.png'));
   background-size: contain;
   background-position: bottom;
   background-repeat: no-repeat;
@@ -281,7 +281,7 @@ div.button-pink {
 
 .white-light-bg {
   background-color: white;
-  background-image: url('/static/v2/images/light-bg.png');
+  background-image: url(static('v2/images/light-bg.png'));
   background-size: contain;
   background-position: bottom;
   background-repeat: no-repeat;

--- a/app/assets/v2/scss/town_square.scss
+++ b/app/assets/v2/scss/town_square.scss
@@ -415,195 +415,195 @@ a.offer_container.animate:hover .prize-gift::after {
 }
 div.back0,
 body.back0 {
-  background: url('/static/v2/images/quests/backs/0.gif') repeat;
+  background: url(static('v2/images/quests/backs/0.gif')) repeat;
   background-size: 150%;
 }
 
 div.back1,
 body.back1 {
-  background: url('/static/v2/images/quests/backs/back1.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back1.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back2,
 body.back2 {
-  background: url('/static/v2/images/quests/backs/back2.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back2.jpeg')) repeat;
   background-size: 170%;
 }
 
 div.back3,
 body.back3 {
-  background: url('/static/v2/images/quests/backs/back3.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back3.jpeg')) repeat;
   background-size: 160%;
 }
 
 div.back4,
 body.back4 {
-  background: url('/static/v2/images/quests/backs/back4.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back4.jpeg')) repeat;
   background-size: 160%;
 }
 
 div.back5,
 body.back5 {
-  background: url('/static/v2/images/quests/backs/back5.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back5.jpeg')) repeat;
   background-size: 160%;
 }
 
 div.back6,
 body.back6 {
-  background: url('/static/v2/images/quests/backs/back6.jpg') repeat;
+  background: url(static('v2/images/quests/backs/back6.jpg')) repeat;
   background-size: 110%;
 }
 
 div.back7,
 body.back7 {
-  background: url('/static/v2/images/quests/backs/back7.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back7.jpeg')) repeat;
   background-size: 110%;
 }
 
 div.back8,
 body.back8 {
-  background: url('/static/v2/images/quests/backs/back8.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back8.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back9,
 body.back9 {
-  background: url('/static/v2/images/quests/backs/back9.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back9.jpeg')) repeat;
   background-size: 110%;
 }
 
 div.back10,
 body.back10 {
-  background: url('/static/v2/images/quests/backs/back10.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back10.jpeg')) repeat;
   background-size: 120%;
 }
 
 div.back11,
 body.back11 {
-  background: url('/static/v2/images/quests/backs/back11.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back11.jpeg')) repeat;
   background-size: 105%;
 }
 
 div.back12,
 body.back12 {
-  background: url('/static/v2/images/quests/backs/back12.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back12.jpeg')) repeat;
   background-size: 120%;
 }
 
 div.back13,
 body.back13 {
-  background: url('/static/v2/images/quests/backs/back13.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back13.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back14,
 body.back14 {
-  background: url('/static/v2/images/quests/backs/back14.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back14.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back15,
 body.back15 {
-  background: url('/static/v2/images/quests/backs/back15.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back15.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back16,
 body.back16 {
-  background: url('/static/v2/images/quests/backs/back16.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back16.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back19,
 body.back19 {
-  background: url('/static/v2/images/quests/backs/back19.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back19.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back17,
 body.back17 {
-  background: url('/static/v2/images/quests/backs/back17.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back17.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back18,
 body.back18 {
-  background: url('/static/v2/images/quests/backs/back18.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back18.jpeg')) repeat;
   background-size: 100%;
 }
 
 div.back20,
 body.back20 {
-  background: url('/static/v2/images/quests/backs/back20.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back20.jpeg')) repeat;
   background-size: 120%;
 }
 
 div.back21,
 body.back21 {
-  background: url('/static/v2/images/quests/backs/back21.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back21.jpeg')) repeat;
   background-size: 120%;
 }
 
 div.back22,
 body.back22 {
-  background: url('/static/v2/images/quests/backs/back22.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back22.jpeg')) repeat;
   background-size: 120%;
 }
 
 div.back23,
 body.back23 {
-  background: url('/static/v2/images/quests/backs/back23.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back23.jpeg')) repeat;
   background-size: 120%;
 }
 div.back24,
 body.back24 {
-  background: url('/static/v2/images/quests/backs/back24.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back24.jpeg')) repeat;
   background-size: 120%;
 }
 div.back25,
 body.back25 {
-  background: url('/static/v2/images/quests/backs/back25.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back25.jpeg')) repeat;
   background-size: 120%;
 }
 div.back26,
 body.back26 {
-  background: url('/static/v2/images/quests/backs/back26.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back26.jpeg')) repeat;
   background-size: 120%;
 }
 div.back27,
 body.back27 {
-  background: url('/static/v2/images/quests/backs/back27.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back27.jpeg')) repeat;
   background-size: 120%;
 }
 div.back28,
 body.back28 {
-  background: url('/static/v2/images/quests/backs/back28.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back28.jpeg')) repeat;
   background-size: 120%;
 }
 div.back29,
 body.back29 {
-  background: url('/static/v2/images/quests/backs/back29.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back29.jpeg')) repeat;
   background-size: 120%;
 }
 div.back30,
 body.back30 {
-  background: url('/static/v2/images/quests/backs/back30.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back30.jpeg')) repeat;
   background-size: 120%;
 }
 div.back31,
 body.back31 {
-  background: url('/static/v2/images/quests/backs/back31.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back31.jpeg')) repeat;
   background-size: 120%;
 }
 div.back32,
 body.back32 {
-  background: url('/static/v2/images/quests/backs/back32.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back32.jpeg')) repeat;
   background-size: 120%;
 }
 div.back33,
 body.back33 {
-  background: url('/static/v2/images/quests/backs/back33.jpeg') repeat;
+  background: url(static('v2/images/quests/backs/back33.jpeg')) repeat;
   background-size: 120%;
 }
 
@@ -1035,7 +1035,7 @@ body.green.offer_view .announce {
 }
 
 .promo {
-  background-image: url("/static/v2/images/tribes/promo-decoration.svg");
+  background-image: url(static('v2/images/tribes/promo-decoration.svg'));
   background-color: var(--gc-blue);
   background-size: cover;
 }
@@ -1081,7 +1081,7 @@ body.green.offer_view .announce {
 }
 
 .get-started {
-  background-image: url(/static/v2/images/tribe-notce.svg);
+  background-image: url(static('v2/images/tribe-notce.svg'));
   background-color: var(--gc-blue);
   font-style: normal;
   font-weight: normal;
@@ -1116,7 +1116,7 @@ body.green.offer_view .announce {
 
 #modal-get-started {
   background-color: rgba(62, 0, 255, 0.7);
-  background-image: url(/static/v2/images/modal-bg.svg);
+  background-image: url(static('v2/images/modal-bg.svg'));
   background-size: contain;
   background-repeat: no-repeat;
   background-position: right;
@@ -1260,7 +1260,7 @@ body.green.offer_view .announce {
 .activity.hackathon_new_hacker #profile-avatar-link::after {
   height: 6.1rem;
   content: '';
-  background-image: url(/static/v2/images/townsquare-nh.svg);
+  background-image: url(static('v2/images/townsquare-nh.svg'));
   width: 6.1rem;
   position: absolute;
   top: -1.5rem;

--- a/app/retail/templates/emails/shared_template_head.html
+++ b/app/retail/templates/emails/shared_template_head.html
@@ -15,8 +15,7 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static compress %}
-{% compress css file email_head %}
-  <!-- updated to the shared version -->
+{% compress css inline email_head %}
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/gitcoin.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/town_square.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/activity_stream.scss" %} />

--- a/app/retail/templates/shared/head.html
+++ b/app/retail/templates/shared/head.html
@@ -23,9 +23,9 @@
 
 {% compress css file libs %}
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/lib/index.scss" %} />
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/search.scss" %}>
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/lib/typography.scss" %}>
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/fontawesome-all.min.scss" %}>
+  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/search.scss" %} />
+  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/lib/typography.scss" %} />
+  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/fontawesome-all.min.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/gitcoin.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/top-nav.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/base.scss" %} />


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This will fix the email's shared template head: 
1. We changed the Compress tags from `inline` to `file` so that we could get the `compress` command to complete, this reverses that
2. Replaces `url('...')` with `url(static('...'))` so that static paths are more clearly defined in the scss sheets
3. There are also several `OfflineGenerationError` errors flowing into sentry that this will fix (we should merge asap because emails will be failing until this is deployed)
3. Depends on: https://github.com/gdixon/django-compressor/commit/c98be36a49471efb004f6aced50c6d9c3916b002
##### Refers/Fixes

Commit: 845a5d43708bc8d1a7a658d8435d0a30ca402b6d
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally with development and production .envs