### PR TITLE
GITC-622: move under button errors to top

### DIFF
--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -182,13 +182,15 @@ Vue.component('grantsCartEthereumPolygon', {
       this.cart.unsupportedTokens = this.cart.tokenList.filter(
         (token) => !this.supportedTokens.includes(token)
       );
+      if (this.cart.unsupportedTokens.length > 0) {
+        _alert(`Polygon checkout not supported due to the use of the token ${this.cart.unsupportedTokens[0]}`, 'danger');
+      }
 
       // Update the fee estimate and gas cost based on changes
       this.polygon.estimatedGasCost = await this.estimateGasCost();
 
       // Emit event so cart.js can update state accordingly to display info to user
       this.$emit('polygon-data-updated', {
-        polygonUnsupportedTokens: this.cart.unsupportedTokens,
         polygonEstimatedGasCost: this.polygon.estimatedGasCost
       });
     },

--- a/app/assets/v2/js/cart-ethereum-zksync.js
+++ b/app/assets/v2/js/cart-ethereum-zksync.js
@@ -138,6 +138,10 @@ Vue.component('grantsCartEthereumZksync', {
         (token) => !this.supportedTokens.includes(token)
       );
 
+      if (this.cart.unsupportedTokens.length > 0) {
+        _alert(`zkSync checkout not supported due to the use of the token ${this.cart.unsupportedTokens[0]}`, 'danger');
+      }
+
       // If currently selected fee token is still in the cart, don't change it. Otherwise, set
       // fee token to the token used for the first item in the cart
       if (!this.cart.tokenList.includes(this.zksync.feeTokenSymbol)) {
@@ -170,7 +174,6 @@ Vue.component('grantsCartEthereumZksync', {
 
       // Emit event so cart.js can update state accordingly to display info to user
       this.$emit('zksync-data-updated', {
-        zkSyncUnsupportedTokens: this.cart.unsupportedTokens,
         zkSyncEstimatedGasCost: estimatedGasCost
       });
     },

--- a/app/grants/templates/grants/cart/eth.html
+++ b/app/grants/templates/grants/cart/eth.html
@@ -502,7 +502,7 @@
 
           <b-tooltip target="zksync-tooltip" triggers="hover">
             <p v-if="grantsByTenant.length > maxCartItems">
-              Zksync checkout supports checkout for [[maxCartItems]] items.
+              zkSync checkout supports checkout for [[maxCartItems]] items.
               Please remove [[ grantsByTenant.length - maxCartItems ]] grant
               <span v-if="grantsByTenant.length - maxCartItems > 1">s</span>
               from your cart to use zkSync checkout.
@@ -511,21 +511,9 @@
         </div>
 
         <!-- Checkout recommendation -->
-        <div class="text-center mt-2" v-if="
-          (zkSyncUnsupportedTokens.length > 0 || polygonUnsupportedTokens.length > 0) ||
-          polygonUnsupportedTokens.length > 0 ||
-          !isNaN(checkoutRecommendation.savingsInPercent)
-        ">
+        <div class="text-center mt-2" v-if="!isNaN(checkoutRecommendation.savingsInPercent)">
           <div class="font-smaller-3 bg-lightpurple p-3 rounded w-100">
-            <template v-if="zkSyncUnsupportedTokens.length > 0 || polygonUnsupportedTokens.length > 0">
-              <template v-if="zkSyncUnsupportedTokens.length > 0">
-                zkSync checkout not supported due to [[ zkSyncUnsupportedTokens.join(', ') ]]
-              </template>
-              <template v-if="polygonUnsupportedTokens.length > 0">
-                Polygon checkout not supported due to [[ polygonUnsupportedTokens.join(', ') ]]
-              </template>
-            </template>
-            <template v-else-if="!isNaN(checkoutRecommendation.savingsInPercent)">
+            <template v-if="!isNaN(checkoutRecommendation.savingsInPercent)">
               💡 Save <span class="text-primary">~[[ checkoutRecommendation.savingsInPercent ]]%</span>
               on gas fees with [[ checkoutRecommendation.name ]]!
             </template>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

GIVEN I am on the Grants checkout page
WHEN I trigger an error that appears below the checkout button
THEN the error should not appear under the checkout button and instead be mapped to a standard error that appears as a banner on the top of the page.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

https://share.vidyard.com/watch/zPsfRpVM23vKw7pTc4x4DQ?
