### PR TITLE
chore: ensure get_prices doesn't break with missing data

### DIFF
--- a/app/economy/management/commands/get_prices.py
+++ b/app/economy/management/commands/get_prices.py
@@ -140,11 +140,10 @@ def coingecko(source, tokens):
 
     """Handle pulling market data from Coingecko."""
 
-    now = timezone.now()
-
     token_str = ''
     for token in tokens:
-        token_str += (token.conversion_rate_id + ',')
+        if token.conversion_rate_id:
+            token_str += (token.conversion_rate_id + ',')
 
     url =  f'https://api.coingecko.com/api/v3/simple/price?ids={token_str}&vs_currencies=usd,eth'
 
@@ -153,6 +152,11 @@ def coingecko(source, tokens):
     response = requests.get(url).json()
 
     for token in tokens:
+
+        if not token.symbol or not token.conversion_rate_id:
+            print(f'error: {token} is missing symbol /conversion_rate_id. skipping fetching conversion rate.')
+            continue
+
         from_currency = token.symbol
         conversion_rate_id = token.conversion_rate_id
         conversion_rates = response.get(conversion_rate_id)


### PR DESCRIPTION
##### Description

This ensures get_prices doesn't crash when user adds a token and doesn't set the conversion_rate_id param (which is mandatory) 

##### Refers/Fixes

https://gitcoincore.slack.com/archives/CAXQ7PT60/p1624028091237400

##### Testing

![uninstall_wv](https://user-images.githubusercontent.com/5358146/122739766-eac03f00-d2a0-11eb-9cda-f97aa5f08ac7.gif)
