### PR TITLE
Fix small bug when click to slack link

### DIFF
--- a/app/retail/templates/emails/new_bounty_expire_warning.html
+++ b/app/retail/templates/emails/new_bounty_expire_warning.html
@@ -53,7 +53,7 @@ along with this program. If not, see
     <br>
     <br>
     {% blocktrans %}If you have any questions, feel free to reach out {% endblocktrans %}<a
-      href="{% url 'slack' %}?{{ utm_tracking }}">{% blocktrans %}on slack{% endblocktrans %}</a>.
+      href="https://discord.gg/gitcoin">{% blocktrans %}on Discord{% endblocktrans %}</a>.
 
     {% else %}
 
@@ -62,8 +62,7 @@ along with this program. If not, see
 
     <br>
     <br>
-    {% blocktrans %}If you have any problems, feel free to reach out {% endblocktrans %}<a
-      href="{% url 'slack' %}?{{ utm_tracking }}">{% blocktrans %}on slack{% endblocktrans %}</a>.
+    {% blocktrans %}If you have any problems, feel free to reach out {% endblocktrans %}<a href="https://discord.gg/gitcoin">{% blocktrans %}on Discord{% endblocktrans %}</a>.
 
 
     {% endif %}

--- a/app/retail/templates/emails/render_bounty_startwork_expired.html
+++ b/app/retail/templates/emails/render_bounty_startwork_expired.html
@@ -56,7 +56,7 @@ along with this program. If not, see
 
     <br>
     <br>
-    If you have any questions, feel free to reach out <a href="{% url 'slack' %}?{{ utm_tracking }}">on slack</a>.
+    If you have any questions, feel free to reach out <a href="https://discord.gg/gitcoin">on Discord</a>.
 
     <br>
   <h1>{% trans "Funded Issue Details" %}</h1>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

When I get an email from gitcoin, then I click to link slack it will be redirect to discord
![image](https://user-images.githubusercontent.com/1762691/131444142-cf77f740-3429-4c7c-ab59-b5b121b65e6e.png)



##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

Just fix small text and link, so do not need testing
