### PR TITLE
GITC-430: Forces nav-cart images to use auto height on ios

### DIFF
--- a/app/dashboard/templates/shared/cart_nav.html
+++ b/app/dashboard/templates/shared/cart_nav.html
@@ -21,7 +21,7 @@
           <div v-for="(item, index) in items" :key="index">
             <div :class="['row', (index != items.length-1 ? 'pb-3' : '')]">
               <div class="d-flex col-3 justify-content-center my-auto" style="overflow:hidden;">
-                <img :src="item.grant_logo" width="40">
+                <img class="align-self-start" :src="item.grant_logo" width="40">
               </div>
               <div class="col-7 line-clamp-1 my-auto cursor-none">
                 [[ item.grant_title ]]


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will fix a bug in ios where the carts images were being stretched.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-430

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested on ios device
