### PR TITLE
fix: pins to a working fork of goslate (dep on django-autotranslate)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,6 +50,7 @@ geoip2==2.8.0
 django-silk==2.0.0
 django-extensions==2.2.1
 ipdb==0.13.9
+git+https://github.com/gdixon/goslate#egg=goslate
 django-autotranslate==1.1.1
 svgutils==0.3.0
 watchdog==0.9.0


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will pin us to a fork of goslate in order to fix our CI build (as well as our local install) following recent changes in setuptools (see here for details: https://github.com/pypa/setuptools/issues/1390)

-- 

I have opened a PR against goslate (https://github.com/zhuoqiang/goslate/pull/2) which will solve this without the need for us to pin anything however it will also require a version bump on `django-autotranslate` so we should merge this and look to the maintainers of these external libs to roll out a fix.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Failing build on travis (and my local)

<img width="1508" alt="Screenshot 2021-11-15 at 21 50 23" src="https://user-images.githubusercontent.com/5897836/141860450-67bc5f31-3bcc-4256-bec8-470c55f0f0b2.png">

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally