### PR TITLE
Allows width/height to be set against an img in the hackathon onboarding description editor

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4474,7 +4474,7 @@ def save_hackathon(request, hackathon):
             'a': ['href', 'title'],
             'abbr': ['title'],
             'acronym': ['title'],
-            'img': ['src'],
+            'img': ['src', 'width', 'height'],
             'iframe': ['src', 'frameborder', 'allowfullscreen'],
             '*': ['class', 'style']},
         styles=['background-color', 'color'],


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR allows width and height to be set against an image in the hackathon onboarding description editor - these tags were not part of the whitelist and were being "cleaned" on save. 

##### Refers/Fixes

Refers: https://gitcoincore.slack.com/archives/CAXQ7PT60/p1617818978085500

##### Testing
<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally
