### PR TITLE
GITC-631: ensure `last_update` is set before comparing it to `three_months_ago`

### DIFF
--- a/app/grants/models/grant.py
+++ b/app/grants/models/grant.py
@@ -816,7 +816,7 @@ class Grant(SuperModel):
     def is_idle(self):
         """Return if grants is idle."""
         three_months_ago = timezone.now() - timezone.timedelta(days=90)
-        return (self.last_update <= three_months_ago)
+        return (self.last_update and self.last_update <= three_months_ago)
 
 
     @property


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR ensures `last_update` is set before we compare it to `three_months_ago` in the `is_idle` check.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: GITC-631

(https://sentry.io/organizations/gitcoin/issues/2761533717/?project=1398424)

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally