### PR TITLE
Fixed This Web3py Signed Message That Will Not Validate In Solidity

### DIFF
--- a/app/passport/views.py
+++ b/app/passport/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from django.http import Http404, JsonResponse
 from dashboard.utils import get_web3
 import web3
+from eth_account.messages import defunct_hash_message
 import json
 from django.conf import settings
 
@@ -20,10 +21,11 @@ def index(request):
 
     #_hash = sp.getMessageHash(player, 0, tokenURI, nonce);
     message = contract.functions.getMessageHash(player, 0, tokenURI, nonce).call()
+    message_hash = defunct_hash_message(primitive=message)
     private_key = settings.PASSPORT_PK
     #signature = await accounts[0].signMessage(ethers.utils.arrayify(hash));
-    signed_message = w3.eth.account.signHash(message.hex(), private_key=private_key).signature.hex()
-    signed_message = '0x304ccffbca9a729465b8b025bb0a41b07e949b8cecf30552bb4413c3eccfe9af590ea3d9bcb337a42f746a6668129395ab2abb459ba371bcbcc6f3c403db71661c'
+    signed_message = w3.eth.account.signHash(message_hash, private_key=private_key).signature.hex()
+    # signed_message = '0x304ccffbca9a729465b8b025bb0a41b07e949b8cecf30552bb4413c3eccfe9af590ea3d9bcb337a42f746a6668129395ab2abb459ba371bcbcc6f3c403db71661c'
     print(message)
     print(signed_message)
     #sp.createPassport(tokenURI, signature, nonce);


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
I have found [defunct_hash_message](https://ethaccount.readthedocs.io/en/stable/eth_account.html#eth_account.messages.defunct_hash_message) from web3py that should use to hash a msg before signHash method.
I did not change any requirement version as discussed in #8571.

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://github.com/gitcoinco/web/issues/8571

##### Testing
Check this tx from my contract:
https://rinkeby.etherscan.io/tx/0xce4c7763b9d5aae69ccd9f0038fd6bf561c8021a9fedc1babb68425ddcd3158a

and here is my Gitcoin Passport
https://rinkeby.etherscan.io/token/0x7b02739251d06dc0669465db00c7986badae50b0?a=0x18ae9fc06bed0637b1d46063d6b7af1a4f97b02c

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
