### PR TITLE
GITC-234 bug: user being able to fire multiple start work events

### DIFF
--- a/app/assets/v2/js/pages/bounty_details2.js
+++ b/app/assets/v2/js/pages/bounty_details2.js
@@ -1119,7 +1119,7 @@ var show_interest_modal = function() {
           _alert({ message: gettext('Please provide an action plan for this ticket. (min 30 chars)') }, 'danger');
           return false;
         }
-
+        $('#submit').attr('disabled', true);
         add_interest(document.result['pk'], {
           issue_message: msg
         }).then(success => {
@@ -1156,20 +1156,6 @@ var show_interest_modal = function() {
   });
   modals.bootstrapModal('show');
 };
-
-// $('body').on('click', '.issue_description img', function() {
-//   var content = $.parseHTML(
-//     '<div><div class="row"><div class="col-12 closebtn">' +
-//       '<a id="" rel="modal:close" href="javascript:void" class="close" aria-label="Close dialog">' +
-//         '<span aria-hidden="true">&times;</span>' +
-//       '</a>' +
-//     '</div>' +
-//     '<div class="col-12 pt-2 pb-2"><img class="magnify" src="' + $(this).attr('src') + '"/></div></div></div>');
-
-//   $(content).appendTo('body').modal({
-//     modalClass: 'modal magnify'
-//   });
-// });
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
##### Description

> Report from Algorand:
Hi all, we found a potential bug of Gitcoin in one of our bounty: https://gitcoin.co/issue/algorandfoundation/grow-algorand/79/100026111
A user named “igarrestu” somehow managed to apply to this bounty multiple times and you can see the record in the bounty page. 
Would you consider this is bug in Gitcoin’s anti-spam feature?


We already have backend checks for this. 
The only time this issue occurs is when users fire click the interest button in quick sucessions -> leading the check to fail as 
the first request is yet to have been saved.

This PR fixes ensure the frontend disables the button preventing the user from clicking it multiple times

##### Refers/Fixes

GITC-234
##### Testing

Tested locally.
