### PR TITLE
GITC-208: fix QD signature failing when saved

### DIFF
--- a/app/assets/v2/js/quadraticlands/mission/diplomacy/room.js
+++ b/app/assets/v2/js/quadraticlands/mission/diplomacy/room.js
@@ -255,13 +255,15 @@ async function vouche() {
     result.push(entry);
   });
 
+  let balance = await getTokenBalances(gtc_address());
+
   // @kev : do something with the result ( sign, safe, whatever)
   // this is how far i could come. now your turn :)
   const accounts = await web3.eth.getAccounts();
   const account = accounts[0];
   const _package = {
     votes: result,
-    balance: balance,
+    balance: balance.balance,
     account: account
   };
   let signature = await web3.eth.personal.sign(


### PR DESCRIPTION
##### Description

Looks like when you try to vouch on https://gitcoin.co/quadraticlands/mission/diplomacy/fe7d112e-4b90-454d-a716-3f074809a1b0/gitcoin-frens
It fails due to incorrect balance being passed from the frontend

##### Testing

Tested Locally