### PR TITLE
Removing code where normalize_url() function is used when the input i…

### DIFF
--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -694,7 +694,6 @@ def get_bounty_id(issue_url, network):
 
 
 def get_bounty_id_from_db(issue_url, network):
-    issue_url = normalize_url(issue_url)
     bounties = Bounty.objects.filter(
         github_url=issue_url,
         network=network,


### PR DESCRIPTION
Removing code where normalize_url() function is used when the input is already Normalized.

get_bounty_id_from_db function is getting normalized URL but was again normalizing it for no good reason.