### PR TITLE
Jeremy/bug fix/grants explorer A-Z/Z-A sort does not take capitalization into account

### DIFF
--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -137,7 +137,6 @@ if (document.getElementById('grants-showcase')) {
         {label: 'A to Z', value: 'title'},
         {label: 'Z to A', value: '-title'},
         {group: 'Current Round', label: null},
-        {label: 'Most Relevant', value: ''},
         {label: 'Highest Amount Raised', value: '-amount_received_in_round'},
         {label: 'Highest Contributor Count', value: '-positive_round_contributor_count'},
         {group: 'All-Time', label: null},

--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -38,6 +38,7 @@ from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.core.paginator import EmptyPage, Paginator
 from django.db import connection, transaction
 from django.db.models import Q, Subquery
+from django.db.models.functions import Lower
 from django.http import Http404, HttpResponse, JsonResponse
 from django.http.response import HttpResponseBadRequest, HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect
@@ -760,6 +761,12 @@ def get_grants_by_filters(
                 field_name = f'clr_prediction_curve__{sort_by_index}__2'
                 _grants = _grants.order_by(f"{order}{field_name}")
 
+        elif 'title' in sort:
+            if sort[0] == '-':
+                _grants = _grants.order_by(Lower('title').desc())
+            else:
+               _grants = _grants.order_by(Lower('title'))
+
         # elif 'random_shuffle' in sort:
         #     _grants = _grants.order_by('?')
 
@@ -769,7 +776,7 @@ def get_grants_by_filters(
             _grants = _grants.filter(is_clr_active=True).order_by(f"{sort}")
 
         elif sort.replace('-', '') in [
-            'weighted_shuffle', 'metadata__upcoming', 'metadata__gem', 'created_on', 'amount_received', 'contribution_count', 'contributor_count', 'last_update', 'title'
+            'weighted_shuffle', 'metadata__upcoming', 'metadata__gem', 'created_on', 'amount_received', 'contribution_count', 'contributor_count', 'last_update'
         ]:
             print(f"Sort is {sort}")
             _grants = _grants.order_by(f"{sort}")

--- a/cypress/integration/grants/test_grant_explorer.js
+++ b/cypress/integration/grants/test_grant_explorer.js
@@ -33,8 +33,8 @@ describe('Grants Explorer page', () => {
         .should('contain', 'Highest Amount Raised')
         .should('contain', 'Highest Contributor Count')
         .should('contain', 'All-Time');
-      cy.get('.vs__dropdown-menu').find('#vs3__option-14').should('contain', 'Highest Amount Raised'); // need to be more specific to test two elements with same name
-      cy.get('.vs__dropdown-menu').find('#vs3__option-15').should('contain', 'Highest Contributor Count');
+      cy.get('.vs__dropdown-menu').find('#vs3__option-13').should('contain', 'Highest Amount Raised'); // need to be more specific to test two elements with same name
+      cy.get('.vs__dropdown-menu').find('#vs3__option-14').should('contain', 'Highest Contributor Count');
     });
 
     it('divides the sort options into category names with disabled labels', () => {
@@ -135,12 +135,12 @@ describe('Grants Explorer page', () => {
       // Options in All-Time category
       cy.get('.vselect-clean').click();
 
-      cy.get('.vs__dropdown-menu').find('#vs3__option-14').contains('Highest Amount Raised').click(); // Need to be more specific here because the same options exist above
+      cy.get('.vs__dropdown-menu').find('#vs3__option-13').contains('Highest Amount Raised').click(); // Need to be more specific here because the same options exist above
       cy.url().should('contain', 'sort_option=-amount_received');
 
       cy.get('.vselect-clean').click();
 
-      cy.get('.vs__dropdown-menu').find('#vs3__option-15').contains('Highest Contributor Count').click();
+      cy.get('.vs__dropdown-menu').find('#vs3__option-14').contains('Highest Contributor Count').click();
       cy.url().should('contain', 'sort_option=-contributor_count');
 
       // Admin options

--- a/cypress/integration/grants/test_grant_explorer.js
+++ b/cypress/integration/grants/test_grant_explorer.js
@@ -30,7 +30,6 @@ describe('Grants Explorer page', () => {
         .should('contain', 'A to Z')
         .should('contain', 'Z to A')
         .should('contain', 'Current Round')
-        .should('contain', 'Most Relevant')
         .should('contain', 'Highest Amount Raised')
         .should('contain', 'Highest Contributor Count')
         .should('contain', 'All-Time');
@@ -123,11 +122,6 @@ describe('Grants Explorer page', () => {
       cy.url().should('contain', 'sort_option=-title');
 
       // Options in Current Round category
-      cy.get('.vselect-clean').click();
-
-      cy.get('.vs__dropdown-menu').contains('Most Relevant').click();
-      cy.url().should('contain', 'sort_option='); // The value of this option is purposely set to empty string (see app/assets/v2/js/grants/index.js)
-
       cy.get('.vselect-clean').click();
 
       cy.get('.vs__dropdown-menu').contains('Highest Amount Raised').click();


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR fixes a bug present in the A-Z/Z-A sort on the grants explorer that breaks the sort if some grant titles are capitalized and others are not capitalized.

Also removes a deprecated sort option that was left in by mistake.


##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally
