### PR TITLE
Fixes bounty payout modal so that the correct instance reopens after web3 onConnect

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -470,7 +470,7 @@ Vue.mixin({
           console.log('success', response);
 
           vm.fetchBounty();
-          this.$refs['payout-modal'][0].closeModal();
+          this.$refs['payout-modal' + fulfillment_id][0].closeModal();
 
           vm.fulfillment_context = {
             active_step: 'payout_amount'
@@ -492,14 +492,14 @@ Vue.mixin({
         const ele = '#payout-with-pypl';
 
         $(ele).html('');
-        const modal = this.$refs['payout-modal'][0];
+        const modal = this.$refs['payout-modal' + fulfillment_id][0];
 
         payWithPYPL(fulfillment_id, fulfiller_identifier, ele, vm, modal);
       });
     },
     payWithExtension: function(fulfillment_id, fulfiller_address, payout_type) {
       let vm = this;
-      const modal = this.$refs['payout-modal'][0];
+      const modal = this.$refs['payout-modal' + fulfillment_id][0];
 
       switch (payout_type) {
         case 'web3_modal':

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -377,7 +377,7 @@
                           [[ fulfillment.fulfiller_metadata.data.payload.fulfiller.hoursWorked ]]
                         </p>
 
-                        <modal :id="`payoutModal${fulfillment.pk}`" ref="payout-modal">
+                        <modal :id="`payoutModal${fulfillment.pk}`" :ref="`payout-modal${fulfillment.pk}`">
                           <div slot="body">
 
                             <!-- PAYPAL FLOW -->


### PR DESCRIPTION

<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description
<!-- Describe your changes here. -->

This PR corrects the following problem:

If there is no wallet connected when a bounty owner goes to payout a submission, then the active modal is closed and the wallet selection modal is opened, when the wallet selection is closed the original modal should be reopened, instead a different modal is being opened - and this is causing the wrong submission to be paid out for the bounty.


##### Refers/Fixes

Fixes: https://gitcoincore.slack.com/archives/CAXQ7PT60/p1617915148092600?thread_ts=1617910888.089500&cid=CAXQ7PT60

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

https://www.loom.com/share/021f94b4991149fdb84c2967b3f22ce0