### PR TITLE
GITC-214: Fixes sync_profile by storing the NamedUser.raw_data vs NamedUser instance

### DIFF
--- a/app/app/utils.py
+++ b/app/app/utils.py
@@ -125,7 +125,7 @@ def actually_sync_profile(handle, user=None, hide_profile=True):
         logger.warning(f'Failed to fetch github username {handle}', exc_info=True, extra={'handle': handle})
         return None
 
-    defaults = {'last_sync_date': timezone.now(), 'data': data}
+    defaults = {'last_sync_date': timezone.now(), 'data': data.raw_data}
 
     if user and isinstance(user, User):
         defaults['user'] = user


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR fixes `sync_profile` by storing the `NamedUser.raw_data` instead of the `NamedUser` instance

See here for details: https://github.com/PyGithub/PyGithub/blob/4faff23ce9eab00c451ffdd842686781e8a1b4eb/github/GithubObject.py

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-214

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally