### PR TITLE
remove override and allow close button clickable by admin

### DIFF
--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -41,7 +41,6 @@
             </span>
             <a v-for="link in quickLinks" class="btn btn-outline-primary px-2 mx-2 btn-sm" :href="[[link.href]]" :title="[[ link.title ]]">[[ link.label ]]</a>
             <button class="btn btn-outline-primary px-2 mx-2 btn-sm" @click="contactFunder()">Contact Funder</button>
-            <button class="btn btn-outline-primary px-2 mx-2 btn-sm" @click="overrideStatus()">Override Status</button>
           </div>
           <div class="col-12" v-if="loadingState === 'resolved'">
             {% if event_tag %}
@@ -157,7 +156,7 @@
 
             <div class="row">
               <div id="right_actions" class="col-12 d-block bounty-actions mt-4 pt-2 pb-1 text-center text-lg-left" v-if="bounty.action_urls">
-                <template v-if="isOwner">
+                <template v-if="isOwner || contxt.is_staff">
                   <div v-if="hasAcceptedFulfillments().length && bounty.status != 'done' " class="d-inline-block">
                     <a class="btn btn-primary btn-sm mr-2 px-3 font-caption text-white" @click="closeBounty()" title="This bounty can be closed since it's been paid out">
                       <i class="fas fa-check mr-2"></i>


### PR DESCRIPTION
##### Description


From connor
>Problem: “Override status” button no longer works for admins after moving from standard bounties, admins have to “view in admin” and then type in “done” in override status field to close
Request: Fix “Override status” button on bounty frontend


The fix instead :
- to expose close bounty button to admin
- remove override status  (this is done cause we don't want bounty jumping the states)




##### Testing

<img width="1462" alt="Screenshot 2021-03-25 at 4 20 34 PM" src="https://user-images.githubusercontent.com/5358146/112462412-0641a980-8d87-11eb-8491-b4dbfc425278.png">
