### PR TITLE
removing error log for claim breakdown not found

### DIFF
--- a/app/quadraticlands/helpers.py
+++ b/app/quadraticlands/helpers.py
@@ -191,7 +191,7 @@ def get_initial_dist_breakdown(request):
             'GMV': int(initial_dist["GMV"]) / 10**18
         }
     except Exception as e: # if user doesn't have a token claim record in DB
-        logger.error(f'QuadLands: Error getting initial dist: {e}')
+        # logger.error(f'QuadLands: Error getting initial dist: {e}')
         context = {
             'active_user': 0,
             'kernel': 0,


### PR DESCRIPTION
##### Description

Users with 0 tokens for the drop are still able to get to the claims page and attempt claim for 0 tokens.  This fix will remove the unnecessary error log from the backend and is the first part of this fix only.  @scco and are working on a client side fix that will make this more clear to the user as well. We aim to have that ready soon. This can be merged now (to stop the flood of error logs) or when we complete the UI fix. 

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/8948

