### PR TITLE
Adds commit hash to the 'manifest.json' making manifest generation deploy specific

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import json
 import os
 import socket
+import subprocess
 
 from django.utils.translation import gettext_noop
 
@@ -439,11 +440,15 @@ STATICFILES_FINDERS = [
 LIBSASS_PRECISION = 8
 # minify sass output in production (offline)
 if ENV not in ['local', 'test', 'staging', 'preview']:
-    # compress offline (use './manage.py compress' to build manifest.json)
+    # get current commit hash to feed into the manifest's name
+    commit = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
+    # compress offline (use './manage.py compress' to build manifest.*.json)
     COMPRESS_OFFLINE = True
-    # Allow for the full path (url) to be included in the manifest
+    # make manifest deploy specific (new manifest for each deployment)
+    COMPRESS_OFFLINE_MANIFEST = 'manifest.' + commit.decode('utf8') + '.json'
+    # allow for the full path (url) to be included in the manifest
     COMPRESS_INCLUDE_URLS = True
-    # Allow the placeholder insertion to be skipped
+    # allow the placeholder insertion to be skipped
     COMPRESS_SKIP_PLACEHOLDER = True
     # use content based hashing so that we always match between servers
     COMPRESS_CSS_HASHING_METHOD = 'content'


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Adds the HEAD commit hash to the manifest filename so that for each deployment we generate a new manifest.*.json file, allowing the old version to carry on serving files whilst the deployment finishes (avoiding OfflineGenerationError's).

Depends on updates to -> https://github.com/gdixon/django-compressor/commit/97cf285af96110da88810f5e19b3809ef748a322
<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Refers: #8368

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally (with production .env variables)
