### PR TITLE
Fixes content cards so that they link to respective pages

### DIFF
--- a/app/assets/v2/js/activity.js
+++ b/app/assets/v2/js/activity.js
@@ -260,8 +260,10 @@ $(document).ready(function() {
   }, 1000);
 
   $(document).on('click', '.activity_stream .content', function(e) {
-    window.open($(this).find('a.d-block').first().attr('href'));
-    e.preventDefault();
+    if ($(this).data('href')) {
+      window.open($(this).data('href'));
+      e.preventDefault();
+    }
   });
 
   // expand attachments

--- a/app/assets/v2/scss/activity_stream.scss
+++ b/app/assets/v2/scss/activity_stream.scss
@@ -23,8 +23,13 @@
 .activity_stream{
   margin-bottom: 50px;
 }
-.activity_stream .content{
+.activity_stream .content {
   cursor: pointer;
+}
+.activity_stream .content:not(.cursor-none):hover {
+  p:first-of-type, .title {
+    text-decoration: underline;
+  }
 }
 #new_activity_notifier {
   text-align: center;

--- a/app/assets/v2/scss/base.scss
+++ b/app/assets/v2/scss/base.scss
@@ -30,6 +30,10 @@ span {
   cursor: pointer !important;
 }
 
+.cursor-none {
+  cursor: default !important;
+}
+
 .nav_avatar {
   width: 40px;
   height: 40px;

--- a/app/retail/templates/shared/activity-vue.html
+++ b/app/retail/templates/shared/activity-vue.html
@@ -101,7 +101,7 @@
         </template>
         <template v-else-if="row.activity_type == 'created_kudos'">
           a new kudos has been minted:
-          <a href="row.kudos.external_url">
+          <a href="{{ row.kudos.external_url }}">
             {{ row.kudos.ui_name }}
           </a>
         </template>
@@ -400,7 +400,7 @@
   </div>
   {% elif row.metadata.resource.type == 'content' %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content">
+    <div class="row align-items-center bg-light content cursor-none" >
       <div class="col-12 col-md-3 text-center">
         {% if not row.metadata.resource.image or row.metadata.resource.image  == 'undefined' %}
           <img class="py-2" style="max-height: 7rem;" src="{% static 'v2/images/team/gitcoinbot.png' %}">

--- a/app/retail/templates/shared/activity.html
+++ b/app/retail/templates/shared/activity.html
@@ -308,7 +308,7 @@
       {% else %}
         {{row.humanized_activity_type }}
         {% if row.bounty %}
-          : <a href="{{ row.bounty.url }}">{{ row.bounty.title }}</a>
+          : <a href="{{ row.bounty.url }}">{{ row.bounty.title | safe }}</a>
         {% endif %}
       {% endif %}
       </div>
@@ -525,7 +525,7 @@
   </div>
   {% if row.activity_type == 'hypercharge_bounty'%}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3">
+    <div class="row align-items-center bg-light content py-3" data-href="{{ row.bounty.url }}">
       <div class="col-12 col-md-2 text-center">
         {% if row.bounty.funding_organisation %}
           <img class="logo-metacard rounded-circle" src="{% url 'org_avatar' row.bounty.funding_organisation %}">
@@ -554,7 +554,7 @@
   </div>
   {% elif row.activity_type == 'new_bounty' and not for_email %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3">
+    <div class="row align-items-center bg-light content py-3" data-href="{{ row.bounty.url }}">
       <div class="col-12 col-md-2 text-center">
         {% if row.bounty.funding_organisation %}
           <img class="logo-metacard rounded-circle" src="{% url 'org_avatar' row.bounty.funding_organisation %}">
@@ -565,7 +565,7 @@
       <div class="col-12 col-md-7 d-flex flex-column pl-5">
         <div class="bounty-detail">
           <div class="title font-subheader font-weight-bold">
-            {{ row.bounty.title }}
+            {{ row.bounty.title | safe }}
           </div>
 
           <div class="bounty-summary p-0 col-12">
@@ -599,7 +599,7 @@
   </div>
   {% elif row.activity_type == 'new_kudos' and not for_email %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3">
+    <div class="row align-items-center bg-light content py-3" data-href="{{ row.kudos.external_url }}">
       <div class="col-12 col-md-3 text-center">
           <img class="logo-metacard" src="{{ row.kudos.img_url }}">
       </div>
@@ -611,13 +611,13 @@
   </div>
   {% elif row.activity_type == 'new_hackathon_project' and not for_email %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3">
+    <div class="row align-items-center bg-light content py-3" data-href="{% if row.project.name %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slugify %}{% else %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id %}{% endif %}">
       <div class="col-12 col-md-2 text-center">
-         {% if row.project.logo %}
-           <img class="logo-metacard rounded-circle" src="{{MEDIA_URL}}{{row.project.logo}}" alt="Hackathon logo" />
-         {% else %}
-           <img class="logo-metacard rounded-circle" src="{{ row.project.bounty.avatar_url }}" alt="{{row.project.bounty.org_name}}" />
-         {% endif %}
+        {% if row.project.logo %}
+          <img class="logo-metacard rounded-circle" src="{{MEDIA_URL}}{{row.project.logo}}" alt="Hackathon logo" />
+        {% else %}
+          <img class="logo-metacard rounded-circle" src="{{ row.project.bounty.avatar_url }}" alt="{{row.project.bounty.org_name}}" />
+        {% endif %}
       </div>
       <div class="col-12 col-md-6 text-left">
         <p class="mt-2 mb-1 font-weight-bold" style="font-size: 1.2em;">{{ row.project.name }}</p>
@@ -634,7 +634,7 @@
   </div>
   {% elif row.activity_type == 'new_grant' and not for_email %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3">
+    <div class="row align-items-center bg-light content py-3" data-href="{{ row.metadata.grant_url }}">
       <div class="col-12 col-md-2 text-center mr-2">
           <img class="logo-metacard" src="{% if row.grant.logo and row.grant.logo.url %}{{ row.grant.logo.url }}{% else %}{% with grant_logo='v2/images/grants/logos/' id=row.grant.id|modulo:3 %}{% static grant_logo|addstr:id|add:'.png' %}{% endwith %}{% endif %}">
       </div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR fixes the activity stream's content cards (New bounty/New Kudos etc...), clicking a card will open the respective page in a new tab.

##### Refers/Fixes

Fixes: https://github.com/gitcoinco/web/issues/8483#issuecomment-793939602

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally
