### PR TITLE
Fixing bug in grants explorer scrolling.

### DIFF
--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -441,7 +441,6 @@ if (document.getElementById('grants-showcase')) {
             await vm.fetchCollections(true);
           } else if (vm.grantsHasNext && !vm.pageIsFetched(vm.params.page + 1)) {
             await vm.fetchGrants(vm.params.page, true, true);
-            vm.grantsHasNext = false;
           }
         }
       },


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

In grants explorer not all pages are loaded when scrolling.
This change fixes the issue by removing an erroneous setting of the flag `vm.grantsHasNext = false`

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

Before fix: in the grants explorer only a limited subset of the grants are shown in total (normally the first 2 pages, 12 items). Scrolling down doesn't load all items.
After fix: all the grants are loaded as the user scroll down.