### PR TITLE
GITC-40: remove metadata from bounty api

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -322,7 +322,7 @@ class BountySerializerSlim(BountySerializer):
             'fulfillment_started_on', 'fulfillment_submitted_on', 'canceled_on', 'web3_created', 'bounty_owner_address',
             'avatar_url', 'network', 'standard_bounties_id', 'github_org_name', 'interested', 'token_name', 'value_in_usdt',
             'keywords', 'value_in_token', 'project_type', 'is_open', 'expires_date', 'latest_activity', 'token_address',
-            'bounty_categories', 'metadata'
+            'bounty_categories'
         )
 
 


### PR DESCRIPTION
##### Description

Removes metadata from the bounty model

##### Refers/Fixes

GITC-40

##### Testing

Flows tested
- Creation
- Start / Approve Work
- Submit Work
- Payout 
- the bounty showing up on the Explorer 