### PR TITLE
feat: introduce steward endpoint

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -111,6 +111,7 @@ INSTALLED_APPS = [
     'retail',
     'ptokens',
     'rest_framework',
+    'django_filters',
     'marketing',
     'economy',
     'dashboard',

--- a/app/quadraticlands/router.py
+++ b/app/quadraticlands/router.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Define dashboard specific DRF API routes.
+
+Copyright (C) 2021 Gitcoin Core
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+from quadraticlands.serializer import GTCStewardSerializer
+from rest_framework import routers, viewsets
+from rest_framework.pagination import PageNumberPagination
+
+from .models import GTCSteward
+
+
+class GTCStewardPagination(PageNumberPagination):
+    page_size = 30
+    page_size_query_param = 'page_size'
+
+
+class GTCStewardViewSet(viewsets.ModelViewSet):
+    queryset = GTCSteward.objects.all()
+    serializer_class = GTCStewardSerializer
+    pagination_class = GTCStewardPagination
+
+
+router = routers.DefaultRouter()
+router.register(r'stewards', GTCStewardViewSet)

--- a/app/quadraticlands/serializer.py
+++ b/app/quadraticlands/serializer.py
@@ -1,0 +1,15 @@
+from dashboard.models import ProfileSerializer
+from rest_flex_fields import FlexFieldsModelSerializer
+
+from .models import GTCSteward
+
+
+class GTCStewardSerializer(FlexFieldsModelSerializer):
+    """Handle serializing of GTCSteward"""
+    class Meta:
+        """Define the GrantCLR serializer metadata."""
+        model = GTCSteward
+        fields = ('profile', 'real_name', 'bio', 'gtc_address', 'profile_link', 'custom_steward_img')
+        expandable_fields = {
+          'profile': ProfileSerializer
+        }

--- a/app/quadraticlands/urls.py
+++ b/app/quadraticlands/urls.py
@@ -18,9 +18,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """
 from django.conf import settings
+from django.conf.urls import include, url
 from django.urls import path, re_path
 
 from quadraticlands.helpers import vote
+from quadraticlands.router import router
 from quadraticlands.views import (
     base, base_auth, dashboard_index, handler400, handler403, handler404, handler500, index, mission_diplomacy,
     mission_diplomacy_room, mission_index, mission_lore, mission_postcard, mission_postcard_svg, mission_schwag,
@@ -52,6 +54,7 @@ urlpatterns = [
     path('mission/diplomacy/<str:uuid>/<str:name>', mission_diplomacy_room, name='mission_diplomacy_room'),
     re_path(r'^mission/diplomacy/?', mission_diplomacy, name='mission_diplomacy'),
 
+    url(r'^api/v1/', include(router.urls)),
 ]
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -116,3 +116,4 @@ libsass==0.20.1
 graphqlclient==0.2.4
 docutils==0.17.1
 unidecode==1.2.0
+drf-flex-fields==0.9.1


### PR DESCRIPTION
##### Description

This PR uses drf-flex-fields to introduct endpoint for stewards information

**URL:** 
- `http://localhost:8000/quadraticlands/api/v1/stewards`
- `http://localhost:8000/quadraticlands/api/v1/stewards/?expand=profile`



##### Testing

https://gitcoin.atlassian.net/browse/GITC-333

![image](https://user-images.githubusercontent.com/5358146/130230127-0fd74f7d-c6dc-4211-9269-4ccf0e48fc94.png)