### PR TITLE
Start improving missing contribution page

### DIFF
--- a/app/grants/templates/grants/ingest-contributions.html
+++ b/app/grants/templates/grants/ingest-contributions.html
@@ -65,6 +65,7 @@
               <div class="col-12 mb-3">
                 <p class="font-body mb-1">
                   <ul>
+                    <li>Make sure your wallet is connected to mainnet with the same address you used to checkout</li>
                     <li>If you donated using L1 (Standard Checkout), please enter the transaction hash</li>
                     <li>If you donated using L2 (zkSync Checkout), please enter your wallet address</li>
                     <li>At least one of these two is required</li>

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -68,6 +68,7 @@ from dashboard.tasks import increment_view_count
 from dashboard.utils import get_web3, has_tx_mined
 from economy.models import Token as FTokens
 from economy.utils import convert_amount, convert_token_to_usdt
+from eth_account.messages import defunct_hash_message
 from gas.utils import conf_time_spread, eth_usd_conv_rate, gas_advisories, recommend_min_gas_price_to_confirm_in_time
 from grants.models import (
     CartActivity, Contribution, Flag, Grant, GrantAPIKey, GrantBrandingRoutingPolicy, GrantCategory, GrantCLR,
@@ -3397,8 +3398,27 @@ def ingest_contributions(request):
     profile = request.user.profile
     txHash = request.POST.get('txHash')
     userAddress = request.POST.get('userAddress')
+    signature = request.POST.get('signature')
+    message = request.POST.get('message')
     network = request.POST.get('network')
     ingestion_types = [] # after each series of ingestion, we append the ingestion_method to this array
+
+    # Setup web3
+    PROVIDER = f"wss://{network}.infura.io/ws/v3/{settings.INFURA_V3_PROJECT_ID}"
+    w3 = Web3(Web3.WebsocketProvider(PROVIDER))
+
+    def verify_signature(signature, message, expected_address):
+        message_hash = defunct_hash_message(text=message)
+        recovered_address = w3.eth.account.recoverHash(message_hash, signature=signature)
+        if recovered_address.lower() != expected_address.lower():
+            raise Exception("Signature could not be verified")
+
+    if txHash != '':
+        receipt = w3.eth.getTransactionReceipt(txHash)
+        from_address = receipt['from']
+        verify_signature(signature, message, from_address)
+    if userAddress != '':
+        verify_signature(signature, message, userAddress)
 
     def get_token(w3, network, address):
         if (address == '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'):

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -3404,8 +3404,7 @@ def ingest_contributions(request):
     ingestion_types = [] # after each series of ingestion, we append the ingestion_method to this array
 
     # Setup web3
-    PROVIDER = f"wss://{network}.infura.io/ws/v3/{settings.INFURA_V3_PROJECT_ID}"
-    w3 = Web3(Web3.WebsocketProvider(PROVIDER))
+    w3 = get_web3(network)
 
     def verify_signature(signature, message, expected_address):
         message_hash = defunct_hash_message(text=message)


### PR DESCRIPTION
- Frontend verifies that connected wallet address matches form inputs
- Frontend asks for a signature and passes that data to backend
- Backend verifies address recovered from signature matches user address

I *think* this should work, but before merging needs more testing first against a mainnet token list. The reason is because web3py does not let you recover addresses from PoA networks like Rinkeby and it throws with:

`web3.exceptions.ValidationError: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('0xd883010918846765746888676f312e31352e35856c696e757800000000000000c4f6ccfbbfd37487321a523acfb0d11475512cb299470d2991199c781e5594e80349e828106f55eb2f2a7734b377050624ea517aba9f55178d9fcd1165d9f31000')`

So to verify this works:
- Visit https://localhost:8000/grants/add-missing-contributions
- Connect wallet to mainnet and make sure your DB has the mainnet token list
- Try both options and make sure ingestion succeeds