### PR TITLE
fix: prevent CSS injection in profile banner filename filter

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -5780,7 +5780,7 @@ def change_user_profile_banner(request):
     try:
         profile = profile_helper(handle, True)
         is_valid = request.user.profile.id == profile.id
-        if filename[0:19] != '/static/wallpapers/' or filename.split('/')[-1] not in load_files_in_directory('wallpapers'):
+        if filename[0:19] != '/static/wallpapers/' or filename[19:] not in load_files_in_directory('wallpapers'):
             is_valid = False
         if not is_valid:
             return JsonResponse(

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -5780,7 +5780,7 @@ def change_user_profile_banner(request):
     try:
         profile = profile_helper(handle, True)
         is_valid = request.user.profile.id == profile.id
-        if filename[0:7] != '/static' or filename.split('/')[-1] not in load_files_in_directory('wallpapers'):
+        if filename[0:19] != '/static/wallpapers/' or filename.split('/')[-1] not in load_files_in_directory('wallpapers'):
             is_valid = False
         if not is_valid:
             return JsonResponse(


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This PR fix a CSS injection in profile banner filename filter. 
The old filter can be bypassed with the payload below:
```
Content-Disposition: form-data; name="banner"

/static"); background-image: url(**Image Link Here**); display: (/wallpapers/2021_795.png
``` 
Any CSS without double quote could be injected by using the payload.

An injected example: https://gitcoin.co/tkzcm

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
The new filter should be fine while the banners are only from the wallpapers folder.