### PR TITLE
chore : remove cap limit on std checkout

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -61,7 +61,7 @@ Vue.component('grants-cart', {
       windowWidth: window.innerWidth,
       userAddress: undefined,
       isCheckoutOngoing: false, // true once user clicks "Standard checkout" button
-      maxCartItems: 40, // Max supported items in cart at once
+      maxCartItems: 90, // Max supported items in cart at once
       // Checkout, zkSync
       zkSyncUnsupportedTokens: [], // Used to inform user which tokens in their cart are not on zkSync
       zkSyncEstimatedGasCost: undefined, // Used to tell user which checkout method is cheaper

--- a/app/grants/templates/grants/cart/eth.html
+++ b/app/grants/templates/grants/cart/eth.html
@@ -256,7 +256,7 @@
       </grants-cart-ethereum-zksync>
     
       <button class="btn btn-primary ml-0 ml-md-2 mt-2 mt-md-0 py-2 rounded-sm w-100" id='js-fundGrants-button'
-        @click="standardCheckout" :disabled="isCheckoutOngoing || grantsByTenant.length > maxCartItems"
+        @click="standardCheckout" :disabled="isCheckoutOngoing"
         v-b-tooltip.hover.top="'Traditional Ethereum easy payout using funds from your connected wallet (easiest option).'"
       >
         Standard Checkout
@@ -265,10 +265,10 @@
   </div>
 
   <small class="row justify-content-end mt-2">
-    <div v-if="grantsByTenant.length > maxCartItems">
-    Cart must have a maximum of [[maxCartItems]] items, but has [[ grantsByTenant.length ]] items.
-    Please remove [[ grantsByTenant.length - maxCartItems ]] item<span v-if="grantsByTenant.length - maxCartItems > 1">s</span>
-    from your cart to continue checkout.
+    <div v-if="grantsByTenant.length > maxCartItems" class="text-right">
+      Zksync Checkout supports only [[maxCartItems]] items.<br>
+      Please remove [[ grantsByTenant.length - maxCartItems ]] item<span v-if="grantsByTenant.length - maxCartItems > 1">s</span>
+      from your cart to use zksync checkout / use standard checkout instead.
     </div>
     <div v-else-if="isZkSyncDown">
       zkSync is down at the moment, so if you'd like to checkout now you may need to use standard checkout


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

- inc zksync limit to 90 (max is now 100 )
- Re-purposes the cartMaxItems to allow users to use standard checkout for any number of grants 
- Updates the text when cart exceeds 40 telling the user 
   - the reason zksync has been disabled
   - they should reduce how many items from the cart to enable it 
   - they can use standard checkout instead

##### Refers/Fixes
Closes https://github.com/gitcoinco/web/issues/8916
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
![uninstall_wv](https://user-images.githubusercontent.com/5358146/121554205-94950580-ca2f-11eb-99bd-a883d6e618eb.gif)
