### PR TITLE
Opens twitter share in a new tab and ensures trust-bonus always opens

### DIFF
--- a/app/assets/v2/js/grants/contribution-trust-bonus.js
+++ b/app/assets/v2/js/grants/contribution-trust-bonus.js
@@ -13,7 +13,7 @@ Vue.component('contribution-trust-bonus', {
     close() {
       this.$bvModal.hide(this.modalId);
     },
-    goToTrustBonus() {
+    openProfileTrustBonus() {
       document.location = '/profile/trust';
     }
   }

--- a/app/assets/v2/js/grants/grant-thanks-modal.js
+++ b/app/assets/v2/js/grants/grant-thanks-modal.js
@@ -33,13 +33,16 @@ Vue.component('contribution-thanks-modal', {
   methods: {
     close() {
       this.$bvModal.hide(this.modalId);
-      this.$bvModal.show('trust-bonus');
     },
     handleHide() {
       CartData.clearCheckedOut();
+      this.$bvModal.show('trust-bonus');
     },
     showSaveAsCollection() {
       this.$bvModal.show('create-collection');
+    },
+    shareOnTwitter() {
+      window.open(this.tweetUrl, '_blank');
     }
   }
 });

--- a/app/retail/templates/shared/contribution_trust_bonus.html
+++ b/app/retail/templates/shared/contribution_trust_bonus.html
@@ -44,7 +44,7 @@
           <b-button
             class="mt-2 col-md-4 col-sm-12 btn-primary"
             variant="primary"
-            @click="goToTrustBonus()"
+            @click="openProfileTrustBonus()"
           >
             Verify Profile
           </b-button>

--- a/app/retail/templates/shared/grant_thanks_modal.html
+++ b/app/retail/templates/shared/grant_thanks_modal.html
@@ -62,7 +62,7 @@
               <b-button
                 class="mt-2 mx-2 col-md-4 col-sm-12"
                 variant="primary"
-                :href="tweetUrl"
+                @click="shareOnTwitter()"
               >
                 <i class="fab fa-twitter" aria-hidden="true"></i>
                 Share on Twitter


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR fixes the Twitter Share button in the post-checkout thank you modal so that it opens in a new tab, and ensures the trust-bonus modal will always open when the thank you modal closes.

##### Refers/Fixes

Fixes: https://github.com/gitcoinco/web/issues/8483#issuecomment-796760402
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally