### PR TITLE
Removing the third RR reference

### DIFF
--- a/app/app/db.py
+++ b/app/app/db.py
@@ -9,7 +9,7 @@ class PrimaryDBRouter:
         Reads go to a randomly-chosen replica if backend node
         Else go to default DB
         """
-        replicas = ['read_replica_1', 'read_replica_2', 'read_replica_3']
+        replicas = ['read_replica_1', 'read_replica_2']
         return random.choice(replicas)
 
     def db_for_write(self, model, **hints):
@@ -23,7 +23,7 @@ class PrimaryDBRouter:
         Relations between objects are allowed if both objects are
         in the primary/replica pool.
         """
-        db_set = {'default', 'read_replica_1', 'read_replica_2', 'read_replica_3'}
+        db_set = {'default', 'read_replica_1', 'read_replica_2'}
         if obj1._state.db in db_set and obj2._state.db in db_set:
             return True
         return True # TODO: be more stringent about this IFF we ever have a situation in which diff tables are on diff DBs

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -212,7 +212,6 @@ if ENV in ['prod']:
         'default': env.db(),
         'read_replica_1': env.db('READ_REPLICA_1_DATABASE_URL'),
         'read_replica_2': env.db('READ_REPLICA_2_DATABASE_URL'),
-        'read_replica_3': env.db('READ_REPLICA_3_DATABASE_URL')
         }
     DATABASE_ROUTERS = ['app.db.PrimaryDBRouter']
 


### PR DESCRIPTION
##### Description

 Remove the third reference to a read-replica so that we can dedicate RR-1 and RR-2 to CLRs and then dedicate RR-3 and RR-4 to the app and asset servers.

##### Testing

We need multiple RRs and to set the environment variables to test. Which we will do on prod.
