### PR TITLE
fix: ensures `banner_text` never exceeds 50 chars

### DIFF
--- a/app/grants/tests/factories/grant_clr_factory.py
+++ b/app/grants/tests/factories/grant_clr_factory.py
@@ -16,5 +16,5 @@ class GrantCLRFactory(factory.django.DjangoModelFactory):
     start_date = factory.LazyFunction(datetime.now)
     end_date = factory.LazyAttribute(lambda o: o.start_date + timedelta(weeks=2))
     type = factory.LazyFunction(lambda: choice(GrantCLR.CLR_TYPES)[0])
-    banner_text = factory.Faker('catch_phrase')
+    banner_text = factory.Faker('text', max_nb_chars=50)
     owner = factory.SubFactory(ProfileFactory)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@
 futures==3.1.1
 pytest==6.2.4
 pytest-cov==2.12.0
-pytest-factoryboy==2.1.0
 pytest-isort==2.0.0
 pytest-factoryboy==2.1.0
 pytest-django==4.3.0


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will fix `GrantCLR` -> `banner_text` to 50 chars with `factory.Faker` to prevent insert transaction from failing (intermittently).

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Failing tests

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally 