### PR TITLE
fix(email): add timeago to bounties tag matching fallback

### DIFF
--- a/app/marketing/mails.py
+++ b/app/marketing/mails.py
@@ -1377,6 +1377,7 @@ def new_bounty_daily(es):
         bounties = Bounty.objects.current().filter(
             network='mainnet',
             idx_status__in=['open'],
+            web3_created__gt=timezone.now() - timezone.timedelta(hours=24),
         ).exclude(bounty_reserved_for_user__isnull=False).order_by('-_val_usd_db')[0:3]
 
     to_emails = [to_email]


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

limit bounties in daily digest to 24 hours ago;

nothing new, just a piece that was left out in fallback from tag matching

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
