### PR TITLE
fix: Fixes position of sticky-nav after closing ql-banner

### DIFF
--- a/app/assets/v2/js/ql-banner.js
+++ b/app/assets/v2/js/ql-banner.js
@@ -1,6 +1,8 @@
 
 // check if the banner has been closed
 if (!localStorage.getItem('ql-banner')) {
+  // get body
+  const body = document.querySelector('body');
   // grab the elements
   const banner = document.getElementById('ql-banner');
   // grab the elements
@@ -11,7 +13,7 @@ if (!localStorage.getItem('ql-banner')) {
   const bannerInnerRow = document.querySelector('#ql-banner-inner .row');
 
   // show the banner
-  banner.style.display = 'flex';
+  body.classList.add('ql-banner-visible');
 
   // set up the kinetics (using custom implementation to contain the particles in a single el)
   const kinetics = new Kinetics({

--- a/app/assets/v2/scss/ql-banner.scss
+++ b/app/assets/v2/scss/ql-banner.scss
@@ -7,6 +7,10 @@
   z-index: 4;
 }
 
+body.ql-banner-visible #ql-banner {
+  display: flex;
+}
+
 #ql-banner-inner {
   height: 160px;
 }
@@ -79,7 +83,7 @@
   z-index: 0;
 }
 
-body:not(.navbar-menu-open) .sticky-nav {
+body.ql-banner-visible:not(.navbar-menu-open) .sticky-nav {
   top: 160px;
 }
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR ensures that after closing the ql-banner, the `top` position on the sticky-nav is `0px`

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
fixes: #9006

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally
