### PR TITLE
GITC-165: Increase celery task_time_limit to account for longer running tasks (v2)

### DIFF
--- a/app/dashboard/tasks.py
+++ b/app/dashboard/tasks.py
@@ -258,7 +258,7 @@ def maybe_market_to_user_slack(self, bounty_pk, event_name, retry: bool = True) 
         maybe_market_to_user_slack_helper(bounty, event_name)
 
 
-@app.shared_task(bind=True, max_retries=3)
+@app.shared_task(bind=True, soft_time_limit=600, time_limit=660, max_retries=3)
 def grant_update_email_task(self, pk, retry: bool = True) -> None:
     """
     :param self:

--- a/app/grants/tasks.py
+++ b/app/grants/tasks.py
@@ -31,7 +31,7 @@ def lineno():
     """Returns the current line number in our program."""
     return inspect.currentframe().f_back.f_lineno
 
-@app.shared_task(bind=True, max_retries=1)
+@app.shared_task(bind=True, soft_time_limit=600, time_limit=660, max_retries=1)
 def update_grant_metadata(self, grant_id, retry: bool = True) -> None:
 
     if settings.FLUSH_QUEUE:

--- a/app/townsquare/tasks.py
+++ b/app/townsquare/tasks.py
@@ -14,7 +14,7 @@ redis = RedisService().redis
 # Lock timeout of 2 minutes (just in the case that the application hangs to avoid a redis deadlock)
 LOCK_TIMEOUT = 60 * 2
 
-@app.shared_task(bind=True, max_retries=3)
+@app.shared_task(bind=True, soft_time_limit=600, time_limit=660, max_retries=3)
 def increment_view_counts(self, pks, retry=False):
     """
     :param self:


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will double the time given to a celery task before it will fail (if we still get errors we will need to profile the longest running tasks on production/staging and set these values accordingly)

Tasks covered in this PR ([see breadcrumbs on this sentry regression](https://sentry.io/organizations/gitcoin/issues/1506566643/?project=1398424&query=is%3Aunresolved+300s&statsPeriod=14d)):

- grant_update_email_task
- increment_view_counts
- update_grant_metadata

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-165

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested configuration locally
