### PR TITLE
GITC-211: upgrade zksync to 0.0.13

### DIFF
--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -141,7 +141,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     {% comment %} ===================== START ZKSYNC SCRIPTS ====================== {% endcomment %}
     <script type="text/javascript" src="https://cdn.ethers.io/lib/ethers-5.0.umd.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/zksync-checkout@0.0.11/dist/main.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/zksync-checkout@0.0.13/dist/main.js"></script>
     {% comment %} ====================== END ZKSYNC SCRIPTS ======================= {% endcomment %}
 
     <script>


### PR DESCRIPTION
##### Description

Check GITC-211 for complete story.
TLDR: zksync rinkeby was broken due to few issues. Team advised on upgrading and this PR does that and tests to ensure the following flow works

- Contributing to a Grant via L2 with no deposit
- Making the deposit
- Doing the actual transfer
- Saving the right txn ID

The same flow was also tested with the account not having to do a deposit as funds were already present. 
It worked as expected

##### Refers/Fixes

GITC-211 

![uninstall_wv](https://user-images.githubusercontent.com/5358146/125805033-d6ce61f6-41a2-4bae-b430-7b955cda8c78.gif)

