### PR TITLE
fix: ensure that an invalid tezos txhash will not halt the sync command

### DIFF
--- a/app/dashboard/sync/tezos.py
+++ b/app/dashboard/sync/tezos.py
@@ -46,7 +46,8 @@ def get_tezos_txn_status(fulfillment):
 
     tx_response = requests.get(f'{BASE_URL}/operations/{txnid}').json()
 
-    if tx_response:
+    # a valid response will return a list whereas an invalid response will return a dict
+    if tx_response and isinstance(tx_response, list) and len(tx_response) > 0:
         tx_response = tx_response[0]
         block_tip = requests.get(f'{BASE_URL}/head').json()['level']
         confirmations = block_tip - tx_response['level']
@@ -70,7 +71,7 @@ def sync_tezos_payout(fulfillment):
         if txn:
             fulfillment.payout_tx_id = txn['hash']
             fulfillment.save()
-            
+
     if fulfillment.payout_tx_id and fulfillment.payout_tx_id != "0x0":
         txn_status = get_tezos_txn_status(fulfillment)
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will ensure the sync command will continue even when presented with a malformed/missing (from chain) txhash

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refers to: L2 issue (https://discord.com/channels/562828676480237578/910066042284429332/910686876329988147)

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally