### PR TITLE
show submission only to needed folks

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -766,6 +766,18 @@ Vue.mixin({
           vm.fulfillment_context.active_step = 'payout_amount';
           break;
       }
+    },
+    showWorkSubmitted: function(handle) {
+      let vm = this;
+
+      if (
+        vm.contxt.is_staff ||
+        vm.isOwner ||
+        (handle && handle == vm.contxt.github_handle)
+      ) {
+        return true;
+      }
+      return false;
     }
   },
   computed: {

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -365,11 +365,13 @@
                     </div>
                     <div class="col-12">
                       <div class="bg-lightblue py-3 px-4 rounded mt-3 mb-0 w-100 overflow-auto">
-                        <i class="far fa-link mr-1"></i>
-                        <span class="font-weight-bold mb-2">PR:</span>
-                        <a :href="fulfillment.fulfiller_github_url" target="_blank">
-                          [[ fulfillment.fulfiller_github_url ]]
-                        </a>
+                        <template v-if="showWorkSubmitted(fulfillment.fulfiller_github_username)">
+                          <i class="far fa-link mr-1"></i>
+                          <span class="font-weight-bold mb-2">PR:</span>
+                          <a :href="fulfillment.fulfiller_github_url" target="_blank">
+                            [[ fulfillment.fulfiller_github_url ]]
+                          </a>
+                        </template>
                         <p class="mb-0" v-if="fulfillment.fulfiller_metadata.data.payload.fulfiller && fulfillment.fulfiller_metadata.data.payload.fulfiller.hoursWorked">
                           <i class="far fa-clock font-caption mr-1"></i>
                           <span class="font-weight-bold">Hours worked:</span>


### PR DESCRIPTION
##### Description

Show PR link to 
- admin
- funder
- person who made the submission


![Untitled](https://user-images.githubusercontent.com/5358146/112329319-1b61fe00-8cdd-11eb-8e5e-f39fa1747b15.gif)


#### Issue Reported 

By @connoroday 

>Problem: Some bounties (especially for bug bounties) should not have submissions be public
Request: “Private” submissions for bug bounties or similar

