### PR TITLE
bug fix/users cannot extend deadline of existing bounties

### DIFF
--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -1101,6 +1101,7 @@
     {% bundle merge_js file libs %}
       <script src="highlight.min.js" base-dir="/node_modules/@highlightjs/cdn-assets/"></script>
       <script src="markdown-it.min.js" base-dir="/node_modules/markdown-it/dist/"></script>
+      <script src="daterangepicker.js" base-dir="/node_modules/daterangepicker/"></script>
     {% endbundle %}
 
     <script src="/dynamic/js/tokens_dynamic.js"></script>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR resolves a bug in which users were unable to extend the deadline of existing bounties. The issue was that the daterangepicker was broken because the script importing it was not present in the HTML.