### PR TITLE
GITC-201: Imports NOTION_API_KEY and NOTION_SYBIL_DB directly

### DIFF
--- a/app/grants/utils.py
+++ b/app/grants/utils.py
@@ -29,7 +29,7 @@ from secrets import token_hex
 from django.templatetags.static import static
 from django.utils import timezone
 
-from app.settings import BASE_DIR, BASE_URL, MEDIA_URL, STATIC_HOST, STATIC_URL
+from app.settings import BASE_DIR, BASE_URL, MEDIA_URL, NOTION_API_KEY, NOTION_SYBIL_DB, STATIC_HOST, STATIC_URL
 from app.utils import notion_write
 from avatar.utils import convert_img
 from economy.utils import ConversionRateNotFoundError, convert_amount
@@ -323,12 +323,12 @@ def sync_payout(contribution):
 def save_grant_to_notion(grant):
     """Post an insert to notions sybil-db table"""
     # check for notion credentials before attempting insert
-    if settings.NOTION_SYBIL_DB and settings.NOTION_API_KEY:
+    if NOTION_SYBIL_DB and NOTION_API_KEY:
         # fully qualified url
-        fullUrl = settings.BASE_URL.rstrip('/') + grant.url
+        fullUrl = BASE_URL.rstrip('/') + grant.url
 
         # write to NOTION_SYBIL_DB following the defined schema (returns dict of new object)
-        return notion_write(settings.NOTION_SYBIL_DB, {
+        return notion_write(NOTION_SYBIL_DB, {
             'Current Status': {
                 'id': 'ea{s',
                 'type': 'select',


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR Imports NOTION_API_KEY and NOTION_SYBIL_DB directly allowing the continued use of `save_grant_to_notion()`

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-201

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally