### PR TITLE
GITC-108: Fixes 500 errors when bounty.name contains unicode chars

### DIFF
--- a/app/assets/v2/js/pages/project-page.js
+++ b/app/assets/v2/js/pages/project-page.js
@@ -27,7 +27,7 @@
               break;
           }
 
-          let newUrl = `/hackathon/${vm.hackathon['slug']}/projects/${vm.project.id}/${vm.project.name}/${newPathName}?${window.location.search}`;
+          let newUrl = `${vm.project.url}/${newPathName}?${window.location.search}`;
 
           history.pushState({}, `${vm.hackathon['slug']} - ${newPathName}`, newUrl);
         },

--- a/app/assets/v2/js/vue-components.js
+++ b/app/assets/v2/js/vue-components.js
@@ -618,14 +618,6 @@ Vue.component('project-card', {
     };
   },
   props: [ 'project', 'edit', 'is_staff' ],
-  computed: {
-    project_url: function() {
-      let project = this.$props.project;
-      let project_name = (project.name || '').replace(/ /g, '-');
-
-      return `/hackathon/${project.hackathon.slug}/projects/${project.pk}/${project_name}`;
-    }
-  },
   methods: {
     projectModal() {
       let project = this.$props.project;
@@ -650,7 +642,7 @@ Vue.component('project-card', {
             [[ project.summary | truncate(500) ]]
           </p>
           <div class="text-left">
-            <a :href="project_url" target="_blank" class="btn btn-sm btn-primary font-smaller-2">View Project</a>
+            <a :href="project.url_project_page" target="_blank" class="btn btn-sm btn-primary font-smaller-2">View Project</a>
             <a :href="project.bounty.url" class="btn btn-sm btn-outline-primary font-smaller-2">View Bounty</a>
           </div>
         </div>

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -27,6 +27,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import reduce
 from logging import error
+from unidecode import unidecode
 from urllib.parse import urlsplit
 
 from django.conf import settings
@@ -5186,7 +5187,7 @@ class HackathonEvent(SuperModel):
     def save(self, *args, **kwargs):
         """Define custom handling for saving HackathonEvent."""
         if not self.slug:
-            self.slug = slugify(self.name)
+            self.slug = slugify(unidecode(self.name))
         super().save(*args, **kwargs)
 
 
@@ -5316,12 +5317,16 @@ class HackathonProject(SuperModel):
         return f"{self.name} - {self.bounty} on {self.created_on}"
 
     def url(self):
-        slug = slugify(self.name)
+        slug = slugify(unidecode(self.name))
         return f'/hackathon/projects/{self.hackathon.slug}/{slug}/'
 
-    def url_page(self):
-        slug = slugify(self.name)
-        return f'/hackathon/{self.bounty.org_name}/projects/{self.pk}/${self.name}'
+    def url_project_page(self):
+        slug = slugify(unidecode(self.name))
+        return f'/hackathon/{self.hackathon.slug}/projects/{self.pk}/{slug}'
+
+    def url_bounty_page(self):
+        slug = slugify(unidecode(self.name))
+        return f'/hackathon/{self.bounty.org_name}/projects/{self.pk}/{slug}'
 
     def get_absolute_url(self):
         return self.url()

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -213,7 +213,7 @@ class HackathonProjectSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = HackathonProject
-        fields = ('pk', 'chat_channel_id', 'status', 'badge', 'bounty', 'name', 'summary', 'work_url', 'profiles', 'hackathon', 'summary', 'logo', 'message', 'looking_members', 'winner', 'grant_obj', 'admin_url', 'comments',)
+        fields = ('pk', 'chat_channel_id', 'status', 'badge', 'bounty', 'name', 'summary', 'work_url', 'profiles', 'hackathon', 'summary', 'logo', 'message', 'looking_members', 'winner', 'grant_obj', 'admin_url', 'comments', 'url_project_page')
         depth = 1
 
     def get_comments(self, obj):

--- a/app/dashboard/templates/bounty/details.html
+++ b/app/dashboard/templates/bounty/details.html
@@ -218,7 +218,7 @@
                           {% endif %}
 
                           <div class="text-center mt-2">
-                            <a href="{{project.url_page}}" target="_blank" class="font-weight-bold card-subtitle">{{project.name}}</a>
+                            <a href="{{project.url_bounty_page}}" target="_blank" class="font-weight-bold card-subtitle">{{project.name}}</a>
                             <div class="mb-2">
                               <b class="text-muted font-smaller-2">Team Members</b>
                               <div class="mt-1">

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -1,4 +1,4 @@
-{% load i18n static bundle %}
+{% load i18n static bundle slug %}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -1004,7 +1004,7 @@
 
                           <div class="text-center mt-2">
                             <a href="{%if project.name %}
-                              {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slugify %}
+                              {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slug %}
                             {% else %}
                               {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id %}
                             {% endif %}

--- a/app/dashboard/templates/dashboard/hackathon/project_page.html
+++ b/app/dashboard/templates/dashboard/hackathon/project_page.html
@@ -41,10 +41,6 @@
         background: none !important;
       }
 
-      #hackathon-project-app {
-        margin-top: -14px !important;
-      }
-
       .bg-gc-blue {
         background-color: var(--gc-black);
         color: white;

--- a/app/dashboard/templates/dashboard/hackathon/projects.html
+++ b/app/dashboard/templates/dashboard/hackathon/projects.html
@@ -15,7 +15,7 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 
-{% load i18n static bundle %}
+{% load i18n static bundle slug %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -174,7 +174,7 @@
                     <h5 class="card-title text-uppercase">{{ project.name }}</h5>
                     <a href="
                     {% if project.name %}
-                        {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slugify %}
+                        {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slug %}
                     {% else %}
                         {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id %}
                     {% endif %}" class="font-weight-bold card-subtitle">Project Home</a>

--- a/app/dashboard/templates/profiles/tab_hackathons.html
+++ b/app/dashboard/templates/profiles/tab_hackathons.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n static slug %}
 
 <style>
 
@@ -68,7 +68,7 @@
       <div class="card-body">
         <h5 class="card-title text-uppercase"><a href="
          {% if project.name %}
-            {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slugify %}
+            {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id project_name=project.name|slug %}
           {% else %}
             {% url 'hackathon_project_page' hackathon=project.hackathon.slug project_id=project.id %}
           {% endif %}" target="_blank" class="font-weight-bold card-subtitle">{{ project.name }}</a></h5>

--- a/app/dashboard/templates/project/detail/info.html
+++ b/app/dashboard/templates/project/detail/info.html
@@ -15,9 +15,9 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load static humanize i18n grants_extra %}
-<div class="mt-3 mx-0 px-0">
+<div class="mx-0 px-0">
   <hackathon-project :hackathon="hackathon" :project="project" v-on:project:edit="projectModal()" inline-template>
-  <div class="row hackathon-project mt-3 mb-5">
+  <div class="row hackathon-project mb-5">
     <div class="col-12 px-0">
       <div class="bg-gc-blue px-3 pb-3 px-md-5 d-md-flex justify-content-between">
         <div class="col-12 col-md-6 py-2 pt-md-4 pb-md-1">

--- a/app/dashboard/templatetags/slug.py
+++ b/app/dashboard/templatetags/slug.py
@@ -1,0 +1,9 @@
+from django import template
+from unidecode import unidecode
+from django.utils.text import slugify
+
+register = template.Library()
+
+@register.filter
+def slug(value):
+    return slugify(unidecode(value))

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -32,6 +32,7 @@ import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
+from unidecode import unidecode
 
 from django.conf import settings
 from django.contrib import messages
@@ -5333,7 +5334,7 @@ def project_data(project_id):
             'winner': project.winner,
             'looking_members': project.looking_members,
             'work_url': project.work_url,
-            'url': reverse('hackathon_project_page', args=[project.hackathon.slug, project_id, slugify(project.name)]),
+            'url': reverse('hackathon_project_page', args=[project.hackathon.slug, project_id, slugify(unidecode(project.name))]),
             'demo': {
                 'url': project.extra.get('video_url', None),
                 'provider': project.extra.get('video_provider', None),
@@ -5397,7 +5398,7 @@ def hackathon_project_page(request, hackathon, project_id, project_name='', tab=
             'name': project.name,
             'id': project.id,
             'summary': project.summary,
-            'url': reverse('hackathon_project_page', args=[project.hackathon.slug, project_id, slugify(project.name)]),
+            'url': reverse('hackathon_project_page', args=[project.hackathon.slug, project_id, slugify(unidecode(project.name))]),
             'status': project.status,
             'winner': project.winner,
             'looking_members': project.looking_members,

--- a/app/grants/tasks.py
+++ b/app/grants/tasks.py
@@ -15,10 +15,13 @@ from celery.utils.log import get_task_logger
 from dashboard.models import Profile
 from grants.models import Grant, GrantCollection, Subscription
 from grants.utils import get_clr_rounds_metadata, save_grant_to_notion
-from marketing.mails import new_contributions, new_grant, new_grant_admin, notion_failure_email, thank_you_for_supporting
+from marketing.mails import (
+    new_contributions, new_grant, new_grant_admin, notion_failure_email, thank_you_for_supporting,
+)
 from marketing.models import Stat
 from perftools.models import JSONStore
 from townsquare.models import Comment
+from unidecode import unidecode
 
 logger = get_task_logger(__name__)
 
@@ -73,7 +76,7 @@ def update_grant_metadata(self, grant_id, retry: bool = True) -> None:
 
     # cheap calcs
     print(lineno(), round(time.time(), 2))
-    instance.slug = slugify(instance.title)[:49]
+    instance.slug = slugify(unidecode(instance.title))[:49]
     instance.twitter_handle_1 = instance.twitter_handle_1.replace('@', '')
     instance.twitter_handle_2 = instance.twitter_handle_2.replace('@', '')
 

--- a/app/kudos/models.py
+++ b/app/kudos/models.py
@@ -39,6 +39,7 @@ from economy.models import SuperModel
 from eth_utils import to_checksum_address
 from gas.utils import recommend_min_gas_price_to_confirm_in_time
 from pyvips.error import Error as VipsError
+from unidecode import unidecode
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +399,7 @@ class Token(SuperModel):
 
     @property
     def img_url(self):
-        return f'{settings.BASE_URL}dynamic/kudos/{self.pk}/{slugify(self.name)}'
+        return f'{settings.BASE_URL}dynamic/kudos/{self.pk}/{slugify(unidecode(self.name))}'
 
     @property
     def preview_img_url(self):
@@ -410,7 +411,7 @@ class Token(SuperModel):
 
     @property
     def url(self):
-        return f'{settings.BASE_URL}kudos/{self.pk}/{slugify(self.name)}'
+        return f'{settings.BASE_URL}kudos/{self.pk}/{slugify(unidecode(self.name))}'
 
     def get_absolute_url(self):
         return self.url
@@ -425,7 +426,7 @@ class Token(SuperModel):
             str: The relative URL for the Bounty.
 
         """
-        return f'/kudos/{self.pk}/{slugify(self.name)}'
+        return f'/kudos/{self.pk}/{slugify(unidecode(self.name))}'
 
     @property
     def is_available(self):

--- a/app/quests/models.py
+++ b/app/quests/models.py
@@ -9,6 +9,7 @@ from django.utils.text import slugify
 
 # Create your models here.
 from economy.models import SuperModel
+from unidecode import unidecode
 
 num_backgrounds = 34
 video_enabled_backgrounds = [4, 6, 8, 9, 10, 11, 13, 14, 22, 23, 34]
@@ -59,7 +60,7 @@ class Quest(SuperModel):
     ui_data = JSONField(default=dict, blank=True)
     edit_comments = models.TextField(default='', blank=True)
     admin_comments = models.TextField(default='', blank=True)
-    
+
     def __str__(self):
         """Return the string representation of this obj."""
         return f'{self.pk}, {self.title} (visible: {self.visible})'
@@ -75,7 +76,7 @@ class Quest(SuperModel):
 
     @property
     def relative_url(self):
-        return f"quests/{self.pk}/{slugify(self.title)}"
+        return f"quests/{self.pk}/{slugify(unidecode(self.title))}"
 
     @property
     def edit_url(self):

--- a/app/retail/templates/results.html
+++ b/app/retail/templates/results.html
@@ -15,7 +15,7 @@
   along with this program. If not,see
   <http://www.gnu.org/licenses/>.
 {% endcomment %}
-{% load humanize i18n static bundle %}
+{% load humanize i18n static bundle slug %}
 {% load kudos_extras %}
 
 <!DOCTYPE html>
@@ -249,7 +249,7 @@
             <div class="row">
               <div class="col-md-12 p-1">
                 {% for kudos_leaderboard in kudos_leaderboards %}
-              <div id="{{kudos_leaderboard.0|slugify}}" class="col-md-12 p-1 hidden leaderboard_target">
+              <div id="{{kudos_leaderboard.0|slug}}" class="col-md-12 p-1 hidden leaderboard_target">
                 <div class="justify-content-center align-items-center p-3 pt-1 mt-1 ">
                   <p style="text-align: center; font-size: 0.9rem;">Kudos is a digital collectible + a way of showing your appreciation for another Gitcoin member. It's also a way to showcase special skills that a member might have, such as Pythonista, or Design Star. Kudos tokens can also be bought and sold on the <a href="/kudos/marketplace">Kudos Marketplace</a>.</p>
                 </div>

--- a/app/retail/templates/shared/activity.html
+++ b/app/retail/templates/shared/activity.html
@@ -16,7 +16,7 @@
 
 {% endcomment %}
 
-{% load humanize i18n static grants_extra %}
+{% load humanize i18n static grants_extra slug %}
 <div class="box d-block m-0 mb-3 activity {% if is_pin %} pinned-activity {% else %} infinite-item {% endif %} {{ row.activity_type }} px-sm-3 py-4" {% if not is_pin %} data-pk="{{row.pk}}" {% endif %}>
   <div class="activity_main pl-2 row bg_{{ row.activity_type }} m-0">
     <div class="col-2 p-0">
@@ -75,7 +75,7 @@
           {% endif %}
           {% if row.project %}
             {% if row.project.name %}
-              <a href="{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slugify %}" class="tag"   data-toggle="tooltip" title="Go to {{ row.project.name }}">via {{ row.project.name }}</a>
+              <a href="{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slug %}" class="tag"   data-toggle="tooltip" title="Go to {{ row.project.name }}">via {{ row.project.name }}</a>
             {% else %}
               <a href="{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id %}" class="tag"   data-toggle="tooltip" title="Go to project {{ row.project.id }}">via project {{ row.project.id }}</a>
             {% endif %}
@@ -611,7 +611,7 @@
   </div>
   {% elif row.activity_type == 'new_hackathon_project' and not for_email %}
   <div class="mt-1 mb-2">
-    <div class="row align-items-center bg-light content py-3" data-href="{% if row.project.name %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slugify %}{% else %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id %}{% endif %}">
+    <div class="row align-items-center bg-light content py-3" data-href="{% if row.project.name %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id project_name=row.project.name|slug %}{% else %}{% url 'hackathon_project_page' hackathon=row.project.hackathon.slug project_id=row.project.id %}{% endif %}">
       <div class="col-12 col-md-2 text-center">
         {% if row.project.logo %}
           <img class="logo-metacard rounded-circle" src="{{MEDIA_URL}}{{row.project.logo}}" alt="Hackathon logo" />

--- a/app/townsquare/models.py
+++ b/app/townsquare/models.py
@@ -9,6 +9,7 @@ from django.utils.text import slugify
 
 import townsquare.clr as clr
 from economy.models import SuperModel
+from unidecode import unidecode
 
 
 class Like(SuperModel):
@@ -172,7 +173,7 @@ class Offer(SuperModel):
 
     @property
     def view_url(self):
-        slug = slugify(self.title)
+        slug = slugify(unidecode(self.title))
         return f'/action/{self.pk}/{slug}'
 
     def get_absolute_url(self):
@@ -358,10 +359,10 @@ class MatchRanking(SuperModel):
 
 
 def get_eligible_input_data(mr):
-    from dashboard.models import Tip
-    from django.db.models import Q, F
-    from dashboard.models import Earning, Profile
     from django.contrib.contenttypes.models import ContentType
+    from django.db.models import F, Q
+
+    from dashboard.models import Earning, Profile, Tip
     network = 'mainnet'
     earnings = Earning.objects.filter(created_on__gt=mr.valid_from, created_on__lt=mr.valid_to)
     # filter out earnings that have invalid info (due to profile deletion), or dont have a USD value, or are not on the correct network

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -116,3 +116,4 @@ rcssmin==1.0.6
 libsass==0.20.1
 graphqlclient==0.2.4
 docutils==0.17.1
+unidecode==1.2.0


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR fixes the project_page by ensuring any `project.name` containing unicode is decoded prior to slugifying (this same fix is applied to every use of slugify across the codebase), also DRYs up the process by declaring URLs in the model avoiding the need to recreate them on the frontend and corrects some minor styling issues.

* Note: this PR adds `unidecode` as a dependency

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-108

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally