### PR TITLE
fix: UncompressableFileError due to non-existent file

### DIFF
--- a/app/retail/templates/shared/head.html
+++ b/app/retail/templates/shared/head.html
@@ -46,7 +46,6 @@
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/faucet.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/colors.scss" %} />
   <!-- Forms -->
-  <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/forms/button.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/forms/checkbox.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/forms/drop.scss" %} />
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/forms/form.scss" %} />


### PR DESCRIPTION
Reference to non-existent assets, `/v2/scss/forms/button.scss`, deleted in PR https://github.com/gitcoinco/web/pull/8622, is causing django-compressor to throw `UncompressableFileError`.

Resolved by deleting the line.