### PR TITLE
bugfix: bounty slim - invalid literal for int() with base 10

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -534,7 +534,8 @@ class BountiesViewSet(viewsets.ModelViewSet):
 
         # offset / limit
         if 'is_featured' not in param_keys:
-            limit = int(self.request.query_params.get('limit', 5))
+            limit = self.request.query_params.get('limit', '5')
+            limit = 5 if not limit.isdigit() else int(limit)
             max_bounties = 100
             if limit > max_bounties:
                 limit = max_bounties


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->


This PR:

- Closes a sentry issue (reported events: **5.7k**)
- Ensures the bounty slim api's `limit` get param is always an int

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: https://sentry.io/share/issue/ee152a3b616b401cb8b948297c5ded2d/

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally