### PR TITLE
jeremy/bug-fix/reject-worker-button-navigates-to-wrong-page

### DIFF
--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -1237,6 +1237,7 @@ def render_start_work_new_applicant(interest, bounty):
 		'email_type': 'bounty',
         'utm_tracking': build_utm_tracking('start_work_new_applicant'),
         'approve_worker_url': bounty.approve_worker_url(interest.profile.handle),
+        'reject_worker_url': bounty.reject_worker_url(interest.profile.handle),
     }
 
     subject = "A new request to work on your bounty"
@@ -1255,6 +1256,7 @@ def render_start_work_applicant_about_to_expire(interest, bounty):
 		'email_type': 'bounty',
         'utm_tracking': build_utm_tracking('start_work_applicant_about_to_expire'),
         'approve_worker_url': bounty.approve_worker_url(interest.profile.handle),
+        'reject_worker_url': bounty.reject_worker_url(interest.profile.handle),
     }
 
     subject = "24 Hrs to Approve"


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

Resolves an bug that was preventing the `Reject Worker` button in certain emails from working properly by ensuring that the correct `reject_worker_url` is present in the params of the method that renders the emails.

Previous behavior: `Reject Worker` button navigates to the landing page when clicked

New behavior: `Reject Worker` button navigates to the bounty show page and rejects the worker


##### Description

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tests are forthcoming. I want to get the review process started before deployment meeting tomorrow.
