### PR TITLE
Reverts inline .scss block to inline .css block

### DIFF
--- a/app/retail/templates/emails/shared_template_head.html
+++ b/app/retail/templates/emails/shared_template_head.html
@@ -14,10 +14,12 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load i18n static compress %}
-{% compress css inline email_head %}
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/gitcoin.scss" %} />
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/town_square.scss" %} />
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/activity_stream.scss" %} />
-{% endcompress %}
+{% load i18n static %}
+
+<style>
+  {% include './assets/css/gitcoin.css' %}
+  {% include './assets/css/town_square.css' %}
+  {% include './assets/css/activity_stream.css' %}
+</style>
+
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap" rel="stylesheet" data-premailer="ignore">


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->


This PR reverts .scss changes made in commit 4763718c325b31390f4d4e21d770597c7e42120b.

We made these changes because the css being used in `shared_template_head.html` is duplicated from the core app's css - in order to DRY up the codebase, we wanted to use a single source of truth, unfortunately django-compressor is failing to inline the .scss block in production. 

We will readdress this in the future, the path forward will likely be:

- assess what css is being used by the emails
- refactor and bring just that css into a single new css document and inline that instead of the 3 .css documents we are currently inlining
- rename that new document `email_head.css` so that there is no ambiguity as to what the file is. 

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Fixes: 4763718c325b31390f4d4e21d770597c7e42120b

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally
