### PR TITLE
Fixing red tests in assemble_leaderboards

### DIFF
--- a/app/marketing/management/commands/assemble_leaderboards.py
+++ b/app/marketing/management/commands/assemble_leaderboards.py
@@ -202,7 +202,7 @@ def do_leaderboard():
 
                 print('---')
 
-                # set old LR as inactive
+                # set old LeaderboardRank as inactive
                 created_on = timezone.now()
                 with transaction.atomic():
                     print(" - saving -")


### PR DESCRIPTION


<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

All of the imports were broken. After removing them, all of the tests became invalid. Decided to start from the top and test any public functions and functions that were complex.

Plan:

* [ ] test `do_leaderboard` for daily, weekly, quarterly, yearly, and all time tables
* [ ] same tests as above except for `do_leaderboard_feed`

_Might be more accurate to just test all the possible cadences through the `Command` since it seems like `do_leaderboard_feed` needs `do_leaderboard` to run first? Would love some advice here._

##### Refers/Fixes

Broken build

##### Testing

Only tests, maybe some small refactors