### PR TITLE
bugfix: add error checking for new users when round_num is [None]

### DIFF
--- a/app/grants/models.py
+++ b/app/grants/models.py
@@ -646,6 +646,7 @@ class Grant(SuperModel):
         """Generates CLR rounds sub_round_slug seperated by comma"""
         if self.pk:
             round_nums = [ele for ele in self.in_active_clrs.values_list('sub_round_slug', flat=True)]
+            round_nums = list(filter(None, round_nums))
             return ", ".join(round_nums)
         return ''
 
@@ -655,6 +656,7 @@ class Grant(SuperModel):
         """Generates CLR rounds display text seperated by comma"""
         if self.pk:
             round_nums = [ele for ele in self.in_active_clrs.values_list('display_text', flat=True)]
+            round_nums = list(filter(None, round_nums))
             return ", ".join(round_nums)
         return ''
 


### PR DESCRIPTION
#### Description


Ran into this issue on my local where without any historic Grant CLR and I tried running it for the first time,
it errors out cause round_nums ends up being an empty list with `None` AKA `round_nums = [None]`
This just adds an extra safety to check  

![image](https://user-images.githubusercontent.com/5358146/115032802-5a076480-9ee7-11eb-9109-92d35b0597fe.png)
