### PR TITLE
bug: bounty flow - invalid literal for int() for base 10

### DIFF
--- a/app/git/utils.py
+++ b/app/git/utils.py
@@ -746,7 +746,11 @@ def get_url_dict(issue_url):
         }
     except IndexError as e:
         logger.warning(e)
-        return {'org': org_name(issue_url), 'repo': repo_name(issue_url), 'issue_num': int(issue_number(issue_url))}
+        return {
+            'org': org_name(issue_url),
+            'repo': repo_name(issue_url),
+            'issue_num': int(issue_number(issue_url)) if issue_number(issue_url) else ''
+        }
 
 
 def repo_url(issue_url):


### PR DESCRIPTION
##### Description

- Issue: https://sentry.io/share/issue/efca7d7914d046458d75eb4f4e3b7edc/
- report: 280
- flow affected: bounty detail page

##### Refers/Fixes

![image](https://user-images.githubusercontent.com/5358146/114868475-936ea000-9e13-11eb-93bd-e14e939e445d.png)
