### PR TITLE
Bug Fixes: Users cannot make progress during different quest stages

### DIFF
--- a/app/assets/v2/js/pages/quests.quest.quiz_style.js
+++ b/app/assets/v2/js/pages/quests.quest.quiz_style.js
@@ -181,7 +181,7 @@ var advance_to_state = async function(new_state) {
     typeWriter();
     await wait_for_typewriter();
 
-    var $safe_reward = $('<div />');
+    var safe_reward = $('<div />');
 
     safe_reward.append(" <BR><BR> If you're successful in this quest, you'll earn this limited edition ");
 
@@ -315,7 +315,7 @@ var winner = async function(prize_url) {
   if (document.reward_tip['token_amount']) {
     $('#desc').html($('<strong />').text(document.reward_tip['token_amount'] + ' ' + document.reward_tip['token']));
   } else {
-    $('#desc').append($span);
+    $('#desc').append(span);
     $('#desc').append(
       $('<img>').attr('style', 'height: 250px;width: 220px;').attr('src', document.kudos_reward['img'])
     );


### PR DESCRIPTION
This pull request is addressing two issues that were introduced following some refactoring and XSS fixing in the past few days.

#9738 - Individual Quests Intermittently Unable to Progress passed Intro - Browser's Console Error: Changed line 184

#9739 - Quest - User not prompted to claim rewards after the message announcing the user won the quest: Changed Line 318

the code changes are obvious since they both concerns variables declaration that does not match their intended references (the declaration has dollar sign in front of name when references do not have the dollar symbol).





