### PR TITLE
only load chains lib scripts when needed

### DIFF
--- a/app/assets/v2/js/grants/cart/polkadot_extension.js
+++ b/app/assets/v2/js/grants/cart/polkadot_extension.js
@@ -1,7 +1,7 @@
 const initPolkadotConnection = async(grant, vm) => {
 
   // step 1: check if web3 is injected
-  if (!polkadot_utils.isWeb3Injected) {
+  if (!polkadot_utils.isWeb3Injected()) {
     vm.updatePaymentStatus(grant.grant_id, 'failed');
     _alert({ message: `Please ensure your Polkadot One wallet is installed and unlocked`}, 'error');
     return;

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -42,8 +42,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       {% include 'shared/tag_manager_2.html' %}
       {% include 'shared/top_nav.html' with class='d-md-flex' %}
       {% include 'grants/nav.html' %}
-      
-      
+
+
       <div id="gc-grants-cart" v-cloak>
         <grants-cart ref="cart" inline-template>
           <div class="container">
@@ -136,33 +136,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         document.isFullyVerified = '{{is_fully_verified}}' === 'True';
       </script>
       <script src="{% static "v2/js/cart-ethereum-zksync.js" %}"></script>
-
-      <!-- <template v-if="grantsCountByTenant.BINANCE !== undefined"> -->
-        <script src="{% static "v2/js/grants/cart/rsk_extension.js" %}"></script>
-      <!-- </template> -->
-
-      <!-- <template v-if="grantsCountByTenant.HARMONY !== undefined"> -->
-        <script src="{% static "v2/js/lib/harmony/HarmonyUtils.browser.js" %}"></script>
-        <script src="{% static "v2/js/lib/harmony/HarmonyJs.browser.js" %}"></script>
-        <script src="{% static "v2/js/lib/harmony/HarmonyAccount.browser.js" %}"></script>
-        <script src="{% static "v2/js/lib/harmony/HarmonyCrypto.browser.js" %}"></script>
-        <script src="{% static "v2/js/lib/harmony/HarmonyNetwork.browser.js" %}"></script>
-        <script src="{% static "v2/js/lib/harmony/utils.js" %}"></script>
-        <script src="{% static "v2/js/grants/cart/harmony_extension.js" %}"></script>
-      <!-- </template> -->
-
-      <!-- <template v-if="grantsCountByTenant.POLKADOT !== undefined || grantsCountByTenant.KUSAMA !== undefined"> -->
-        <script src="{% static "v2/js/lib/polkadot/core.min.js" %}"></script>
-        <script src="{% static "v2/js/lib/polkadot/extension.min.js" %}"></script>
-        <script src="{% static "v2/js/lib/polkadot/utils.js" %}"></script>
-        <script src="{% static "v2/js/grants/cart/polkadot_extension.js" %}"></script>
-      <!-- </template> -->
-
-      <!-- <template v-if="grantsCountByTenant.BINANCE !== undefined"> -->
-        <script src="{% static "v2/js/lib/binance/utils.js" %}"></script>
-        <script src="{% static "v2/js/grants/cart/binance_extension.js" %}"></script>
-      <!-- </template> -->
-
       <script src="{% static "v2/js/grants/create-collection-modal.js" %}"></script>
       <script src="{% static "v2/js/cart.js" %}"></script>
     </div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This pr move the chains js dependencies to an object and add a computed prop to with the tenants presents on the cart. For each tenant present on the cartData (grants)  this will inject the proper chain js lib needed avoiding load unused big js libs if not going to be used.

For future chains additions we will need to just add the tenant name and the object with all the js endpoints (external or internal) following the same pattern we do for the tabs.

There is a special rule for kuzama as this one have diff chain id / name but is actually part of polkadot and use the same files.

With this approach cart seems to be loading normally again and even if you pick a polkadot grant then the load time doesn't fill tedious as the other js are not loaded (unless you pick one grant of each of our supported chains, then will be the same time as today online) 


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
