### PR TITLE
feat: toggle sybil/non sybil users

### DIFF
--- a/app/dashboard/helpers.py
+++ b/app/dashboard/helpers.py
@@ -35,10 +35,7 @@ from dashboard.models import (
     Activity, BlockedURLFilter, Bounty, BountyEvent, BountyFulfillment, BountyInvites, BountySyncRequest, Coupon,
     HackathonEvent, UserAction,
 )
-from dashboard.notifications import (
-    maybe_market_to_email, maybe_market_to_github,
-    notify_of_lowball_bounty,
-)
+from dashboard.notifications import maybe_market_to_email, maybe_market_to_github, notify_of_lowball_bounty
 from dashboard.tokens import addr_to_token
 from economy.utils import convert_amount
 from git.utils import get_issue_details, get_url_dict, org_name

--- a/app/grants/urls.py
+++ b/app/grants/urls.py
@@ -30,7 +30,7 @@ from grants.views import (
     grant_new, grants, grants_addr_as_json, grants_bulk_add, grants_by_grant_type, grants_cart_view, grants_info,
     grants_landing, grants_type_redirect, ingest_contributions, ingest_contributions_view, invoice, leaderboard,
     manage_ethereum_cart_data, new_matching_partner, profile, quickstart, remove_grant_from_collection, save_collection,
-    toggle_grant_favorite, verify_grant,
+    toggle_grant_favorite, toggle_user_sybil, verify_grant,
 )
 
 app_name = 'grants/'
@@ -115,6 +115,6 @@ urlpatterns = [
     path('v1/api/export_info/grant<int:grant_id>_round<int:round_id>.json', contribution_info_from_grant_during_round_as_json, name='contribution_addr_from_grant_during_round_as_json'),
 
     # custom API
-    path('v1/api/get-clr-data/<int:round_id>', get_clr_sybil_input, name='get_clr_sybil_input')
-
+    path('v1/api/get-clr-data/<int:round_id>', get_clr_sybil_input, name='get_clr_sybil_input'),
+    path('v1/api/toggle_user_sybil', toggle_user_sybil, name='toggle_user_sybil')
 ]


### PR DESCRIPTION
##### Description

Introduces and endoint to allow bsci toggle users as sybil/not

Endpoint: `/grants/v1/api/toggle_user_sybil`
Headers: `token: <PROVIDED-BY-GITCOIN>`

### To mark users as sybil and not sybil

**Body:**
```
{
    "sybil_users" :[
        {
            "id": 94849,
            "comment": "reason for marking user as sybil"
        }
    ],
     "non_sybil_users" :[
        {
            "id": 94841
        }
    ]
}
```

comment is mandatory when user is marked as sybil




##### Testing

![Untitled](https://user-images.githubusercontent.com/5358146/132202510-e59cf587-b5c4-48d9-bbfe-98752e0083df.gif)
