### PR TITLE
fix: bounty tab not loading on tribe when user is logged out

### DIFF
--- a/app/assets/v2/js/explorer.js
+++ b/app/assets/v2/js/explorer.js
@@ -212,6 +212,8 @@ Vue.component('bounty-explorer', Vue.extend({
     };
   },
   mounted() {
+    let vm = this;
+
     vm.bounties = [];
     vm.featuredBounties = [];
     if (this.tribe && this.tribe.handle) {

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3630,6 +3630,9 @@ def profile(request, handle, tab=None):
     user_only_tabs = ['viewers', 'earnings', 'spent', 'trust']
     tab = default_tab if tab in user_only_tabs and not is_my_profile else tab
 
+    if not request.user.is_authenticated and tab in ['people', 'manage']:
+        tab = default_tab
+
     context = {}
     context['tags'] = [('#announce', 'bullhorn'), ('#mentor', 'terminal'), ('#jobs', 'code'), ('#help', 'laptop-code'), ('#other', 'briefcase'), ]
     # get this user
@@ -3724,7 +3727,6 @@ def profile(request, handle, tab=None):
             context['profile_handle'] = profile.handle
             context['title'] = profile.handle
             context['card_desc'] = profile.desc
-
 
             return TemplateResponse(request, 'profiles/tribes-vue.html', context, status=status)
         except Exception as e:


### PR DESCRIPTION
##### Description

This PR ensures logged out users are able to view bounties tab on org profiles

##### Refers/Fixes

https://github.com/gitcoinco/web/issues/9010


##### Testing

![Untitled](https://user-images.githubusercontent.com/5358146/121188557-ddf62100-c886-11eb-8e24-318c5d7aedb3.gif)

