### PR TITLE
GITC-182 chore: add endpoint for GrantCLR metadata

### DIFF
--- a/app/grants/serializers.py
+++ b/app/grants/serializers.py
@@ -1,7 +1,7 @@
 from dashboard.router import ProfileSerializer
 from rest_framework import serializers
 
-from .models import CLRMatch, Contribution, Grant, Subscription
+from .models import CLRMatch, Contribution, Grant, GrantCLR, Subscription
 from .utils import amount_in_wei, get_converted_amount
 
 
@@ -132,3 +132,13 @@ class DonorSerializer(serializers.Serializer):
         """Define the Donor serializer metadata."""
 
         fields = ('grant_name', 'asset', 'timestamp', 'grant_amount', 'gitcoin_maintenance_amount', 'grant_usd_value', 'gitcoin_usd_value')
+
+
+class GrantCLRSerializer(serializers.ModelSerializer):
+    """Handle metadata of CLR rounds"""
+    class Meta:
+        """Define the GrantCLR serializer metadata."""
+        model = GrantCLR
+        fields = (
+            'id', 'display_text', 'round_num', 'is_active', 'start_date', 'end_date'
+        )


### PR DESCRIPTION
##### Description

Introduces a new endpoint for `/clr_round_metadata` to get information on rounds 

**URL:**  `api/v0.1/grants/get_clr_round_metadata`

**Parameters:**
_Note: All parameters are optional_

- `id=<number>` -> returns specific CLR round 
- `active=true` -> returns only active rounds
- `from_timestamp` -> returns CLR rounds which started after given date. Format: `YYYY-MM-DD`
- `to_timestamp` -> returns CLR rounds which ended before given date. Format: `YYYY-MM-DD`

##### Refers/Fixes

- https://github.com/gitcoinco/web/issues/9255
- https://github.com/gitcoinco/web/issues/9256
- GITC-182
- GITC-190 


##### Testing

<img width="1285" alt="Screenshot 2021-07-07 at 7 26 56 PM" src="https://user-images.githubusercontent.com/5358146/124784325-70abdd80-df63-11eb-8936-c8f3d5262052.png">
