### PR TITLE
record proper usd value of a bounty fulfillment

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1476,6 +1476,55 @@ class BountyFulfillment(SuperModel):
         """
         return f'BountyFulfillment ID: ({self.pk}) - Bounty ID: ({self.bounty.pk})'
 
+    @property
+    def get_value_in_usdt_now(self):
+        return self.value_in_usdt_at_time(None)
+
+    @property
+    def get_value_in_usdt(self):
+        if self.status in self.OPEN_STATUSES:
+            return self.value_in_usdt_now
+        return self.value_in_usdt_then
+
+    @property
+    def value_in_usdt_then(self):
+        return self.value_in_usdt_at_time(self.created_on)
+
+    # TODO: DRY
+    def get_natural_value(self):
+        token = token_by_name(self.token_name)
+        decimals = token['decimals']
+        amount = self.payout_amount if self.payout_amount else 0
+        return float(amount) / 10**decimals
+
+    @property
+    def value_true(self):
+        return self.get_natural_value()
+
+
+    def value_in_usdt_at_time(self, at_time):
+        decimals = 10 ** 18
+        if self.token_name in ['USDT', 'USDC']:
+            return float(self.payout_amount / 10 ** 6)
+        if self.token_name in settings.STABLE_COINS:
+            return float(self.payout_amount / 10 ** 18)
+        try:
+            return round(float(convert_amount(self.value_true, self.token_name, 'USDT', at_time)), 2)
+        except ConversionRateNotFoundError:
+            try:
+                in_eth = round(float(convert_amount(self.value_true, self.token_name, 'ETH', at_time)), 2)
+                return round(float(convert_amount(in_eth, 'USDT', 'USDT', at_time)), 2)
+            except ConversionRateNotFoundError:
+                return None
+
+    @property
+    def token_value_in_usdt_now(self):
+        if self.token_name in settings.STABLE_COINS:
+            return 1
+        try:
+            return round(convert_token_to_usdt(self.token_name), 2)
+        except ConversionRateNotFoundError:
+            return None
 
     @property
     def fulfiller_email(self):
@@ -2056,7 +2105,7 @@ def psave_bounty_fulfilll(sender, instance, **kwargs):
                 "org_profile":instance.bounty.org_profile,
                 "from_profile":instance.bounty.bounty_owner_profile,
                 "to_profile":instance.profile,
-                "value_usd":instance.bounty.value_in_usdt_then,
+                "value_usd":instance.value_in_usdt_then,
                 "url":instance.bounty.url,
                 "network":instance.bounty.network,
                 "txid": instance.payout_tx_id,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
https://gitcoin.co/nance2uiuc

that user paid out a $60k bounty, to 20 diff users.  and instead of giving credit to the user for one $60k bounty the system did it 20 times.

this PR fixes that by taking the bounty fulfillment amount + creating the earning from that.

but this PR is blocked from being truly useful by the fact that bountyfulfillment.payout_amount is null for most objects in production ( https://github.com/gitcoinco/web/issues/8486 )

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
see above

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
tested locally