### PR TITLE
/administration/mesh performance fix, so i can ship GR10 data viz

### DIFF
--- a/app/dataviz/d3_views.py
+++ b/app/dataviz/d3_views.py
@@ -752,7 +752,7 @@ def mesh_network_viz(request, ):
     _type = request.GET.get('type', 'all')
     theme = request.GET.get('theme', 'light')
     show_labels = request.GET.get('show_labels', '0')
-    trim_pct = int(request.GET.get('trim_pct', '0'))
+    trim_pct = int(request.GET.get('trim_pct', '0')) - 1
 
     since = f"{year}/{month}/{day}"
 

--- a/app/dataviz/d3_views.py
+++ b/app/dataviz/d3_views.py
@@ -752,6 +752,7 @@ def mesh_network_viz(request, ):
     _type = request.GET.get('type', 'all')
     theme = request.GET.get('theme', 'light')
     show_labels = request.GET.get('show_labels', '0')
+    trim_pct = int(request.GET.get('trim_pct', '0'))
 
     since = f"{year}/{month}/{day}"
 
@@ -767,6 +768,8 @@ def mesh_network_viz(request, ):
         }
         earnings = earnings.filter(source_type=mapping[_type])
     earnings = earnings.values_list('from_profile', 'to_profile')
+    if trim_pct:
+        earnings = earnings.extra(where=[f'MOD(id, 100) > {trim_pct}'])
     for obj in earnings:
         handle1 = obj[0]
         handle2 = obj[1]
@@ -807,6 +810,8 @@ def mesh_network_viz(request, ):
         "theme": theme,
         "themes": ['light', 'dark'],
         "show_labels_options": ['1', '0'],
+        'trim_pct_options': range(0,100),
+        'trim_pct': trim_pct,
         "day": day,
         "to_year": to_year,
         "to_month": to_month,

--- a/app/dataviz/templates/dataviz/mesh.html
+++ b/app/dataviz/templates/dataviz/mesh.html
@@ -407,6 +407,11 @@ Drawing.SimpleGraph = function(options) {
 
     <div style="position: absolute; bottom: 0;">
       <form method=GET>
+      <select name="trim_pct">
+        {% for option in trim_pct_options %}
+          <option value="{{option}}" {% if trim_pct == option %}selected=selected{%endif%}  >Trimmed:{{option}}%</option>
+        {% endfor %}
+      </select>
       <select name="show_labels">
         {% for option in show_labels_options %}
           <option value="{{option}}" {% if show_labels == option %}selected=selected{%endif%}  >Label:{{option}}</option>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
https://gitcoin.co/_administration/mesh wasnt loading the most recent grants rounds data anymore, because its just TOO much data (400k rows).  so i wrote a trimmer that thins out the data so the network can still be representatively viewed without the system suffering in-browser-memory issues or 504 gateway timeouts on the server side.

this PR trims nodes from the mesh network for browser perf reasons, so we can view GR10 mesh data and update this thread https://twitter.com/owocki/status/1375278049420144645

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://gitcoin.co/_administration/mesh if you try to view most recent grants round

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
tested locally