### PR TITLE
fixes bounty fulfillment data (usd amounts)

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -1510,16 +1510,16 @@ class BountyFulfillment(SuperModel):
     def value_in_usdt_at_time(self, at_time):
         try:
             if self.token_name in ['USDT', 'USDC']:
-                return float(self.payout_amount / 10 ** 6)
+                return float(self.payout_amount)
             if self.token_name in settings.STABLE_COINS:
-                return float(self.payout_amount / 10 ** 18)
+                return float(self.payout_amount)
             if self.token_name in ['ETH']:
                 return round(float(convert_amount(self.payout_amount, self.token_name, 'USDT', at_time)), 2)
             try:
-                return round(float(convert_amount(self.value_true, self.token_name, 'USDT', at_time)), 2)
+                return round(float(convert_amount(self.payout_amount, self.token_name, 'USDT', at_time)), 2)
             except ConversionRateNotFoundError:
                 try:
-                    in_eth = round(float(convert_amount(self.value_true, self.token_name, 'ETH', at_time)), 2)
+                    in_eth = round(float(convert_amount(self.payout_amount, self.token_name, 'ETH', at_time)), 2)
                     return round(float(convert_amount(in_eth, 'USDT', 'USDT', at_time)), 2)
                 except ConversionRateNotFoundError:
                     return None


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
i recently discovered that the usd amounts for the earnings table for all bountyfulfilments data.

upon further investigation, this was because the usd conversion function on bountyfulfillment assumes that `self.payment_amount` was an integer which needed to be divided by `10**decimals` , when in fact it is not.  it is a floating point number that represents the amount of tokens transfered

                # https://gitcoin.co/_administrationdashboard/earning/1108896/change
                # https://gitcoin.co/_administrationdashboard/bounty/26254/change/
                # https://gitcoin.co/_administrationdashboard/earning/1107885/change
                # https://gitcoin.co/_administrationdashboard/bountyfulfillment/982/


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://gitcoincore.slack.com/archives/CBWA6A75M/p1629222791016400

this test data

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
tested locally

##### Deploy notes

we will need to run save() on all bountyfulfillments when this is done

```
from dashboard.models import *
for bf in BountyFulfillment.objects.all():
    bf.save()
```