### PR TITLE
Zac signed message fix

### DIFF
--- a/app/assets/v2/js/quadraticlands/mission/use/vote.js
+++ b/app/assets/v2/js/quadraticlands/mission/use/vote.js
@@ -168,11 +168,11 @@ function submit() {
         if (err.code == '4001') {
           console.debug('User canceled Sig');
         }
-        console.error('ERROR', err);
-        return;
+        console.error('ERROR signing message', err);
+        updateInterface('success'); // signed message failing for HW wallets, this is okay as an edge case so we'll just move on
       } else if (result.error) {
-        console.error('ERROR', result.error.message);
-        return;
+        console.error('ERROR signing message', result.error.message);
+        updateInterface('success'); // signed message failing for HW wallets, this is okay as an edge case so we'll just move on
       }
       const signature = result.result.substring(2);
       const r = '0x' + signature.substring(0, 64);

--- a/app/quadraticlands/helpers.py
+++ b/app/quadraticlands/helpers.py
@@ -191,7 +191,7 @@ def get_initial_dist_breakdown(request):
             'GMV': int(initial_dist["GMV"]) / 10**18
         }
     except Exception as e: # if user doesn't have a token claim record in DB
-        logger.error(f'QuadLands: Error getting initial dist: {e}')
+        # logger.error(f'QuadLands: Error getting initial dist: {e}')
         context = {
             'active_user': 0,
             'kernel': 0,


### PR DESCRIPTION
##### Description

In QL delegate mode OFF workflow there is an issue with signing the vote message from some (mostly hardware) wallets. This PR will fix that issue by moving the user ahead even in the event that the signed message fails. 

##### Refers/Fixes

No bug filed yet for this that I'm aware of. 

