### PR TITLE
GITC-223: ignore squelched profiles in clr

### DIFF
--- a/app/app/bundle_context.py
+++ b/app/app/bundle_context.py
@@ -21,6 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from cacheops import cached_as
 from perftools.models import JSONStore
 
+
 @cached_as(JSONStore.objects.filter(view='bundleTags', key='bundleTags'), timeout=60)
 def templateTags():
 

--- a/app/dashboard/admin.py
+++ b/app/dashboard/admin.py
@@ -25,6 +25,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from adminsortable2.admin import SortableInlineAdminMixin
+from perftools.management.commands import create_page_cache
 
 from .models import (
     Activity, Answer, BlockedIP, BlockedURLFilter, BlockedUser, Bounty, BountyEvent, BountyFulfillment, BountyInvites,
@@ -35,7 +36,6 @@ from .models import (
     TransactionHistory, TribeMember, TribesSubscription, UserAction, UserVerificationModel,
 )
 
-from perftools.management.commands import create_page_cache
 
 class BountyEventAdmin(admin.ModelAdmin):
     list_display = ['created_on', '__str__', 'event_type']

--- a/app/dashboard/management/commands/bundle.py
+++ b/app/dashboard/management/commands/bundle.py
@@ -7,9 +7,8 @@ from django.core.management.base import BaseCommand
 from django.template import Context, Template
 from django.template.loaders.app_directories import get_app_template_dirs
 
-from dashboard.templatetags.bundle import render
-
 from app.bundle_context import context, templateTags
+from dashboard.templatetags.bundle import render
 
 
 def rmdir(loc, depth=1):

--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -23,6 +23,7 @@ from django.utils import timezone
 
 import numpy as np
 from grants.models import Contribution, Grant, GrantCollection
+from townsquare.models import SquelchProfile
 
 CLR_PERCENTAGE_DISTRIBUTED = 0
 
@@ -288,6 +289,10 @@ def fetch_data(clr_round, network='mainnet'):
 
     if subscription_filters:
         contributions = contributions.filter(**subscription_filters)
+
+    # ignore profiles which have been squelched
+    profiles_to_be_ignored = SquelchProfile.objects.filter(active=True).values_list('profile__pk')
+    contributions = contributions.exclude(profile_for_clr__in=profiles_to_be_ignored)
 
     grants = clr_round.grants.filter(network=network, hidden=False, active=True, is_clr_eligible=True, link_to_new_grant=None)
 


### PR DESCRIPTION
##### Description

We realized in Gr10 that the team was using shadow ban users to ignore contributions to be considered for matching.
Upon digging into it -> it came to light that our CLR calculations doesn't really ignore banned contributions. We would need to fix this

This PR tweaks that to ensure squelch profiles are taken into account while fetching the data

##### Refers/Fixes

GITC-223

##### Testing

<img width="1003" alt="Screenshot 2021-07-22 at 9 22 23 AM" src="https://user-images.githubusercontent.com/5358146/126588033-70835c4f-94eb-4a88-b13b-f3201275e275.png">

