### PR TITLE
bug: invalid literal for int() with base 10: 'test ORDER BY 1#'

### DIFF
--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -1013,9 +1013,9 @@ def get_specific_activities(what, trending_only, user, after_pk, request=None):
 def activity(request):
     """Render the Activity response."""
     page_size = 7
-    page = int(request.GET.get('page', 1))
+    page = int(request.GET.get('page', 1)) if request.GET.get('page').isdigit() else 1
     what = request.GET.get('what', 'everywhere')
-    trending_only = int(request.GET.get('trending_only', 0))
+    trending_only = int(request.GET.get('trending_only', 0)) if request.GET.get('trending_only').isdigit() else 0
     activities = get_specific_activities(what, trending_only, request.user, request.GET.get('after-pk'), request)
     activities = activities.prefetch_related('profile', 'likes', 'comments', 'kudos', 'grant', 'subscription', 'hackathonevent', 'pin')
     # store last seen


### PR DESCRIPTION
##### Description

- Issue: 
   - https://sentry.io/share/issue/323917544b4d4d2ea38a6464b774c506/
   - https://sentry.io/share/issue/60236e3fcaca4d74b78b5380114ba938/
- report: 4.1k + 6.4k
- flow affected: /activity

##### Refers/Fixes
![image](https://user-images.githubusercontent.com/5358146/114870083-60c5a700-9e15-11eb-94b8-47dafa98e4b6.png)

