### PR TITLE
GITC-38: Adds stats and activity to Grants nav

### DIFF
--- a/app/dashboard/templates/shared/menu.html
+++ b/app/dashboard/templates/shared/menu.html
@@ -280,6 +280,12 @@
                     <li>
                       <a class="dropdown-item dropdown-item-small" href="{% url 'grants:quickstart' %}">{% trans "About Grants" %}</a>
                     </li>
+                    <li>
+                      <a class="dropdown-item dropdown-item-small" href="{% url 'grants:grants_explorer' %}stats">{% trans "Stats" %}</a>
+                    </li>
+                    <li>
+                      <a class="dropdown-item dropdown-item-small" href="{% url 'grants:grants_explorer' %}activity">{% trans "Activity" %}</a>
+                    </li>
                   </ul>
                 </div>
                 <div class="gc-products-submenu gc-menu-submenu gc-menu-submenu-quests position-absolute {% if '/quests' in request.path %}active{% endif %}">

--- a/app/grants/templates/grants/explorer.html
+++ b/app/grants/templates/grants/explorer.html
@@ -65,219 +65,217 @@ along with this program. If not, see
     {% include 'shared/top_nav.html' with class='d-md-flex' %}
     {% include 'grants/nav.html' %}
     <div id="grants-showcase" v-cloak>
-      {% if is_staff %}
-        <div class="container-fluid pt-2 grants-search" id="content_navbar">
-          <div class="container">
-            <form>
-              <div class="row font-caption font-weight-semibold alpha-warning" v-if="credentials.is_staff">
-                <div class="col-12">
-                  {% trans "[ Admin ] Choose Network :" %}
-                  <span class="network-container">
-                    <select @change="changeQuery({network: network})" v-model="network" name="network" id="network">
-                      <option value="mainnet">Mainnet</option>
-                      <option value="rinkeby">Rinkeby</option>
-                    </select>
-                  </span>
-                  <button class="btn btn-sm btn-primary" @click="credentials.is_staff = !credentials.is_staff">see as user</button>
-                </div>
-              </div>
-            </form>
-          </div>
-        </div>
-      {% endif %}
+
       <div class="container mt-1">
-
-        <b-tabs content-class="mt-3" @input="tabChange" v-model="tabIndex" ref="grantstabs" lazy>
-          <b-tab ref="grants" id="grants" title-link-class="nav-line font-weight-bold">
-            <template v-slot:title>Grants</template>
-
-            <div v-if="clrData.count > 0" class="d-flex vertical-scroll" style="gap: 10px; padding: 4px 0;">
-              <button class="btn rounded-pill flex-shrink-0" @click="resetFilters()" :class="`${ !params?.sub_round_slug ? 'btn-gc-black':'btn-gc-grey'}`">
-                All Grants
-              </button>
-              <button class="btn rounded-pill flex-shrink-0" v-for="clr in clrData.results" @click="changeQuery({page: 1, sub_round_slug: clr.sub_round_slug, round_num: clr.round_num, customer_name: clr.customer_name})" v-if="clr.is_active" :class="`${ params?.sub_round_slug == clr.sub_round_slug ? 'btn-gc-black':'btn-gc-grey'}`">
-                [[clr.display_text]] ($[[clr.total_pot | moneyCompact]])
-              </button>
+        <template v-if="'activity' == current_type">
+          {% include 'grants/shared/landing_activity.html' %}
+        </template>
+        <template v-else-if="'stats' == current_type">
+          <div id="insert_iframe">
+            <div style="background-color: #eee; font-size: 14px; text-align: center;">
+              <strong>Did you know?  During active matching rounds, @gitcoinbot will post updated stats on a daily basis.  <a href="/gitcoinbot">Check out @gitcoinbot's profile.</a> You can also find grants stats on <a href="{% url 'grants:leaderboard' %}">the Grants Leaderboard</a>.
             </div>
-            <div
-                ref="filterNav"
-                id="filterNav"
-                class="position-sticky top-0 bg-white py-2 mt-2 d-flex flex-column-reverse flex-md-row justify-content-between"
-                :style="`z-index: 1; top: -1px; margin-top: 1px; ${sticky_active ? 'box-shadow: 0px 8px 10px -14px rgba(0, 0, 0, 0.5);' : ''}`"
-              >
-                <div class="flex-lg-shrink-0 mt-n2">
-
-                  <span v-if="currentCLR?.display_text" class="align-middle border-grey border-right-1 d-inline-block h-100 mt-2 mr-2 pr-2 pt-1" style="max-height: 32px;">
-                    [[currentCLR?.display_text]]
-                  </span>
-
-                  <!-- GRANT TYPE FILTERS -->
-                  <b-dropdown @hide="fetchGrants(1)" ref="grantFlitersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip v-if="grant_types.length">
-                    <template #button-content>
-                      Categories <span v-if="params.grant_types.length"> • [[params.grant_types.length]]</span>
-                    </template>
-                    <b-dropdown-form>
-                      <b-form-checkbox-group id="checkbox-group-types" v-model.lazy="params.grant_types" aria-describedby="ariaDescribedby" name="grant_types">
-                        <template v-for="grant_type in grant_types" v-if="grant_type.is_visible">
-                          <b-form-checkbox class="mb-3" :value="grant_type.keyword">[[grant_type.label]]</b-form-checkbox>
-                        </template>
-                      </b-form-checkbox-group>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_types.length}" @click="params.grant_types=[], closeDropdown('grantFlitersDropdown')">Clear</b-button>
-                        <b-button variant="primary" size="sm" @click="closeDropdown('grantFlitersDropdown')">Apply</b-button>
-                      </div>
-                    </b-dropdown-form>
-                  </b-dropdown>
-
-                  <!-- TAG FILTERS -->
-                  <b-dropdown @hide="fetchGrants(1)" ref="tagFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
-                    <template #button-content>
-                      Tags <span v-if="params.grant_tags?.length"> • [[params.grant_tags.length]]</span>
-                    </template>
-                    <b-dropdown-form>
-                      <!-- <v-select id="team_members" label="name" :close-on-select="false" @search="tagSearch"  :options="tagsOptions" :reduce="tag => tag.name" placeholder="Add your team Gitcoin usernames" v-model="params.grant_tags" multiple>
-                        <template slot="no-options">
-                          type to search Users..
-                        </template>
-                        <template slot="option" slot-scope="option">
-                          <div class="d-flex align-items-baseline">
-                            <div>[[ option.name ]]</div>
-                          </div>
-                        </template>
-                        <template slot="selected-option" slot-scope="option">
-                          <div class="d-flex align-items-center">
-                            <div>[[ option.name ]]</div>
-                          </div>
-                        </template>
-                      </v-select> -->
-                      <b-form-checkbox-group id="checkbox-group-tags" v-model="params.grant_tags" aria-describedby="ariaDescribedby" name="grant_tags">
-                        <template v-for="tag in tagsOptions">
-                          <b-form-checkbox class="mb-3" :value="tag.name">[[tag.name]]</b-form-checkbox>
-                        </template>
-                      </b-form-checkbox-group>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_tags.length}" @click="params.grant_tags=[], closeDropdown('tagFiltersDropdown')">Clear</b-button>
-                        <b-button variant="primary" size="sm" @click="closeDropdown('tagFiltersDropdown')">Apply</b-button>
-                      </div>
-                    </b-dropdown-form>
-                  </b-dropdown>
-
-                  <!-- REGION FILTERS -->
-                  <b-dropdown @hide="fetchGrants(1)" ref="regionFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
-                    <template #button-content>
-                      Regions <span v-if="params.grant_regions?.length"> • [[params.grant_regions.length]]</span>
-                    </template>
-                    <b-dropdown-form>
-                      <b-form-checkbox-group id="checkbox-group-regions" v-model="params.grant_regions" aria-describedby="ariaDescribedby" name="grant_regions" stacked>
-                        <template v-for="region in grantRegions">
-                          <b-form-checkbox class="mb-3" :value="region.name">[[region.label]]</b-form-checkbox>
-                        </template>
-                      </b-form-checkbox-group>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_regions.length}" @click="params.grant_regions=[], closeDropdown('regionFiltersDropdown')">Clear</b-button>
-                        <b-button variant="primary" size="sm" @click="closeDropdown('regionFiltersDropdown')">Apply</b-button>
-                      </div>
-                    </b-dropdown-form>
-                  </b-dropdown>
-
-                  <!-- TENANT FILTERS -->
-                  <b-dropdown @hide="fetchGrants(1)" ref="tenantFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
-                    <template #button-content>
-                      Blockchains <span v-if="params.tenants?.length"> • [[params.tenants.length]]</span>
-                    </template>
-                    <b-dropdown-form>
-                      <b-form-checkbox-group id="checkbox-group-tenants" v-model="params.tenants" aria-describedby="ariaDescribedby" name="tenants" stacked>
-                        <template v-for="tenant in grantTenants">
-                          <b-form-checkbox class="mb-3" :value="tenant.name">[[tenant.label]]</b-form-checkbox>
-                        </template>
-                      </b-form-checkbox-group>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-button variant="link" size="sm" :class="{'disabled' : !params.tenants.length}" @click="params.tenants=[], closeDropdown('tenantFiltersDropdown')">Clear</b-button>
-                        <b-button variant="primary" size="sm" @click="closeDropdown('tenantFiltersDropdown')">Apply</b-button>
-                      </div>
-                    </b-dropdown-form>
-                  </b-dropdown>
-
-                  <!-- MORE FILTERS -->
-                  <b-dropdown @hide="fetchGrants(1)" ref="moreFiltersDropdown" size="sm" menu-class="mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
-                    <template #button-content>
-                      More Filters
-                      <span v-if="params.idle || params.only_contributions || params.me || params.following">
-                      • [[ [params.idle, params.only_contributions, params.me, params.following].filter((v)=>v).length ]]</span>
-                    </template>
-                    <b-dropdown-form>
-                      <div class="pt-2">
-                        <b-form-checkbox id="idle" v-model="params.idle" name="idle"> Show Idle Grants</b-form-checkbox>
-                        <b-dropdown-text class="font-smaller-4"style="width: 230px;">Grants not updated in 3 months</b-dropdown-text>
-                      </div>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-dropdown-header id="dropdown-header-shortcuts">
-                          My Shortcuts
-                        </b-dropdown-header>
-                        <b-form-checkbox id="only_contributions" v-model="params.only_contributions" name="only_contributions">My Contributions</b-form-checkbox>
-                        <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve contributed to</b-dropdown-text>
-                        <b-form-checkbox id="me" v-model="params.me" name="me"> My Grants</b-form-checkbox>
-                        <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve created</b-dropdown-text>
-                        <b-form-checkbox id="following" v-model="params.following" name="following"> Following</b-form-checkbox>
-                        <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve followed</b-dropdown-text>
-                      </div>
-                      <b-dropdown-divider></b-dropdown-divider>
-                      <div>
-                        <b-button variant="link" size="sm" @click="params.idle=false,params.only_contributions=false, params.me=false, params.following=false, closeDropdown('moreFiltersDropdown')">Clear</b-button>
-                        <b-button variant="primary" size="sm" @click="closeDropdown('moreFiltersDropdown')">Apply</b-button>
-                      </div>
-                    </b-dropdown-form>
-                  </b-dropdown>
-
-                  <button class="btn btn-sm mt-2" @click="resetFilters()"> <i class="fal fa-times mr-1"></i> Clear</button>
-                </div>
-
-                <!-- SEARCH BAR AND CART -->
-                <div class="flex-basis-md-25 flex-nowrap d-flex bg-white" :class="{'position-md-absolute w-100': searchVisible}">
-                  <button class="btn" v-show="searchVisible" @click="searchVisible=!searchVisible"><i class="fas fa-chevron-left"></i></button>
-                  <i
-                    class="far fa-fw fa-search font-smaller-3 position-absolute text-grey-300"
-                    :style="(searchVisible ? 'top: 10px;margin-left: 7px;left: 34px;' : 'top: 19px; margin-left: 7px;')"
-                  ></i>
-                  <input class="form-control form-control-sm rounded-pill pl-4" placeholder="Search..." type="search" @click="searchVisible=!searchVisible" v-model="params.keyword" @input="changeQuery({page: 1})" @keyup.enter="changeQuery({page: 1})">
-                  <div class="navCart dropdown gc-cart" v-if="!searchVisible && sticky_active">
-                    <a href="" class="gc-cart__icon d-block" role="button" @click="$refs.navCart.init()"
-                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="padding: 0.3rem 1rem;">
-                      <i class="far fa-shopping-cart fa-fw fa-lg"></i>
-                      <span class="cart-notification-dot notification__dot ml-2 mt-n1" :class="{'notification__dot_active': cart_data_count}">[[ cart_data_count ]]</span>
-                    </a>
-                    <div class="dropdown-menu dropdown-menu-right gc-cart-box p-0 px-3 overflow-hidden" aria-labelledby="cartDropdown" style="margin-top: 6px; min-width: 352px;">
-                      <gc-cart-content ref="navCart"/>
+            <br>
+            <iframe :src="`https://metabase.gitcoin.co/public/dashboard/f57f8c61-e2f2-4129-89fc-d851f4d721ac`" style="width: 100%; height: 100%; min-height: 1000px;">
+            </iframe>
+          </div>
+        </template>
+        <template v-else>
+          {% if is_staff %}
+            <div class="container-fluid pt-2 grants-search" id="content_navbar">
+              <div class="container">
+                <form>
+                  <div class="row font-caption font-weight-semibold alpha-warning" v-if="credentials.is_staff">
+                    <div class="col-12">
+                      {% trans "[ Admin ] Choose Network :" %}
+                      <span class="network-container">
+                        <select @change="changeQuery({network: network})" v-model="network" name="network" id="network">
+                          <option value="mainnet">Mainnet</option>
+                          <option value="rinkeby">Rinkeby</option>
+                        </select>
+                      </span>
+                      <button class="btn btn-sm btn-primary" @click="credentials.is_staff = !credentials.is_staff">see as user</button>
                     </div>
                   </div>
-                </div>
-
+                </form>
               </div>
-
-            <div class="container-fluid header dash grants_hero_img" id="grant-hero-img" style="background-image: url({{grant_bg.banner_image}});" :style="[ regex_style?.banner_image ? {backgroundImage: `url(${regex_style?.banner_image})`} : '']">
-
             </div>
+          {% endif %}
+          <b-tabs content-class="mt-3" @input="tabChange" v-model="tabIndex" ref="grantstabs" lazy>
+            <b-tab ref="grants" id="grants" title-link-class="nav-line font-weight-bold">
+              <template v-slot:title>Grants</template>
 
-            <template v-if="'activity' == current_type">
-              {% include 'grants/shared/landing_activity.html' %}
-            </template>
-            <template v-else-if="'stats' == current_type">
-              <div id="insert_iframe">
-                <div style="background-color: #eee; font-size: 14px; text-align: center;">
-                  <strong>Did you know?  During active matching rounds, @gitcoinbot will post updated stats on a daily basis.  <a href="/gitcoinbot">Check out @gitcoinbot's profile.</a> You can also find grants stats on <a href="{% url 'grants:leaderboard' %}">the Grants Leaderboard</a>.
-                </div>
-                <br>
-                <iframe :src="`https://metabase.gitcoin.co/public/dashboard/f57f8c61-e2f2-4129-89fc-d851f4d721ac`" style="width: 100%; height: 100%; min-height: 1000px;">
-                </iframe>
+              <div v-if="clrData.count > 0" class="d-flex vertical-scroll" style="gap: 10px; padding: 4px 0;">
+                <button class="btn rounded-pill flex-shrink-0" @click="resetFilters()" :class="`${ !params?.sub_round_slug ? 'btn-gc-black':'btn-gc-grey'}`">
+                  All Grants
+                </button>
+                <button class="btn rounded-pill flex-shrink-0" v-for="clr in clrData.results" @click="changeQuery({page: 1, sub_round_slug: clr.sub_round_slug, round_num: clr.round_num, customer_name: clr.customer_name})" v-if="clr.is_active" :class="`${ params?.sub_round_slug == clr.sub_round_slug ? 'btn-gc-black':'btn-gc-grey'}`">
+                  [[clr.display_text]] ($[[clr.total_pot | moneyCompact]])
+                </button>
               </div>
-            </template>
-            <template v-else>
+              <div
+                  ref="filterNav"
+                  id="filterNav"
+                  class="position-sticky top-0 bg-white py-2 mt-2 d-flex flex-column-reverse flex-md-row justify-content-between"
+                  :style="`z-index: 1; top: -1px; margin-top: 1px; ${sticky_active ? 'box-shadow: 0px 8px 10px -14px rgba(0, 0, 0, 0.5);' : ''}`"
+                >
+                  <div class="flex-lg-shrink-0 mt-n2">
 
+                    <span v-if="currentCLR?.display_text" class="align-middle border-grey border-right-1 d-inline-block h-100 mt-2 mr-2 pr-2 pt-1" style="max-height: 32px;">
+                      [[currentCLR?.display_text]]
+                    </span>
+
+                    <!-- GRANT TYPE FILTERS -->
+                    <b-dropdown @hide="fetchGrants(1)" ref="grantFlitersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip v-if="grant_types.length">
+                      <template #button-content>
+                        Categories <span v-if="params.grant_types.length"> • [[params.grant_types.length]]</span>
+                      </template>
+                      <b-dropdown-form>
+                        <b-form-checkbox-group id="checkbox-group-types" v-model.lazy="params.grant_types" aria-describedby="ariaDescribedby" name="grant_types">
+                          <template v-for="grant_type in grant_types" v-if="grant_type.is_visible">
+                            <b-form-checkbox class="mb-3" :value="grant_type.keyword">[[grant_type.label]]</b-form-checkbox>
+                          </template>
+                        </b-form-checkbox-group>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_types.length}" @click="params.grant_types=[], closeDropdown('grantFlitersDropdown')">Clear</b-button>
+                          <b-button variant="primary" size="sm" @click="closeDropdown('grantFlitersDropdown')">Apply</b-button>
+                        </div>
+                      </b-dropdown-form>
+                    </b-dropdown>
+
+                    <!-- TAG FILTERS -->
+                    <b-dropdown @hide="fetchGrants(1)" ref="tagFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
+                      <template #button-content>
+                        Tags <span v-if="params.grant_tags?.length"> • [[params.grant_tags.length]]</span>
+                      </template>
+                      <b-dropdown-form>
+                        <!-- <v-select id="team_members" label="name" :close-on-select="false" @search="tagSearch"  :options="tagsOptions" :reduce="tag => tag.name" placeholder="Add your team Gitcoin usernames" v-model="params.grant_tags" multiple>
+                          <template slot="no-options">
+                            type to search Users..
+                          </template>
+                          <template slot="option" slot-scope="option">
+                            <div class="d-flex align-items-baseline">
+                              <div>[[ option.name ]]</div>
+                            </div>
+                          </template>
+                          <template slot="selected-option" slot-scope="option">
+                            <div class="d-flex align-items-center">
+                              <div>[[ option.name ]]</div>
+                            </div>
+                          </template>
+                        </v-select> -->
+                        <b-form-checkbox-group id="checkbox-group-tags" v-model="params.grant_tags" aria-describedby="ariaDescribedby" name="grant_tags">
+                          <template v-for="tag in tagsOptions">
+                            <b-form-checkbox class="mb-3" :value="tag.name">[[tag.name]]</b-form-checkbox>
+                          </template>
+                        </b-form-checkbox-group>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_tags.length}" @click="params.grant_tags=[], closeDropdown('tagFiltersDropdown')">Clear</b-button>
+                          <b-button variant="primary" size="sm" @click="closeDropdown('tagFiltersDropdown')">Apply</b-button>
+                        </div>
+                      </b-dropdown-form>
+                    </b-dropdown>
+
+                    <!-- REGION FILTERS -->
+                    <b-dropdown @hide="fetchGrants(1)" ref="regionFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
+                      <template #button-content>
+                        Regions <span v-if="params.grant_regions?.length"> • [[params.grant_regions.length]]</span>
+                      </template>
+                      <b-dropdown-form>
+                        <b-form-checkbox-group id="checkbox-group-regions" v-model="params.grant_regions" aria-describedby="ariaDescribedby" name="grant_regions" stacked>
+                          <template v-for="region in grantRegions">
+                            <b-form-checkbox class="mb-3" :value="region.name">[[region.label]]</b-form-checkbox>
+                          </template>
+                        </b-form-checkbox-group>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-button variant="link" size="sm" :class="{'disabled' : !params.grant_regions.length}" @click="params.grant_regions=[], closeDropdown('regionFiltersDropdown')">Clear</b-button>
+                          <b-button variant="primary" size="sm" @click="closeDropdown('regionFiltersDropdown')">Apply</b-button>
+                        </div>
+                      </b-dropdown-form>
+                    </b-dropdown>
+
+                    <!-- TENANT FILTERS -->
+                    <b-dropdown @hide="fetchGrants(1)" ref="tenantFiltersDropdown" size="sm" menu-class="scroll-menu p-0 mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
+                      <template #button-content>
+                        Blockchains <span v-if="params.tenants?.length"> • [[params.tenants.length]]</span>
+                      </template>
+                      <b-dropdown-form>
+                        <b-form-checkbox-group id="checkbox-group-tenants" v-model="params.tenants" aria-describedby="ariaDescribedby" name="tenants" stacked>
+                          <template v-for="tenant in grantTenants">
+                            <b-form-checkbox class="mb-3" :value="tenant.name">[[tenant.label]]</b-form-checkbox>
+                          </template>
+                        </b-form-checkbox-group>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-button variant="link" size="sm" :class="{'disabled' : !params.tenants.length}" @click="params.tenants=[], closeDropdown('tenantFiltersDropdown')">Clear</b-button>
+                          <b-button variant="primary" size="sm" @click="closeDropdown('tenantFiltersDropdown')">Apply</b-button>
+                        </div>
+                      </b-dropdown-form>
+                    </b-dropdown>
+
+                    <!-- MORE FILTERS -->
+                    <b-dropdown @hide="fetchGrants(1)" ref="moreFiltersDropdown" size="sm" menu-class="mt-1" variant="outline-gc-grey" toggle-class="rounded-pill mt-2" no-caret no-flip>
+                      <template #button-content>
+                        More Filters
+                        <span v-if="params.idle || params.only_contributions || params.me || params.following">
+                        • [[ [params.idle, params.only_contributions, params.me, params.following].filter((v)=>v).length ]]</span>
+                      </template>
+                      <b-dropdown-form>
+                        <div class="pt-2">
+                          <b-form-checkbox id="idle" v-model="params.idle" name="idle"> Show Idle Grants</b-form-checkbox>
+                          <b-dropdown-text class="font-smaller-4"style="width: 230px;">Grants not updated in 3 months</b-dropdown-text>
+                        </div>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-dropdown-header id="dropdown-header-shortcuts">
+                            My Shortcuts
+                          </b-dropdown-header>
+                          <b-form-checkbox id="only_contributions" v-model="params.only_contributions" name="only_contributions">My Contributions</b-form-checkbox>
+                          <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve contributed to</b-dropdown-text>
+                          <b-form-checkbox id="me" v-model="params.me" name="me"> My Grants</b-form-checkbox>
+                          <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve created</b-dropdown-text>
+                          <b-form-checkbox id="following" v-model="params.following" name="following"> Following</b-form-checkbox>
+                          <b-dropdown-text class="font-smaller-4 pb-2" style="width: 230px;">Grants I’ve followed</b-dropdown-text>
+                        </div>
+                        <b-dropdown-divider></b-dropdown-divider>
+                        <div>
+                          <b-button variant="link" size="sm" @click="params.idle=false,params.only_contributions=false, params.me=false, params.following=false, closeDropdown('moreFiltersDropdown')">Clear</b-button>
+                          <b-button variant="primary" size="sm" @click="closeDropdown('moreFiltersDropdown')">Apply</b-button>
+                        </div>
+                      </b-dropdown-form>
+                    </b-dropdown>
+
+                    <button class="btn btn-sm mt-2" @click="resetFilters()"> <i class="fal fa-times mr-1"></i> Clear</button>
+                  </div>
+
+                  <!-- SEARCH BAR AND CART -->
+                  <div class="flex-basis-md-25 flex-nowrap d-flex bg-white" :class="{'position-md-absolute w-100': searchVisible}">
+                    <button class="btn" v-show="searchVisible" @click="searchVisible=!searchVisible"><i class="fas fa-chevron-left"></i></button>
+                    <i
+                      class="far fa-fw fa-search font-smaller-3 position-absolute text-grey-300"
+                      :style="(searchVisible ? 'top: 10px;margin-left: 7px;left: 34px;' : 'top: 19px; margin-left: 7px;')"
+                    ></i>
+                    <input class="form-control form-control-sm rounded-pill pl-4" placeholder="Search..." type="search" @click="searchVisible=!searchVisible" v-model="params.keyword" @input="changeQuery({page: 1})" @keyup.enter="changeQuery({page: 1})">
+                    <div class="navCart dropdown gc-cart" v-if="!searchVisible && sticky_active">
+                      <a href="" class="gc-cart__icon d-block" role="button" @click="$refs.navCart.init()"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="padding: 0.3rem 1rem;">
+                        <i class="far fa-shopping-cart fa-fw fa-lg"></i>
+                        <span class="cart-notification-dot notification__dot ml-2 mt-n1" :class="{'notification__dot_active': cart_data_count}">[[ cart_data_count ]]</span>
+                      </a>
+                      <div class="dropdown-menu dropdown-menu-right gc-cart-box p-0 px-3 overflow-hidden" aria-labelledby="cartDropdown" style="margin-top: 6px; min-width: 352px;">
+                        <gc-cart-content ref="navCart"/>
+                      </div>
+                    </div>
+                  </div>
+
+                </div>
+
+              <div class="container-fluid header dash grants_hero_img" id="grant-hero-img" style="background-image: url({{grant_bg.banner_image}});" :style="[ regex_style?.banner_image ? {backgroundImage: `url(${regex_style?.banner_image})`} : '']">
+
+              </div>
 
               {% include 'grants/shared/top-filters.html' %}
 
@@ -309,19 +307,19 @@ along with this program. If not, see
                   </a>
                 </div>
               </div>
+            </b-tab>
+            <b-tab ref="collections" id="collections" title-link-class="nav-line font-weight-bold">
+              <template v-slot:title>Collections</template>
+              {% include 'grants/shared/landing_grants.html' %}
+            </b-tab>
+            <template v-slot:tabs-end>
+              <li role="presentation" class="flex-fill nav-item text-right">
+                <a href="{% url 'grants:new' %}" class="btn btn-primary">{% trans 'Create a Grant' %}</a>
+              </li>
             </template>
-          </b-tab>
-          <b-tab ref="collections" id="collections" title-link-class="nav-line font-weight-bold">
-            <template v-slot:title>Collections</template>
-            {% include 'grants/shared/landing_grants.html' %}
-          </b-tab>
-          <template v-slot:tabs-end>
-            <li role="presentation" class="flex-fill nav-item text-right">
-              <a href="{% url 'grants:new' %}" class="btn btn-primary">{% trans 'Create a Grant' %}</a>
-            </li>
-          </template>
 
-        </b-tabs>
+          </b-tabs>
+        </template>
       </div>
 
       <!-- <div class="container-fluid header dash grants_hero_img" id="grant-hero-img" style="background-image: url({{grant_bg.banner_image}});" :style="[ regex_style?.banner_image ? {backgroundImage: `url(${regex_style?.banner_image})`} : '']">


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR adds `stats` and `activity` to Grants section of the global nav, and removes the filter section from those pages (they just show stats/activity.)

----

I've marked this as a draft because 
 - the `stats` point to an old metabase dashboard (for GR10) - Should we look to create and manage a similar dashboard internally to prevent having to update these references between rounds?
 
 - there is currently no additional CTAs/navigation on these pages to push the user back to the explorer, @willsputra / @PixelantDesign - is this something we should add before rolling this out?

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-38

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally