### PR TITLE
feat: have ability to set latest flag to 0 in GrantCLRCalculation

### DIFF
--- a/app/grants/admin.py
+++ b/app/grants/admin.py
@@ -479,7 +479,7 @@ class GrantCLRAdmin(admin.ModelAdmin):
                 recalc_clr.delay(grant.pk)
             self.message_user(request, "submitted recaclulation to queue")
 
-        if "_set_current_grant_clr_calulations_to_false" in request.POST:
+        if "_set_current_grant_clr_calculations_to_false" in request.POST:
             latest_calculations = GrantCLRCalculation.objects.filter(grantclr=obj, latest=True)
 
             if latest_calculations.count() == 0:
@@ -488,7 +488,7 @@ class GrantCLRAdmin(admin.ModelAdmin):
                 latest_calculations.update(latest=False)
                 self.message_user(request, "Current Grant CLR Calculations's latest flag is set to false")
 
-        if "_set_all_grant_clr_calulations_to_false" in request.POST:
+        if "_set_all_grant_clr_calculations_to_false" in request.POST:
             latest_calculations = GrantCLRCalculation.objects.filter(latest=True)
             if latest_calculations.count() == 0:
                 self.message_user(request, "Latest Flag is already false for all CLRs. No action taken")

--- a/app/grants/admin.py
+++ b/app/grants/admin.py
@@ -478,6 +478,24 @@ class GrantCLRAdmin(admin.ModelAdmin):
             for grant in obj.grants:
                 recalc_clr.delay(grant.pk)
             self.message_user(request, "submitted recaclulation to queue")
+
+        if "_set_current_grant_clr_calulations_to_false" in request.POST:
+            latest_calculations = GrantCLRCalculation.objects.filter(grantclr=obj, latest=True)
+
+            if latest_calculations.count() == 0:
+                self.message_user(request, "Latest Flag is already false. No action taken")
+            else:
+                latest_calculations.update(latest=False)
+                self.message_user(request, "Current Grant CLR Calculations's latest flag is set to false")
+
+        if "_set_all_grant_clr_calulations_to_false" in request.POST:
+            latest_calculations = GrantCLRCalculation.objects.filter(latest=True)
+            if latest_calculations.count() == 0:
+                self.message_user(request, "Latest Flag is already false for all CLRs. No action taken")
+            else:
+                latest_calculations.update(latest=False)
+                self.message_user(request, "All Grant CLR Calculations's latest flag is set to false")
+
         return redirect(obj.admin_url)
 
 

--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -416,7 +416,7 @@ def predict_clr(save_to_db=False, from_date=None, clr_round=None, network='mainn
             grant = clr_round.grants.using('default').get(pk=pk)
             latest_calc = grant.clr_calculations.using('default').filter(latest=True, grantclr=clr_round).order_by('-pk').first()
             if not latest_calc:
-                print("- - could not find latest clr calc for {grant.pk} ")
+                print(f"- - could not find latest clr calc for {grant.pk} ")
                 continue
             clr_prediction_curve = copy.deepcopy(latest_calc.clr_prediction_curve)
             clr_prediction_curve[0][1] = grant_calc['clr_amount'] # update only the existing match estimate

--- a/app/marketing/management/commands/assemble_leaderboards.py
+++ b/app/marketing/management/commands/assemble_leaderboards.py
@@ -18,16 +18,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Q
 from django.utils import timezone
-from django.db import connection, transaction
 
 from cacheops import CacheMiss, cache
 from dashboard.models import Earning, Profile
 from marketing.models import LeaderboardRank
-from django.contrib.contenttypes.models import ContentType
 
 # Constants
 IGNORE_PAYERS = []

--- a/app/retail/templates/admin/change_form.html
+++ b/app/retail/templates/admin/change_form.html
@@ -71,8 +71,8 @@
       <input type="submit" value="Generate Cache" name="_generate_cache" value="1">
     {% elif 'grantclr/' in request.build_absolute_uri %}
       <input type="submit" value="Recalculate CLR" name="_recalculate_clr" value="1">
-      <input type="submit" value="Reset CLR calculations for this round" name="_set_current_grant_clr_calulations_to_false" value="1">
-      <input type="submit" value="Reset all CLR calculations for all rounds" name="_set_all_grant_clr_calulations_to_false" value="1">
+      <input type="submit" value="Reset CLR calculations for this round" name="_set_current_grant_clr_calculations_to_false" value="1">
+      <input type="submit" value="Reset all CLR calculations for all rounds" name="_set_all_grant_clr_calculations_to_false" value="1">
     {% elif 'granttype/' in request.build_absolute_uri %}
       <input type="submit" value="Refresh grants type cache" name="_refresh_grants_type_cache" value="1">
       <input type="submit" value="Refresh grants clr cache" name="_refresh_grant_clr_cache" value="1">

--- a/app/retail/templates/admin/change_form.html
+++ b/app/retail/templates/admin/change_form.html
@@ -71,6 +71,8 @@
       <input type="submit" value="Generate Cache" name="_generate_cache" value="1">
     {% elif 'grantclr/' in request.build_absolute_uri %}
       <input type="submit" value="Recalculate CLR" name="_recalculate_clr" value="1">
+      <input type="submit" value="Reset CLR calculations for this round" name="_set_current_grant_clr_calulations_to_false" value="1">
+      <input type="submit" value="Reset all CLR calculations for all rounds" name="_set_all_grant_clr_calulations_to_false" value="1">
     {% elif 'granttype/' in request.build_absolute_uri %}
       <input type="submit" value="Refresh grants type cache" name="_refresh_grants_type_cache" value="1">
       <input type="submit" value="Refresh grants clr cache" name="_refresh_grant_clr_cache" value="1">


### PR DESCRIPTION
##### Description

Introduce 2 new actions on Grant CLR admin
  - `Reset CLR calculations for this round` -> set the `GrantCLRCalculations` for that round to `latest` = `False` 
  - `Reset all CLR calculations for all rounds` -> -> set ALL `GrantCLRCalulations` to `latest` = `False`  
  
###### Why do need this ?

-  Any time the estimate_clr runs for a round -> the earlier records for that CLR`GrantCLRCalculations`  has the `latest` column set to `False` and the once all the CLR are calculated , the effective CLR for each grant is nothing but the same of the latest `GrantCLRCalculations` with `latest=True` and the that grant.pk
- When the round runs
   - the older ones are invalidated (aka latest is set to False) 
   - new records are created
- When a round ends, the records with latest=True are created. Let's call these `Record X`.
- When a new round is started  -> the `record X` would be taken into account cause the older ones cause they were never invalidated 


This PR lets admin reset those for an individual round / bulk reset for all GrantCLRCalculations


##### How to use it

- Head over to GrantCLR object once it's ended and payouts are done 
- Scroll Down to bottom of the page 
- Click on `Reset CLR calculations for this round` OR `Reset all CLR calculations for all rounds`


##### Testing

https://share.vidyard.com/watch/j16VkR3kC5y9tKrjUsCRHb?