### PR TITLE
update bounty expiry date to hackthon end date

### DIFF
--- a/app/app/db.py
+++ b/app/app/db.py
@@ -1,6 +1,7 @@
+import random
+
 from django.conf import settings
 
-import random
 
 class PrimaryDBRouter:
     def db_for_read(self, model, **hints):

--- a/app/dashboard/admin.py
+++ b/app/dashboard/admin.py
@@ -488,7 +488,7 @@ class HackathonEventAdmin(admin.ModelAdmin):
 
 
     def response_change(self, request, obj):
-        if "_auto_update_expiry" in request.POST:
+        if "_bulk_update_expiry" in request.POST:
             try:
                 bounties_to_extend = Bounty.objects.filter(event=obj)
                 for bounty in bounties_to_extend:

--- a/app/dashboard/admin.py
+++ b/app/dashboard/admin.py
@@ -19,6 +19,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -485,6 +486,19 @@ class HackathonEventAdmin(admin.ModelAdmin):
         url = f'/hackathon/{instance.slug}'
         return mark_safe(f'<a href="{url}">Explorer Link</a>')
 
+
+    def response_change(self, request, obj):
+        if "_auto_update_expiry" in request.POST:
+            try:
+                bounties_to_extend = Bounty.objects.filter(event=obj)
+                for bounty in bounties_to_extend:
+                    bounty.expires_date=obj.end_date
+                    bounty.save()
+                self.message_user(request, "updated hackthon bounties expiry dates")
+            except Exception as e:
+                print(e)
+                self.message_user(request, "unable to update bounty expiry dates")
+        return redirect(obj.admin_url)
 
 class CouponAdmin(admin.ModelAdmin):
     """The admin object to maintain discount coupons for bounty"""

--- a/app/grants/management/commands/update_contributor_address.py
+++ b/app/grants/management/commands/update_contributor_address.py
@@ -21,6 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.core.management.base import BaseCommand
+
 import requests
 from dashboard.utils import get_web3
 from grants.models import Subscription

--- a/app/grants/tasks.py
+++ b/app/grants/tasks.py
@@ -390,4 +390,3 @@ def save_contribution(self, contrib_id):
     from grants.models import Contribution
     contrib = Contribution.objects.get(pk=contrib_id)
     contrib.save()
-

--- a/app/grants/urls.py
+++ b/app/grants/urls.py
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.urls import path, re_path
 
 from grants.views import (
-    add_grant_from_collection, bulk_fund, bulk_grants_for_cart, cancel_grant_v1, cart_thumbnail, clr_grants,
+    add_grant_from_collection, bulk_fund, bulk_grants_for_cart, cancel_grant_v1, cart_thumbnail, clr_grants, collage,
     collection_thumbnail, contribute_to_grants_v1, contribution_addr_from_all_as_json,
     contribution_addr_from_grant_as_json, contribution_addr_from_grant_during_round_as_json,
     contribution_addr_from_round_as_json, contribution_info_from_grant_during_round_as_json, create_matching_pledge_v1,
@@ -30,7 +30,7 @@ from grants.views import (
     grants, grants_addr_as_json, grants_bulk_add, grants_by_grant_type, grants_cart_view, grants_info, grants_landing,
     ingest_contributions, ingest_contributions_view, invoice, leaderboard, manage_ethereum_cart_data,
     new_matching_partner, profile, quickstart, remove_grant_from_collection, save_collection, subscription_cancel,
-    toggle_grant_favorite, verify_grant, collage
+    toggle_grant_favorite, verify_grant,
 )
 
 app_name = 'grants/'

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -22,6 +22,7 @@ import hashlib
 import html
 import json
 import logging
+import math
 import re
 import time
 import uuid
@@ -3071,7 +3072,6 @@ https://c.gitcoin.co/grants/ce84fcbf185bd593e54f5c810d060aac/triad_gw_2.jpg
 https://c.gitcoin.co/grants/b8fcf1833fee32fc4be6fba254c1d912/cashu.png
 '''
 
-import math
 def get_urls(scale):
     import random
     global des_urls

--- a/app/retail/templates/admin/change_form.html
+++ b/app/retail/templates/admin/change_form.html
@@ -89,6 +89,8 @@
       <input type="submit" value="Change Owner to Gitcoin" name="_change_owner" value="1">
     {% elif 'quests/quest' in request.build_absolute_uri %}
       <input type="submit" value="Approve Request" name="_approve_quest" value="1">
+    {% elif 'dashboard/hackathonevent/' in request.build_absolute_uri %}
+      <input type="submit" value="Update Related Bounties Expiry Date" name="_auto_update_expiry" value="1">
     {% endif %}
   </div>
 {% endblock %}

--- a/app/retail/templates/admin/change_form.html
+++ b/app/retail/templates/admin/change_form.html
@@ -90,7 +90,7 @@
     {% elif 'quests/quest' in request.build_absolute_uri %}
       <input type="submit" value="Approve Request" name="_approve_quest" value="1">
     {% elif 'dashboard/hackathonevent/' in request.build_absolute_uri %}
-      <input type="submit" value="Update Related Bounties Expiry Date" name="_auto_update_expiry" value="1">
+      <input type="submit" value="Update Related Bounties Expiry Date" name="_bulk_update_expiry" value="1">
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
#### Issue

@connoroday 
> Problem: When extending hackathon end date, bounties expiration doesn’t change
Request: Bounty deadlines get updated when hackathon is extended


##### How to use

- Head over to a hackathon event in admin
- Update the end date and click on SAVE
- Once the hackathon end date has been updated, scroll to the bottom and hit the `Update Related Bounties Expiry Date` button and all the bounties for the hackathon event should have the same expiry date. 

Check the video for more info 

![Untitled](https://user-images.githubusercontent.com/5358146/112467985-bdd9ba00-8d8d-11eb-82b2-9b173c32a2e1.gif)
