### PR TITLE
GITC-213: Purges generate_grants_leaderboard as the resultant JSONStore is unused

### DIFF
--- a/app/grants/utils.py
+++ b/app/grants/utils.py
@@ -93,42 +93,6 @@ def get_upload_filename(instance, filename):
     file_path = os.path.basename(filename)
     return f"grants/{getattr(instance, '_path', '')}/{salt}/{file_path}"
 
-
-def get_leaderboard():
-    return JSONStore.objects.filter(view='grants', key='leaderboard').order_by('-pk').first().data
-
-
-def generate_grants_leaderboard(max_items=100):
-    from grants.models import Subscription, Contribution
-    handles = Subscription.objects.exclude(contributor_profile__isnull=True).values_list('contributor_profile__handle', flat=True)
-    default_dict = {
-        'rank': None,
-        'no': 0,
-        'sum': 0,
-        'handle': None,
-    }
-    users_to_results = { ele : default_dict.copy() for ele in handles }
-
-    # get all contribution attributes
-    for contribution in Contribution.objects.exclude(profile_for_clr__isnull=True).select_related('subscription'):
-        key = contribution.subscription.contributor_profile.handle
-        users_to_results[key]['handle'] = key
-        amount = contribution.subscription.get_converted_amount(False)
-        if amount:
-            users_to_results[key]['no'] += 1
-            users_to_results[key]['sum'] += round(amount)
-    # prepare response for view
-    items = []
-    counter = 1
-    for item in sorted(users_to_results.items(), key=lambda kv: kv[1]['sum'], reverse=True):
-        item = item[1]
-        if item['no']:
-            item['rank'] = counter
-            items.append(item)
-            counter += 1
-    return items[:max_items]
-
-
 def is_grant_team_member(grant, profile):
     """Checks to see if profile is a grant team member
 

--- a/app/perftools/management/commands/create_page_cache.py
+++ b/app/perftools/management/commands/create_page_cache.py
@@ -30,7 +30,7 @@ from dashboard.models import Activity, HackathonEvent, Profile
 from dashboard.utils import set_hackathon_event
 from economy.models import EncodeAnything
 from grants.models import Contribution, Grant, GrantCategory, GrantType
-from grants.utils import generate_grants_leaderboard, get_clr_rounds_metadata
+from grants.utils import get_clr_rounds_metadata
 from marketing.models import Stat
 from perftools.models import JSONStore
 from quests.helpers import generate_leaderboard
@@ -261,17 +261,6 @@ def create_activity_cache():
             data=json.loads(json.dumps(data, cls=EncodeAnything)),
             )
 
-def create_grants_cache():
-    print('grants')
-    view = 'grants'
-    keyword = 'leaderboard'
-    data = generate_grants_leaderboard()
-    JSONStore.objects.create(
-        view=view,
-        key=keyword,
-        data=json.loads(json.dumps(data, cls=EncodeAnything)),
-        )
-
 
 def create_quests_cache():
 
@@ -401,7 +390,6 @@ class Command(BaseCommand):
             operations.append(create_top_grant_spenders_cache)
             operations.append(create_avatar_cache)
             operations.append(create_quests_cache)
-            operations.append(create_grants_cache)
             operations.append(create_contributor_landing_page_context)
             operations.append(create_hackathon_cache)
             operations.append(create_hackathon_list_page_cache)

--- a/scripts/debug/add_grants_team_members.py
+++ b/scripts/debug/add_grants_team_members.py
@@ -1,6 +1,6 @@
 from dashboard.models import Profile
 from grants.models import *
-from grants.utils import get_leaderboard, is_grant_team_member
+from grants.utils import is_grant_team_member
 
 handles = [
     'adamstallard',


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

`grants.utils.generate_grants_leaderboard` returns a dict which is saved to a JSONStore in `create_page_cache`.

This method is performing a conversion for every subscription and is causing `create_page_cache` to be killed before completing and the resultant JSONStore (if it was to be written) is unused.

This PR will purge all references.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-213

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally