### PR TITLE
GITC-198: Puts QD mission behind staff flag on mission page

### DIFF
--- a/app/quadraticlands/templates/quadraticlands/mission/index.html
+++ b/app/quadraticlands/templates/quadraticlands/mission/index.html
@@ -21,10 +21,12 @@
 <!-- governance missions-->
 <section class="mission">
 
-  <!-- Quadratic Diplomacy -->
-  {% with name="Quadratic Diplomacy" %}
-    {% include 'quadraticlands/mission/card.html' with svg="diplomacy.svg" message="available" playable="true" url="/quadraticlands/mission/diplomacy" %}
-  {% endwith %}
+  {% if is_staff %}
+    <!-- Quadratic Diplomacy -->
+    {% with name="Quadratic Diplomacy" %}
+      {% include 'quadraticlands/mission/card.html' with svg="diplomacy.svg" message="available" playable="true" url="/quadraticlands/mission/diplomacy" %}
+    {% endwith %}
+  {% endif %}
 
   <!-- Discourse Forum -->
   {% with name="Discourse Forum" %}


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR puts the Quadratic Diplomacy mission behind a staff flag on the mission homepage

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
Fixes: GITC-198

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally