### PR TITLE
fix: adds reuse-db flag to pytest runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # additional options
-addopts = -p no:ethereum
+addopts = -p no:ethereum --reuse-db
 
 # skip looking in the these directories for tests
 norecursedirs =


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR adds the `reuse-db` flag to `pytest.ini` to speed up any tests after the first run (this flag ensures we don't have to run migrations again once they have been ran once in the pytest context).

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally, see discussion here: https://gitcoincore.slack.com/archives/C01H9H320CV/p1635885499096200