### PR TITLE
GITC-82: fixes "ReferenceError: Cookielaw is not defined"

### DIFF
--- a/app/assets/cookielaw/js/cl.js
+++ b/app/assets/cookielaw/js/cl.js
@@ -1,27 +1,36 @@
-var Cookielaw = {
+document.addEventListener('DOMContentLoaded', () => {
 
-    createCookie: function (name, value, days) {
-        var date = new Date(),
-            expires = '';
-        if (days) {
-            date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-            expires = "; expires=" + date.toGMTString();
-        } else {
-            expires = "";
-        }
-        document.cookie = name + "=" + value + expires + "; path=/";
-    },
+    const Cookielaw = {
 
-    createCookielawCookie: function () {
-        this.createCookie('cookielaw_accepted', '1', 10 * 365);
-
-        if (typeof (window.jQuery) === 'function') {
-            if(jQuery(".sumome-react-wysiwyg-popup-container").length < 1){
-                jQuery('#CookielawBanner').slideUp();
+        createCookie: function (name, value, days) {
+            var date = new Date(),
+                expires = '';
+            if (days) {
+                date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+                expires = "; expires=" + date.toGMTString();
+            } else {
+                expires = "";
             }
-        } else {
-            document.getElementById('CookielawBanner').style.display = 'none';
-        }
-    }
+            document.cookie = name + "=" + value + expires + "; path=/";
+        },
 
-};
+        createCookielawCookie: function () {
+            this.createCookie('cookielaw_accepted', '1', 10 * 365);
+
+            if (typeof (window.jQuery) === 'function') {
+                if(jQuery(".sumome-react-wysiwyg-popup-container").length < 1){
+                    jQuery('#CookielawBanner').slideUp();
+                }
+            } else {
+                document.getElementById('CookielawBanner').style.display = 'none';
+            }
+        }
+    };
+
+    // check for banner content
+    const acceptCookieLaw = document.getElementById('CookielawBannerAccept');
+
+    if (acceptCookieLaw) {
+      acceptCookieLaw.addEventListener('click', () => Cookielaw.createCookielawCookie());
+    }
+});

--- a/app/kudos/templates/transaction/base.html
+++ b/app/kudos/templates/transaction/base.html
@@ -27,7 +27,6 @@
       var static_url = "{{ STATIC_URL }}";
       var media_url = "{{ MEDIA_URL }}";
     </script>
-    <script src="{% static "cookielaw/js/cl.js" %}"></script>
   </head>
   <body id="yge" class="transaction {{ class }}">
     {% include 'shared/tag_manager_2.html' %}

--- a/app/quadraticlands/templates/quadraticlands/components/nav.html
+++ b/app/quadraticlands/templates/quadraticlands/components/nav.html
@@ -1,4 +1,4 @@
-{% load i18n static matches cookielaw_tags %}
+{% load i18n static matches %}
 
 <header>
 

--- a/app/retail/templates/bounties/contributor.html
+++ b/app/retail/templates/bounties/contributor.html
@@ -33,7 +33,6 @@
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/landing_page.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/howitworks.scss" %} />
     {% endbundle %}
-    <script src="{% static "cookielaw/js/cl.js" %}"></script>
   </head>
   <body class="index d-flex flex-column g-font-muli contributor-page">
     <div class="content__main min-vh-100 d-md-flex flex-column">

--- a/app/retail/templates/bounties/contributor/explorer.html
+++ b/app/retail/templates/bounties/contributor/explorer.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load i18n static cookielaw_tags bundle %}
+{% load i18n static bundle %}
 <meta name="title" content="Issue & Open Bug Bounty Explorer | Gitcoin">
 <meta name="description" content="Find open bug bounties & freelance development jobs including crypto bounty reward value in USD, expiration date and bounty age.">
 {% bundle css file bounties %}

--- a/app/retail/templates/bounties/funder.html
+++ b/app/retail/templates/bounties/funder.html
@@ -19,7 +19,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="{% static "cookielaw/js/cl.js" %}"></script>
     {% include 'shared/head.html' with slim=1 %}
     {% include 'shared/cards_pic.html' %}
     {% bundle css file landing_page %}

--- a/app/retail/templates/bounties/funder/howworks.html
+++ b/app/retail/templates/bounties/funder/howworks.html
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load i18n static cookielaw_tags %}
+{% load i18n static %}
 
 <div class="howworks-toggle-container">
   <button type="button" id="funder-toggle" class="howworks-section-toggle">

--- a/app/retail/templates/cookielaw/banner.html
+++ b/app/retail/templates/cookielaw/banner.html
@@ -20,9 +20,7 @@
           </p>
         </div>
         <div class="col-4 col-md-2">
-          <a class="btn btn-primary font-body text-capitalize float-right"
-            href="javascript:Cookielaw.createCookielawCookie();">{% trans "COOKIE_INFO_OK" %}
-          </a>
+          <button id="CookielawBannerAccept" class="btn btn-primary font-body text-capitalize float-right">{% trans "COOKIE_INFO_OK" %}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR:

- moves the dismissal event binding to `cl.js` to avoid Cookielaw being `undefined`
- tidies up bad/duplicate inclusions
 
##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

fixes: GITC-82

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally