### PR TITLE
GITC-389 Remove duplicates from explore page

### DIFF
--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -126,6 +126,8 @@ if (document.getElementById('grants-showcase')) {
       editingCollection: false,
       createCollectionRedirect: false,
       activeTimeout: null,
+      scrollTriggered: false,
+      previouslyLoadedGrants: {},
       selectOptions: [
         {group: 'Discover', label: null},
         {label: 'Weighted Shuffle', value: 'weighted_shuffle'},
@@ -341,13 +343,13 @@ if (document.getElementById('grants-showcase')) {
 
         if (!append_mode) {
           vm.grants = [];
+          vm.prevouslyLoadedGrants = {};
         }
 
-        const previouslyLoadedIds = vm.grants.map(grant => grant.id);
-        
         getGrants.grants.forEach(function(item) {
-          if (!previouslyLoadedIds.includes(item.id)) {
+          if (!vm.prevouslyLoadedGrants[item.id]) {
             vm.grants.push(item);
+            vm.previouslyLoadedGrants[item.id] = item;
           }
         });
 

--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -342,8 +342,13 @@ if (document.getElementById('grants-showcase')) {
         if (!append_mode) {
           vm.grants = [];
         }
+
+        const previouslyLoadedIds = vm.grants.map(grant => grant.id);
+        
         getGrants.grants.forEach(function(item) {
-          vm.grants.push(item);
+          if (!previouslyLoadedIds.includes(item.id)) {
+            vm.grants.push(item);
+          }
         });
 
         vm.fetchedPages = [ ...vm.fetchedPages, Number(vm.params.page) ];


### PR DESCRIPTION
##### Description

This is a quick fix for resolving the bug in GITC-389. When in append mode (the mode triggered from scrolling), before adding new grants received from the server, it will check to see if it already exists. A more robust fix can be included in the server, that will be added as a new ticket.


##### Refers/Fixes

GITC-389

##### Testing

Tested locally

