### PR TITLE
GITC-249: remove fulfiller email from API

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -42,13 +42,13 @@ logger = logging.getLogger(__name__)
 class BountyFulfillmentSerializer(serializers.ModelSerializer):
     """Handle serializing the BountyFulfillment object."""
     profile = ProfileSerializer()
-    fulfiller_email = serializers.ReadOnlyField()
     fulfiller_github_username = serializers.ReadOnlyField()
+
     class Meta:
         """Define the bounty fulfillment serializer metadata."""
 
         model = BountyFulfillment
-        fields = ('pk', 'fulfiller_email', 'fulfiller_address',
+        fields = ('pk', 'fulfiller_address',
                   'fulfiller_github_username', 'fulfiller_metadata',
                   'fulfillment_id', 'accepted', 'profile', 'created_on',
                   'accepted_on', 'fulfiller_github_url', 'payout_tx_id',

--- a/app/retail/templates/emails/bounty.html
+++ b/app/retail/templates/emails/bounty.html
@@ -104,8 +104,6 @@
             {% for fulfillment in bounty.fulfillments.all %}
               {% if fulfillment.fulfiller_github_username %}
                 <a href="{% url 'profile' fulfillment.fulfiller_github_username %}?{{ utm_tracking }}">{{ fulfillment.fulfiller_github_username }}</a>
-              {% elif fulfillment.fulfiller_email %}
-                <a href="mailto:{{ fulfillment.fulfiller_email }}">{{ fulfillment.fulfiller_email }}</a>
               {% else %}
                 <a href="https://etherscan.io/address/{{ fulfillment.fulfiller_address }}?{{ utm_tracking }}">{{ fulfillment.fulfiller_address }}</a>
               {% endif %}


### PR DESCRIPTION
##### Description

Removes fulfiller email form Bounty API
It which is used as fallback field to show the fulfiller info when we don't have their handle.
Does not impact on the actual flow 
 
##### Refers/Fixes

GITC-249

##### Testing

Locally tested

<img width="1424" alt="Screenshot 2021-08-11 at 8 03 18 PM" src="https://user-images.githubusercontent.com/5358146/129048676-2e7cd55f-696a-40ba-88c2-043c38a2fb95.png">
