### PR TITLE
GTC-84: could not convert string to float: '1\xa0000'

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2524,6 +2524,11 @@ def profile_job_opportunity(request, handle):
         profile.save()
     except (ProfileNotFoundException, ProfileHiddenException):
         raise Http404
+    except ValueError:
+        return JsonResponse(
+            {'error': 'Bad request'},
+            status=401
+        )
 
     response = {
         'status': 200,

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2527,7 +2527,7 @@ def profile_job_opportunity(request, handle):
     except ValueError:
         return JsonResponse(
             {'error': 'Bad request'},
-            status=401
+            status=400
         )
 
     response = {


### PR DESCRIPTION
##### Description

https://sentry.io/organizations/gitcoin/issues/1098741849/?project=1398424&query=is%3Aunresolved
Ensures POST call fails gracefully when values are not valid

##### Testing

Tested locally


https://gitcoin.atlassian.net/browse/GITC-84