### PR TITLE
Prevents the footer from displaying on Quests Battle

### DIFF
--- a/app/assets/v2/scss/quests.scss
+++ b/app/assets/v2/scss/quests.scss
@@ -351,7 +351,7 @@
   color: white;
 }
 
-body.quest_battle .footer {
+body.quest_battle footer {
   display: none;
 }
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR will prevent the footer from displaying on Quests Battle (regression).

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Refers: #8500

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

##### Before 
<img width="1362" alt="Screenshot 2021-04-28 at 00 35 58" src="https://user-images.githubusercontent.com/5897836/116330405-5b793c80-a7c5-11eb-9553-ae25963b5e1b.png">

##### After
<img width="1911" alt="Screenshot 2021-04-28 at 01 57 43" src="https://user-images.githubusercontent.com/5897836/116330434-6f24a300-a7c5-11eb-8330-fdcd24f25b28.png">
