### PR TITLE
GITC-513: alters sync_kudos cron to only use --catchup

### DIFF
--- a/scripts/crontab
+++ b/scripts/crontab
@@ -15,9 +15,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/us
 */3 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_pending_fulfillments >> /var/log/gitcoin/sync_pending_fulfillments.log  2>&1
 
 ## KUDOS
-20 3,10,17 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --catchup >> /var/log/gitcoin/sync_kudos_catchup.log 2>&1
-*/10 4,11,18 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --start 1 >> /var/log/gitcoin/sync_kudos_all.log 2>&1
-*/9 3,10,17 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos xdai id --start 1 >> /var/log/gitcoin/sync_kudos_xdai.log 2>&1
+*/10 4,11,18 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos mainnet opensea --catchup >> /var/log/gitcoin/sync_kudos_catchup.log 2>&1
+*/9 3,10,17 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash sync_kudos xdai id --catchup >> /var/log/gitcoin/sync_kudos_xdai_catchup.log 2>&1
 45 */1 * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash kudos_revenue mainnet --account-address 0xAD278911Ad07534F921eD7D757b6c0e6730FCB16  >> /var/log/gitcoin/kudos_revenue.log  2>&1
 15,31 * * * * cd gitcoin/coin; bash scripts/run_management_command_if_not_already_running.bash submit_pending_kudos  >> /var/log/gitcoin/submit_pending_kudos.log  2>&1
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR alters the `sync_kudos` cron to only use `--catchup` (which will fetch only events which happened since the last run)

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Contributes towards fixing: GITC-513

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Unable to test locally

--

**DRAFT BLOCKER**

 @thelostone-mc - do we know why we are currently scanning from `kudos_id=1` every time this runs (3 times a day)?