### PR TITLE
Straw man fix for gitcoin.co/townsquare?dressing=1 being hella flow

### DIFF
--- a/app/townsquare/views.py
+++ b/app/townsquare/views.py
@@ -124,7 +124,7 @@ def get_sidebar_tabs(request):
                 'title': f"Relationships",
                 'slug': key,
                 'helper_text': f'Activity from the users who you\'ve done business with Gitcoin',
-                'badge': max_of_ten(get_specific_activities(key, False, request.user, request.session.get(key, 0)).count()) if request.GET.get('tab') != key else 0
+                'badge': 0
             }
             tabs = [new_tab] + tabs
             default_tab = 'my_tribes'
@@ -136,7 +136,7 @@ def get_sidebar_tabs(request):
                 'title': f'Grants',
                 'slug': key,
                 'helper_text': f'Activity on the Grants you\'ve created or funded.',
-                'badge': max_of_ten(get_specific_activities(key, False, request.user, request.session.get(key, 0)).count()) if request.GET.get('tab') != key else 0
+                'badge': 0,
             }
             tabs = [new_tab] + tabs
             default_tab = 'grants'
@@ -144,7 +144,7 @@ def get_sidebar_tabs(request):
         num_favorites = request.user.favorites.filter(grant=None).all().count()
         if num_favorites:
             key = 'my_favorites'
-            activities = get_specific_activities(key, False, request.user, request.session.get(key, 0)).count()
+            activities = 0
             new_tab = {
                 'title': f"My Favorites",
                 'slug': key,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
Looking at the [datadog trace](https://app.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Adjango%20resource_name%3A%2Atownsquare%2A%20%40duration%3A%3E%3D12.5s&index=apm-search&spanID=1926285002054291218&streamTraces=true&traceID=15069572059855755779&start=1625234553487&end=1625235453487&paused=false) its clear to me that the lookup for activity counts (to show on the badges) is the slow part in a production like env

this pr removes those, under the judgement call that the badges arent worth a 30s load time (and the subsequent load on the db that comes from that).

in the future, refactoring on the activity table (maybe just a db index, but it probably is getting big enough it doesnt belong in postgres too) may be necessary if we want to query this table deeply in the future

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://gitcoincore.slack.com/archives/CAXQ7PT60/p1625158054329700
https://app.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Adjango%20resource_name%3A%2Atownsquare%2A%20%40duration%3A%3E%3D12.5s&index=apm-search&spanID=1926285002054291218&streamTraces=true&traceID=15069572059855755779&start=1625234553487&end=1625235453487&paused=false

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested Locally