### PR TITLE
Checkout falls back to manual ingestion if regular ingestion fails

### DIFF
--- a/app/assets/v2/js/cart-ethereum-zksync.js
+++ b/app/assets/v2/js/cart-ethereum-zksync.js
@@ -222,7 +222,7 @@ Vue.component('grantsCartEthereumZksync', {
 
         // Save off cart data
         this.zksync.checkoutStatus = 'pending';
-        await appCart.$refs.cart.manageEthereumCartJSONStore(this.user.address, 'save');
+        // await appCart.$refs.cart.manageEthereumCartJSONStore(this.user.address, 'save');
 
         // Send user to zkSync to complete checkout
         const txHashes = await this.zksync.checkoutManager.zkSyncBatchCheckout(

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -928,133 +928,207 @@ Vue.component('grants-cart', {
         });
     },
 
-    // POSTs donation data to database
+    // POSTs donation data to database. Wrapped in a try/catch, and if it fails, we fallback to the manual ingestion script
     async postToDatabase(txHash, contractAddress, userAddress) {
-      // this.grantsByTenant is the array used for donations
-      // We loop through each donation to configure the payload then POST the required data
-      const donations = this.donationInputs;
-      const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+      try {
+        // this.grantsByTenant is the array used for donations
+        // We loop through each donation to configure the payload then POST the required data
+        const donations = this.donationInputs;
+        const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
-      // If txHash has a length of one, stretch it so there's one hash for each donation
-      let txHashes = txHash;
+        // If txHash has a length of one, stretch it so there's one hash for each donation
+        let txHashes = txHash;
 
-      if (txHash.length === 1) {
-        txHashes = new Array(donations.length).fill(txHash[0]);
+        if (txHash.length === 1) {
+          txHashes = new Array(donations.length).fill(txHash[0]);
+        }
+
+        // TODO update celery task to manage this so we can remove these two server requests
+        // Update the JSON store with the transaction hashes. We append a timestamp to ensure it
+        // doesn't get overwritten by a subsequent checkout
+        await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save', txHashes);
+        // Once that's done, we can delete the old JSON store
+        await this.manageEthereumCartJSONStore(userAddress, 'delete');
+
+        // All transactions are the same type, so if any hash begins with `sync-tx:` we know it's
+        // a zkSync checkout
+        const checkout_type = txHashes[0].startsWith('sync') ? 'eth_zksync' : 'eth_std';
+
+        // Configure template payload
+        const saveSubscriptionPayload = {
+          // Values that are constant for all donations
+          checkout_type,
+          contributor_address: userAddress,
+          csrfmiddlewaretoken,
+          frequency_count: 1,
+          frequency_unit: 'rounds',
+          gas_price: 0,
+          gitcoin_donation_address: gitcoinAddress,
+          hide_wallet_address: this.hideWalletAddress,
+          anonymize_gitcoin_grants_contributions: false,
+          include_for_clr: this.include_for_clr,
+          match_direction: '+',
+          network: document.web3network,
+          num_periods: 1,
+          real_period_seconds: 0,
+          recurring_or_not: 'once',
+          signature: 'onetime',
+          splitter_contract_address: contractAddress,
+          subscription_hash: 'onetime',
+          // Values that vary by donation
+          'gitcoin-grant-input-amount': [],
+          admin_address: [],
+          amount_per_period: [],
+          comment: [],
+          confirmed: [],
+          contract_address: [],
+          contract_version: [],
+          denomination: [],
+          grant_id: [],
+          split_tx_id: [], // Bulk donation hash for L1, or specific hash for L2
+          sub_new_approve_tx_id: [],
+          token_address: [],
+          token_symbol: []
+        };
+
+        for (let i = 0; i < donations.length; i += 1) {
+          // Get URL to POST to
+          const donation = donations[i];
+          const grantId = donation.grant.grant_id;
+
+          // Get token information
+          const tokenName = donation.grant.grant_donation_currency;
+          const tokenDetails = this.getTokenByName(tokenName);
+
+          // Gitcoin uses the zero address to represent ETH, but the contract does not. Therefore we
+          // get the value of denomination and token_address using the below logic instead of
+          // using tokenDetails.addr
+          const isEth = tokenName === 'ETH';
+          const tokenAddress = isEth ? '0x0000000000000000000000000000000000000000' : tokenDetails.addr;
+
+          // Replace undefined comments with empty strings
+          const comment = donation.grant.grant_comments === undefined ? '' : donation.grant.grant_comments;
+
+          // For automatic contributions to Gitcoin, set 'gitcoin-grant-input-amount' to 100.
+          // Why 100? Because likely no one will ever use 100% or a normal grant, so using
+          // 100 makes it easier to search the DB to find which Gitcoin donations were automatic
+          const isAutomatic = donation.grant.isAutomatic;
+          const gitcoinGrantInputAmt = isAutomatic ? 100 : Number(this.gitcoinFactorRaw);
+
+          // Add the donation parameters
+          saveSubscriptionPayload.admin_address.push(donation.grant.grant_admin_address);
+          saveSubscriptionPayload.amount_per_period.push(Number(donation.grant.grant_donation_amount));
+          saveSubscriptionPayload.comment.push(comment);
+          saveSubscriptionPayload.confirmed.push(false);
+          saveSubscriptionPayload.contract_address.push(donation.grant.grant_contract_address);
+          saveSubscriptionPayload.contract_version.push(donation.grant.grant_contract_version);
+          saveSubscriptionPayload.denomination.push(tokenAddress);
+          saveSubscriptionPayload['gitcoin-grant-input-amount'].push(gitcoinGrantInputAmt);
+          saveSubscriptionPayload.grant_id.push(grantId);
+          saveSubscriptionPayload.split_tx_id.push(txHashes[i]);
+          saveSubscriptionPayload.sub_new_approve_tx_id.push(donation.tokenApprovalTxHash);
+          saveSubscriptionPayload.token_address.push(tokenAddress);
+          saveSubscriptionPayload.token_symbol.push(tokenName);
+        } // end for each donation
+
+        // to allow , within comments
+        saveSubscriptionPayload.comment = saveSubscriptionPayload.comment.join('_,_');
+
+        // Configure request parameters
+        const url = '/grants/bulk-fund';
+        const headers = {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+        };
+        const saveSubscriptionParams = {
+          method: 'POST',
+          headers,
+          body: new URLSearchParams(saveSubscriptionPayload)
+        };
+
+        // Send saveSubscription request
+        const res = await fetch(url, saveSubscriptionParams);
+        const json = await res.json();
+
+        // if (json.failures.length > 0) {
+        //   // Something went wrong, so we create a backup of the users cart
+        //   await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save');
+        // }
+
+        // // Clear JSON Store
+        // await this.manageEthereumCartJSONStore(userAddress, 'delete');
+      } catch (err) {
+        // Something went wrong, so we use the manual ingestion process instead
+        console.error(err);
+        console.log('Standard contribution ingestion failed, falling back to manual ingestion');
+        await this.postToDatabaseManualIngestion(txHash, userAddress);
       }
+    },
 
-      // TODO update celery task to manage this so we can remove these two server requests
-      // Update the JSON store with the transaction hashes. We append a timestamp to ensure it
-      // doesn't get overwritten by a subsequent checkout
-      await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save', txHashes);
-      // Once that's done, we can delete the old JSON store
-      await this.manageEthereumCartJSONStore(userAddress, 'delete');
+    // Alternative to postToDatabase that uses the manual ingestion process
+    async postToDatabaseManualIngestion(txHash, userAddress) {
+      // Determine if this was a zkSync checkout or standard L1 checkout. For this endpoint, we pass a txHash
+      // to ingest L1 contributions or an address to pass L2 contributions
+      const checkout_type = txHash[0].startsWith('sync') ? 'eth_zksync' : 'eth_std';
+      
+      txHash = checkout_type === 'eth_std' ? txHash[0] : ''; // txHash is always an array of hashes from checkout
+      userAddress = checkout_type === 'eth_zksync' ? userAddress : '';
 
-      // All transactions are the same type, so if any hash begins with `sync-tx:` we know it's
-      // a zkSync checkout
-      const checkout_type = txHashes[0].startsWith('sync') ? 'eth_zksync' : 'eth_std';
-
-      // Configure template payload
-      const saveSubscriptionPayload = {
-        // Values that are constant for all donations
-        checkout_type,
-        contributor_address: userAddress,
-        csrfmiddlewaretoken,
-        frequency_count: 1,
-        frequency_unit: 'rounds',
-        gas_price: 0,
-        gitcoin_donation_address: gitcoinAddress,
-        hide_wallet_address: this.hideWalletAddress,
-        anonymize_gitcoin_grants_contributions: false,
-        include_for_clr: this.include_for_clr,
-        match_direction: '+',
-        network: document.web3network,
-        num_periods: 1,
-        real_period_seconds: 0,
-        recurring_or_not: 'once',
-        signature: 'onetime',
-        splitter_contract_address: contractAddress,
-        subscription_hash: 'onetime',
-        // Values that vary by donation
-        'gitcoin-grant-input-amount': [],
-        admin_address: [],
-        amount_per_period: [],
-        comment: [],
-        confirmed: [],
-        contract_address: [],
-        contract_version: [],
-        denomination: [],
-        grant_id: [],
-        split_tx_id: [], // Bulk donation hash for L1, or specific hash for L2
-        sub_new_approve_tx_id: [],
-        token_address: [],
-        token_symbol: []
-      };
-
-      for (let i = 0; i < donations.length; i += 1) {
-        // Get URL to POST to
-        const donation = donations[i];
-        const grantId = donation.grant.grant_id;
-
-        // Get token information
-        const tokenName = donation.grant.grant_donation_currency;
-        const tokenDetails = this.getTokenByName(tokenName);
-
-        // Gitcoin uses the zero address to represent ETH, but the contract does not. Therefore we
-        // get the value of denomination and token_address using the below logic instead of
-        // using tokenDetails.addr
-        const isEth = tokenName === 'ETH';
-        const tokenAddress = isEth ? '0x0000000000000000000000000000000000000000' : tokenDetails.addr;
-
-        // Replace undefined comments with empty strings
-        const comment = donation.grant.grant_comments === undefined ? '' : donation.grant.grant_comments;
-
-        // For automatic contributions to Gitcoin, set 'gitcoin-grant-input-amount' to 100.
-        // Why 100? Because likely no one will ever use 100% or a normal grant, so using
-        // 100 makes it easier to search the DB to find which Gitcoin donations were automatic
-        const isAutomatic = donation.grant.isAutomatic;
-        const gitcoinGrantInputAmt = isAutomatic ? 100 : Number(this.gitcoinFactorRaw);
-
-        // Add the donation parameters
-        saveSubscriptionPayload.admin_address.push(donation.grant.grant_admin_address);
-        saveSubscriptionPayload.amount_per_period.push(Number(donation.grant.grant_donation_amount));
-        saveSubscriptionPayload.comment.push(comment);
-        saveSubscriptionPayload.confirmed.push(false);
-        saveSubscriptionPayload.contract_address.push(donation.grant.grant_contract_address);
-        saveSubscriptionPayload.contract_version.push(donation.grant.grant_contract_version);
-        saveSubscriptionPayload.denomination.push(tokenAddress);
-        saveSubscriptionPayload['gitcoin-grant-input-amount'].push(gitcoinGrantInputAmt);
-        saveSubscriptionPayload.grant_id.push(grantId);
-        saveSubscriptionPayload.split_tx_id.push(txHashes[i]);
-        saveSubscriptionPayload.sub_new_approve_tx_id.push(donation.tokenApprovalTxHash);
-        saveSubscriptionPayload.token_address.push(tokenAddress);
-        saveSubscriptionPayload.token_symbol.push(tokenName);
-      } // end for each donation
-
-      // to allow , within comments
-      saveSubscriptionPayload.comment = saveSubscriptionPayload.comment.join('_,_');
-
-      // Configure request parameters
-      const url = '/grants/bulk-fund';
-      const headers = {
-        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-      };
-      const saveSubscriptionParams = {
-        method: 'POST',
-        headers,
-        body: new URLSearchParams(saveSubscriptionPayload)
-      };
+      // Get user's signature to prevent ingesting arbitrary transactions under your own username, then ingest
+      const { signature, message } = await this.signMessage(userAddress);
+      const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+      const url = '/grants/ingest';
+      const headers = { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' };
+      const network = document.web3network || 'mainnet';
+      const payload = { csrfmiddlewaretoken, txHash, userAddress, signature, message, network };
+      const postParams = { method: 'POST', headers, body: new URLSearchParams(payload) };
+      let json; // response
 
       // Send saveSubscription request
-      const res = await fetch(url, saveSubscriptionParams);
-      const json = await res.json();
+      try {
+        _alert('Please be patient, as manual ingestion may take 1-2 minutes', 'info', '3000');
+        const res = await fetch(url, postParams);
 
-      // if (json.failures.length > 0) {
-      //   // Something went wrong, so we create a backup of the users cart
-      //   await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save');
-      // }
+        json = await res.json();
+        console.log('ingestion response: ', json);
+        if (!json.success) {
+          console.log('ingestion failed');
+          throw new Error(`Your transactions could not be processed. Please visit ${window.location.host}/grants/add-missing-contributions to ensure your contributions are counted`);
+        }
+      } catch (err) {
+        console.error(err);
+        const message = `Your contribution was successful, but was not recognized by our database. Please visit ${window.location.host}/grants/add-missing-contributions to ensure your contributions are counted`;
+        
+        _alert(message, 'error');
+        throw new Error(message);
+      }
+    },
 
-      // // Clear JSON Store
-      // await this.manageEthereumCartJSONStore(userAddress, 'delete');
+    // Asks user to sign a message as verification they own the provided address
+    async signMessage(userAddress) {
+      const baseMessage = 'Something went wrong, but we want to ensure your contributions are counted!\n\nSign this message as verification that you control the provided wallet address so we can process your contributions'; // base message that will be signed
+      const ethersProvider = new ethers.providers.Web3Provider(provider); // ethers provider instance
+      const signer = ethersProvider.getSigner(); // ethers signers
+      const { chainId } = await ethersProvider.getNetwork(); // append chain ID if not mainnet to mitigate replay attack
+      const message = chainId === 1 ? baseMessage : `${baseMessage}\n\nChain ID: ${chainId}`;
+
+      // Get signature from user
+      const isValidSignature = (sig) => ethers.utils.isHexString(sig) && sig.length === 132; // used to verify signature
+      let signature = await signer.signMessage(message); // prompt to user is here, uses eth_sign
+
+      // Fallback to personal_sign if eth_sign isn't supported (e.g. for Status and other wallets)
+      if (!isValidSignature(signature)) {
+        signature = await ethersProvider.send(
+          'personal_sign',
+          [ ethers.utils.hexlify(ethers.utils.toUtf8Bytes(message)), userAddress.toLowerCase() ]
+        );
+      }
+
+      // Verify signature
+      if (!isValidSignature(signature)) {
+        throw new Error(`Invalid signature: ${signature}`);
+      }
+
+      return { signature, message };
     },
 
     /**
@@ -1196,7 +1270,6 @@ Vue.component('grants-cart', {
           };
         });
       }
-
 
       // Send request
       const payload = {

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -907,8 +907,8 @@ Vue.component('grants-cart', {
       const bulkTransaction = new web3.eth.Contract(bulkCheckoutAbi, bulkCheckoutAddress);
       const donationInputsFiltered = this.getDonationInputs();
 
-      // Save off cart data
-      await this.manageEthereumCartJSONStore(userAddress, 'save');
+      // // Save off cart data
+      // await this.manageEthereumCartJSONStore(userAddress, 'save');
 
       // Send transaction
       indicateMetamaskPopup();
@@ -936,23 +936,18 @@ Vue.component('grants-cart', {
         const donations = this.donationInputs;
         const csrfmiddlewaretoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
-        // If txHash has a length of one, stretch it so there's one hash for each donation
-        let txHashes = txHash;
+        // All transactions are the same type, so if any hash begins with `sync-tx:` we know it's a zkSync checkout
+        const checkout_type = txHash[0].startsWith('sync') ? 'eth_zksync' : 'eth_std';
+        
+        // If standard checkout, stretch it so there's one hash for each donation (required for `for` loop below)
+        const txHashes = checkout_type === 'eth_zksync' ? txHash : new Array(donations.length).fill(txHash[0]);
 
-        if (txHash.length === 1) {
-          txHashes = new Array(donations.length).fill(txHash[0]);
-        }
-
-        // TODO update celery task to manage this so we can remove these two server requests
-        // Update the JSON store with the transaction hashes. We append a timestamp to ensure it
-        // doesn't get overwritten by a subsequent checkout
-        await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save', txHashes);
-        // Once that's done, we can delete the old JSON store
-        await this.manageEthereumCartJSONStore(userAddress, 'delete');
-
-        // All transactions are the same type, so if any hash begins with `sync-tx:` we know it's
-        // a zkSync checkout
-        const checkout_type = txHashes[0].startsWith('sync') ? 'eth_zksync' : 'eth_std';
+        // // TODO update celery task to manage this so we can remove these two server requests
+        // // Update the JSON store with the transaction hashes. We append a timestamp to ensure it
+        // // doesn't get overwritten by a subsequent checkout
+        // await this.manageEthereumCartJSONStore(`${userAddress} - ${new Date().getTime()}`, 'save', txHashes);
+        // // Once that's done, we can delete the old JSON store
+        // await this.manageEthereumCartJSONStore(userAddress, 'delete');
 
         // Configure template payload
         const saveSubscriptionPayload = {

--- a/app/assets/v2/js/grants/ingest-missing-contributions.js
+++ b/app/assets/v2/js/grants/ingest-missing-contributions.js
@@ -12,7 +12,8 @@ Vue.component('grants-ingest-contributions', {
     return {
       form: {
         txHash: undefined, // user transaction hash, used to ingest L1 donations
-        userAddress: undefined // user address, used to ingest zkSync (L2) donations
+        userAddress: undefined, // user address, used to ingest zkSync (L2) donations
+        handle: undefined // user to ingest under -- ignored unless you are a staff
       },
       errors: {}, // keys are errors that occurred
       submitted: false // true if form has been submitted and we are waiting on response
@@ -116,7 +117,7 @@ Vue.component('grants-ingest-contributions', {
       // so to workaround that we ask the user for a signature, and the backend will verify that signature
       const baseMessage = 'Sign this message as verification that you control the provided wallet address'; // base message that will be signed
 
-      await postToDatabaseManualIngestion([txHash], userAddress, baseMessage); // this has it's own try/catch error handler
+      await postToDatabaseManualIngestion([txHash], userAddress, baseMessage, this.form.handle); // this method has it's own try/catch error handler
       this.resetForm();
     },
 

--- a/app/grants/templates/grants/ingest-contributions.html
+++ b/app/grants/templates/grants/ingest-contributions.html
@@ -93,10 +93,23 @@
                 <label class="font-caption letter-spacing text-black-60 text-uppercase">Wallet Address (for zkSync checkout)</label>
                 <input id="amount" v-model="form.userAddress" name="amount" class="form__input form__input-lg" />
               </div>
-
               <div class="col-12 text-danger" v-if="errors.address">
                 [[errors.address]]
               </div>
+
+              <!-- Profile to ingest for, only usable by staff -->
+              {% if is_staff %}
+                <div class="col-12 mb-3">
+                  <label class="font-caption letter-spacing text-black-60 text-uppercase">Profile Address </label>
+                  <p>
+                    <span class="font-weight-bold">NOTE</span>:
+                    This field is only viewable to staff. Enter the username of the user you are ingesting for
+                    <span class="font-weight-bold">OR</span>
+                    enter your own username to ingest your own contributions.
+                  </p>
+                  <input id="amount" v-model="form.handle" name="amount" class="form__input form__input-lg" />
+                </div>
+              {% endif %}
 
               <div class="col-12 text-danger" v-if="errors.invalidForm">
                 [[errors.invalidForm]]
@@ -129,6 +142,7 @@
       {% include 'shared/footer_scripts.html' with slim=1 ignore_inject_web3=1 %}
 
       <script type="text/javascript" src="https://cdn.ethers.io/lib/ethers-5.0.umd.min.js"></script>
+      <script src="{% static "v2/js/grants/shared.js" %}"></script>
       <script src="{% static "v2/js/grants/ingest-missing-contributions.js" %}"></script>
 
       <script src="https://cdn.jsdelivr.net/npm/vue-select@3.10.8"></script>
@@ -138,7 +152,6 @@
       <script src="{% static "v2/js/abi.js" %}"></script>
 
       <script src="{% static "v2/js/tokens.js" %}"></script>
-      <script src="{% static "v2/js/grants/shared.js" %}"></script>
 
       <script src="{% static "v2/js/grants/new_match.js" %}"></script>
     </div>

--- a/app/grants/templates/grants/ingest-contributions.html
+++ b/app/grants/templates/grants/ingest-contributions.html
@@ -68,7 +68,7 @@
                     <li>Make sure your wallet is connected to mainnet with the same address you used to checkout</li>
                     <li>If you donated using L1 (Standard Checkout), please enter the transaction hash</li>
                     <li>If you donated using L2 (zkSync Checkout), please enter your wallet address</li>
-                    <li>At least one of these two is required</li>
+                    <li>Only enter one of these at a time!</li>
                   </ul>
                 </p>
               </div>
@@ -81,7 +81,7 @@
 
               <!-- Transaction hash -->
               <div class="col-12 mb-3">
-                <label class="font-caption letter-spacing text-black-60 text-uppercase">Transaction Hash</label>
+                <label class="font-caption letter-spacing text-black-60 text-uppercase">Transaction Hash (for Standard checkout on L1)</label>
                 <input id="amount" v-model="form.txHash" name="amount" class="form__input form__input-lg" />
               </div>
               <div class="col-12 text-danger" v-if="errors.txHash">
@@ -90,7 +90,7 @@
 
               <!-- User address -->
               <div class="col-12 mb-3">
-                <label class="font-caption letter-spacing text-black-60 text-uppercase">Wallet Address</label>
+                <label class="font-caption letter-spacing text-black-60 text-uppercase">Wallet Address (for zkSync checkout)</label>
                 <input id="amount" v-model="form.userAddress" name="amount" class="form__input form__input-lg" />
               </div>
 

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -3407,7 +3407,21 @@ def ingest_contributions(request):
     # Setup web3
     w3 = get_web3(network)
 
+    def get_profile(profile):
+        """
+        If a staff called this endpoint, we use the username passed with the payload. Otherwise, we use the
+        caller's profile
+        """
+        return Profile.objects.filter(handle=request.POST.get('handle')).first() if profile.is_staff else profile
+
     def verify_signature(signature, message, expected_address):
+        """
+        Used to verify that the user ingesting actually owns the address they are ingesting for. This
+        may not work for contract wallets or wallets that use relayers, so those will need to be ingested by staff
+        to bypass this check
+        """
+        if profile.is_staff:
+            return # Skip signature verification for staff so staff can ingest contributions on behalf of a user
         message_hash = defunct_hash_message(text=message)
         recovered_address = w3.eth.account.recoverHash(message_hash, signature=signature)
         if recovered_address.lower() != expected_address.lower():
@@ -3432,7 +3446,7 @@ def ingest_contributions(request):
             address_lowercase = address.lower()
             return FTokens.objects.filter(network=network, address=address_lowercase, approved=True).first().to_dict
 
-    def save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, checkout_type):
+    def save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, checkout_type, from_address):
         """
         Creates contribution and subscription and saves it to database if no matching one exists
         """
@@ -3465,7 +3479,7 @@ def ingest_contributions(request):
             subscription.is_postive_vote = True
             subscription.active = False
             subscription.error = True
-            subscription.contributor_address = "N/A"
+            subscription.contributor_address = Web3.toChecksumAddress(from_address)
             subscription.amount_per_period = amount
             subscription.real_period_seconds = 2592000
             subscription.frequency = 30
@@ -3528,6 +3542,7 @@ def ingest_contributions(request):
     def process_bulk_checkout_tx(w3, txid, profile, network, do_write):
         # Make sure tx was successful
         receipt = w3.eth.getTransactionReceipt(txid)
+        from_address = receipt['from'] # this means wallets like Argent that use relayers will have the wrong from address
         if receipt.status == 0:
             raise Exception("Transaction was not successful")
 
@@ -3570,7 +3585,7 @@ def ingest_contributions(request):
                 continue
 
             if do_write:
-                save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, 'eth_std')
+                save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, 'eth_std', from_address)
         return
 
     def handle_ingestion(profile, network, identifier, do_write):
@@ -3619,6 +3634,10 @@ def ingest_contributions(request):
                 # Find the grant
                 try:
                     grant = Grant.objects.filter(admin_address__iexact=to).order_by("-positive_round_contributor_count").first()
+                    if not grant:
+                        logger.warning(f"{value_adjusted}{symbol}  => {to}, Unknown Grant ")
+                        logger.warning("Skipping unknown grant\n")
+                        continue
                     logger.info(f"{value_adjusted}{symbol}  => {to}, {grant.url} ")
                 except Exception as e:
                     logger.exception(e)
@@ -3629,13 +3648,13 @@ def ingest_contributions(request):
                 if do_write:
                     txid = transaction['hash']
                     created_on = dateutil.parser.parse(transaction['created_at'])
-                    save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, 'eth_zksync')
+                    save_data(profile, txid, network, created_on, symbol, value_adjusted, grant, 'eth_zksync', user_address)
 
     if txHash != '':
-        handle_ingestion(profile, network, txHash, True)
+        handle_ingestion(get_profile(profile), network, txHash, True)
         ingestion_types.append('L1')
     if userAddress != '':
-        handle_ingestion(profile, network, userAddress, True)
+        handle_ingestion(get_profile(profile), network, userAddress, True)
         ingestion_types.append('L2')
 
     return JsonResponse({ 'success': True, 'ingestion_types': ingestion_types })


### PR DESCRIPTION
Checkout falls back to manual ingestion if regular ingestion fails. For simplicity, we notify the user of this in the message they are signing. Rinkeby tests do not work due as explained in #8546, so testing process is similar to that PR:

1. Add item(s) to your cart
2. Connect wallet to mainnet and make sure your DB has the mainnet token list
3. Open `cart.js`, and in `postToDatabase()` on line 932, intentionally throw an error at the beginning of the `try` statement
4. Checkout with standard checkout, and repeat for zkSync. Both should ask you to sign a message which is the fallback to manual ingestion. If that fails, an error message is shown telling the user to visit https://gitcoin.co/grants/add-missing-contributions