### PR TITLE
GITC-81: broken kudos 404 page

### DIFF
--- a/app/kudos/templates/kudos_marketplace.html
+++ b/app/kudos/templates/kudos_marketplace.html
@@ -47,7 +47,7 @@
         {% if not listings %}
         <div class="text-center m-5 bg-white p-5">
           <h1>UH-OH!</h1>
-          The kudos you were looking for isn't here, but here's a surprise!
+          <p class="mb-0">The kudos you were looking for isn't here, but here's a surprise!</p>
           <img id="logo" src="{% static 'v2/images/kudos/assets/no-kudos.gif' %}"  width="500" class="mw-100" />
           <div class="m-3">
             {% trans "Feeling creative?" %} <a href="https://github.com/gitcoinco/kudosbadges/issues/new" target="_blank" class="">{% trans "Mint Your Own!" %}</a>


### PR DESCRIPTION
##### Description

fixes: broken kudos page

##### Refers/Fixes

GITC-81
<!-- If this PR is related to a Github issue, please add a link here. -->


<img width="1680" alt="Screenshot 2021-06-25 at 6 21 33 AM" src="https://user-images.githubusercontent.com/5358146/123353335-ea64c400-d57e-11eb-8a3e-11b8aa2fc2b9.png">
