### PR TITLE
bug: remove reference to gitcoin chat on hack project

### DIFF
--- a/app/assets/v2/js/vue-components.js
+++ b/app/assets/v2/js/vue-components.js
@@ -652,14 +652,6 @@ Vue.component('project-card', {
           <div class="text-left">
             <a :href="project_url" target="_blank" class="btn btn-sm btn-primary font-smaller-2">View Project</a>
             <a :href="project.bounty.url" class="btn btn-sm btn-outline-primary font-smaller-2">View Bounty</a>
-            <b-dropdown variant="outline-primary" toggle-class="btn" split-class="btn-primary">
-            <template v-slot:button-content>
-              <i class="fas fa-comment-dots" style="padding-top: 0.4em;padding-bottom: 0.3em;"></i>
-            </template>
-            <b-dropdown-item-button @click.prevent="chatWindow('@' +profile.handle);" v-for="profile in project.profiles" aria-describedby="dropdown-header-label" :key="profile.id">
-              @ [[ profile.handle ]]
-            </b-dropdown-item-button>
-            </b-dropdown>
           </div>
         </div>
 


### PR DESCRIPTION
##### Description

Chat button is removed on hackathon projects

![image](https://user-images.githubusercontent.com/5358146/121330418-a1343380-c933-11eb-8cc2-d3cee40e9a57.png)


##### Fixes

closes https://github.com/gitcoinco/web/issues/9021