### PR TITLE
feat: trust-bonus api

### DIFF
--- a/app/grants/urls.py
+++ b/app/grants/urls.py
@@ -30,7 +30,7 @@ from grants.views import (
     grants_addr_as_json, grants_bulk_add, grants_by_grant_type, grants_cart_view, grants_info, grants_landing,
     grants_type_redirect, ingest_contributions, ingest_contributions_view, invoice, leaderboard,
     manage_ethereum_cart_data, new_matching_partner, profile, quickstart, remove_grant_from_collection, save_collection,
-    toggle_grant_favorite, verify_grant,
+    toggle_grant_favorite, verify_grant, get_trust_bonus
 )
 
 app_name = 'grants/'
@@ -99,6 +99,7 @@ urlpatterns = [
     path('v1/api/grant/<int:grant_id>/cancel', cancel_grant_v1, name='cancel_grant_v1'),
 
 
+    path('v1/api/trust-bonus', get_trust_bonus, name='get_trust_bonus'),
     path('v1/api/<int:grant_id>/cart_payload', get_grant_payload, name='grant_payload'),
     path('v1/api/<int:grant_id>/verify', verify_grant, name='verify_grant'),
     path('v1/api/collections/new', save_collection, name='create_collection'),


### PR DESCRIPTION
##### Description

Introduces endpoint to fetch trust bonus of given address.
Will be consumed by dGrants

- method: `POST`
- endpoint: `/grants/v1/api/trust-bonus`
- body format: `json`
- request body: 
```json
{   
    "addresses": [
        "0x5cdb35fADB8262A3f88863254c870c2e6A848CcA",
        "0x997D35b300bA1775fdB175dF045252e57D6EA5B0"
    ]
}
```
- response object: 

```json
[
    {
        "address": "0x5cdb35fADB8262A3f88863254c870c2e6A848CcA",
        "score": 0.5
    },
    {
        "address": "0x997D35b300bA1775fdB175dF045252e57D6EA5B0",
        "score": 0.5
    }
]
```


##### Testing

<img width="737" alt="Screenshot 2021-08-12 at 12 26 27 PM" src="https://user-images.githubusercontent.com/5358146/129153121-e29d5e18-4793-4bc9-93d8-611323f02255.png">



#### Refs: https://github.com/dcgtc/dgrants/issues/100


