### PR TITLE
Validation Fix

### DIFF
--- a/app/assets/v2/js/grants/_new.js
+++ b/app/assets/v2/js/grants/_new.js
@@ -107,7 +107,7 @@ Vue.mixin({
           vm.$set(vm.errors, 'eth_payout_address', 'Please enter ETH address');
         } else if (vm.form.eth_payout_address.trim().endsWith('.eth')) {
           vm.$set(vm.errors, 'eth_payout_address', 'ENS is not supported. Please enter ETH address');
-        } else if (!web3.utils.isAddress(vm.form.eth_payout_address)) {
+        } else if (!Web3.utils.isAddress(vm.form.eth_payout_address)) {
           vm.$set(vm.errors, 'eth_payout_address', 'Please enter a valid ETH address');
         }
       } else if (


### PR DESCRIPTION
##### Description

When updating grant creation tests to work with tags I noticed a failure with the eth address validation. This PR updates the call `web3.utils.isAddress` to `Web3.utils.isAddress`. This failure was preventing the form from being submitted and disabled the submission button.


##### Testing

Manual test to verify on staging (until cypress tests are merged). Create a grant with an ETH payout address.
