### PR TITLE
adds loading indicator to grants

### DIFF
--- a/app/grants/templates/grants/detail/_index.html
+++ b/app/grants/templates/grants/detail/_index.html
@@ -60,6 +60,9 @@
               </b-col>
             </b-row>
             <b-container>
+              <b-row>
+                <img src="/static/v2/images/loading_v2.gif" style="max-width: 200px; max-height: 200px; margin: -300px auto 0px;">
+              </b-row>
 
               <b-row>
                 <b-col cols="7">


### PR DESCRIPTION
adds a dynamic loading indicator to grants loading page, so user gets a sense that a grant is loading

<img width="549" alt="Screen Shot 2021-03-05 at 4 57 19 PM" src="https://user-images.githubusercontent.com/513929/110186958-0a0b8d00-7dd4-11eb-81e0-87674e74d207.png">
<img width="1758" alt="Screen Shot 2021-03-05 at 4 57 12 PM" src="https://user-images.githubusercontent.com/513929/110186962-0aa42380-7dd4-11eb-98f9-c8f3f8da2951.png">
