### PR TITLE
GITC-502: infinite-scroll-stops-working-after-applying-filter

### DIFF
--- a/app/assets/v2/js/grants/index.js
+++ b/app/assets/v2/js/grants/index.js
@@ -461,7 +461,7 @@ if (document.getElementById('grants-showcase')) {
         if (bottomOfPage || pageHeight < visible) {
           if (vm.params.tab === 'collections' && vm.collectionsPage) {
             await vm.fetchCollections(true);
-          } else if (vm.grantsHasNext && !vm.pageIsFetched(vm.params.page + 1)) {
+          } else if (vm.grantsHasNext) {
             await vm.fetchGrants(vm.params.page, true, true);
             vm.grantsHasNext = false;
           }
@@ -562,12 +562,6 @@ if (document.getElementById('grants-showcase')) {
         this.$set(this, 'tabSelected', this.params.tab);
         // load the correct tab
         this.loadTab(true);
-      },
-      pageIsFetched: function(page) {
-        let vm = this;
-
-        return vm.fetchedPages.includes(page);
-
       },
       showFilter: function() {
         let vm = this;


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR fixes a bug where infinite scroll would break after applying filters to the results in the grants explorer.

The issue was that before the next page of results would be fetched from the API, the app would check to make sure that it had not been fetched already. Before the initial `fetch`, `!pageIsFetched` returns true, and so the `fetch` will proceed. After the initial `fetch`, `!pageIsFetched` returns `false`, preventing subsequent pages from being fetched.

Removing the `pageIsFetched` check resolves this issue.


https://user-images.githubusercontent.com/36638840/143063709-15d10d6c-7f1b-4069-9cb7-b308531dd8ec.mov



##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
