### PR TITLE
GITC-129: Ignores any contributions which do not have a profile associated from create_top_grant_spenders_cache

### DIFF
--- a/app/perftools/management/commands/create_page_cache.py
+++ b/app/perftools/management/commands/create_page_cache.py
@@ -136,7 +136,7 @@ def create_top_grant_spenders_cache():
         count_dict = {ele[0]:0 for ele in contributions}
         sum_dict = {ele[0]:0 for ele in contributions}
         for ele in contributions:
-            if ele[1]:
+            if ele[0] and ele[1]:
                 count_dict[ele[0]] += 1
                 sum_dict[ele[0]] += ele[1]
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR adds a defensive check to make sure the profile is set before summing contributions in create_top_grant_spenders_cache.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-129
