### PR TITLE
GITC-212: Adds button to admin to refresh hackathon events cache

### DIFF
--- a/app/dashboard/admin.py
+++ b/app/dashboard/admin.py
@@ -35,6 +35,7 @@ from .models import (
     TransactionHistory, TribeMember, TribesSubscription, UserAction, UserVerificationModel,
 )
 
+from perftools.management.commands import create_page_cache
 
 class BountyEventAdmin(admin.ModelAdmin):
     list_display = ['created_on', '__str__', 'event_type']
@@ -501,6 +502,14 @@ class HackathonEventAdmin(admin.ModelAdmin):
             except Exception as e:
                 print(e)
                 self.message_user(request, "unable to update bounty expiry dates")
+        elif "_update_hackathon_events_cache" in request.POST:
+            try:
+                create_page_cache.create_hackathon_list_page_cache()
+                self.message_user(request, "updated hackthon events cache")
+            except Exception as e:
+                print(e)
+                self.message_user(request, "unable to update hackathon events cache")
+
         return redirect(obj.admin_url)
 
 class CouponAdmin(admin.ModelAdmin):

--- a/app/retail/templates/admin/change_form.html
+++ b/app/retail/templates/admin/change_form.html
@@ -62,7 +62,7 @@
       {% if not original.active %}
         <textarea name="more_info" style="background-color:white; color: black; border: 1px solid;">Can you prove your ownership of this brand?</textarea>
         <input type="submit" value="Request More Info" name="_request_more_info" value="1">
-        | 
+        |
         <input type="submit" value="Approve Grant" name="_approve_grant" value="1">
       {% else %}
       N/A
@@ -106,6 +106,7 @@
       <input type="submit" value="Approve Request" name="_approve_quest" value="1">
     {% elif 'dashboard/hackathonevent/' in request.build_absolute_uri %}
       <input type="submit" value="Update Related Bounties Expiry Date" name="_bulk_update_expiry" value="1">
+      <input type="submit" value="Update Hackathon Events Cache" name="_update_hackathon_events_cache" value="1">
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR adds a button to the Hackathon Events admin page to refresh the hackathons-list cache

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-212

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally