### PR TITLE
GITC-207: Updating watchtower version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,7 +80,7 @@ pydoc-markdown==2.0.4
 oauth2client==4.1.3
 pyvips==2.1.4
 redis-semaphore
-watchtower==0.5.4
+watchtower==1.0.6
 Wand==0.4.4
 raven==6.9.0
 sentry-sdk==1.1.0


### PR DESCRIPTION
##### Description

This outdated version is causing a series of evens that results in errors being sent to AWS every few seconds. Increasing the version of watchtower should resolve the issue and stop the logs coming in over and over for the same issue.

##### Testing

Need to test on staging or prod as the logging is not set up locally to be pushed to AWS.
