### PR TITLE
fix: Ensures notification box and search box remain scrollable for short viewports

### DIFF
--- a/app/assets/v2/scss/notifications.scss
+++ b/app/assets/v2/scss/notifications.scss
@@ -89,7 +89,7 @@ html.dark-mode {
 }
 
 .notifications__list {
-  max-height: 328px;
+  max-height: unquote("min(328px, calc(60vh - 112px))");
   overflow-y: auto;
   padding: 0;
   position: relative;
@@ -287,5 +287,11 @@ html.dark-mode {
 @media (min-width:768px) {
   .notifications__box {
     min-width: 430px!important;
+  }
+}
+
+@media (max-width:767.98px) {
+  .notifications__list {
+    max-height: unset;
   }
 }

--- a/app/assets/v2/scss/search.scss
+++ b/app/assets/v2/scss/search.scss
@@ -45,7 +45,7 @@
 }
 
 .gc-search-result {
-  max-height: 328px;
+  max-height: unquote("min(328px, calc(60vh - 112px))");
   overflow-y: auto;
   padding: 0;
   position: relative;
@@ -78,5 +78,11 @@
 @media (max-width: 768px) {
   .gc-search-box.dropdown-menu {
     width: 100%;
+  }
+}
+
+@media (max-width:767.98px) {
+  .gc-search-result {
+    max-height: unset;
   }
 }


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR prevents the notification box and search box from having a double scrollbar at any viewport size, and sets `height: auto;` for mobile.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Fixes: #8982

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally