### PR TITLE
fix(about): team img stretch

### DIFF
--- a/app/assets/v2/scss/about.scss
+++ b/app/assets/v2/scss/about.scss
@@ -102,8 +102,9 @@ h4 {
   opacity: .9;
 }
 
-#team .alt_avatar{
+#team .alt_avatar {
   border-radius: 150px;
+  object-fit: cover;
 }
 
 #team .avatar:hover {

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -599,7 +599,7 @@ def about(request):
             "semovita with afang soup",
             "",
             "OSS Freedom Fighter",
-            "stchibe",
+            "stchibie",
             True
         ),
         (


### PR DESCRIPTION
##### Description

fixes stretching of team images in about page

##### Refers/Fixes

closes #8556 

##### Testing

same locally as in issue