### PR TITLE
fix: cleanups activity commands and queries

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -479,7 +479,7 @@ class Bounty(SuperModel):
     @property
     def latest_activity(self):
         activity_indexes = ActivityIndex.objects.filter(key=f'bounty:{self.pk}').values_list('activity__pk', flat=True)
-        activity = Activity.objects.filter(pk__in=list(activity_indexes)).order_by('-pk')
+        activity = Activity.objects.filter(pk__in=list(activity_indexes.first())).order_by('-pk')
         if activity.exists():
             from dashboard.router import ActivitySerializer
             return ActivitySerializer(activity.first()).data
@@ -2314,10 +2314,10 @@ class ActivityIndex(SuperModel):
     """All Activity Reads happen from this table"""
     key = models.CharField(max_length=255, db_index=True)
     activity = models.ForeignKey(
-        'dashboard.Activity', 
-        null=True, 
-        on_delete=models.SET_NULL, 
-        related_name='activities_index', 
+        'dashboard.Activity',
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name='activities_index',
         blank=True
     )
 
@@ -2657,7 +2657,7 @@ class Activity(SuperModel):
                 key=key,
                 activity=_activity,
                 created_on=_activity.created_on
-            )    
+            )
 
 
     def to_dict(self, fields=None, exclude=None):
@@ -4452,7 +4452,6 @@ class Profile(SuperModel):
             counts = {ele['activity_type']: ele['the_count'] for ele in counts}
         params['activities_counts'] = counts
 
-        params['activities'] = list(self.get_various_activities().values_list('pk', flat=True))
         params['tips'] = list(self.tips.filter(**query_kwargs).send_happy_path().values_list('pk', flat=True))
         params['scoreboard_position_contributor'] = self.get_contributor_leaderboard_index()
         params['scoreboard_position_funder'] = self.get_funder_leaderboard_index()
@@ -5725,7 +5724,7 @@ def psave_answer(sender, instance, created, **kwargs):
                 }
             )
             activity.populate_activity_index()
-            
+
         elif instance.question.hook == 'LOOKING_TEAM_PROJECT':
             registration = HackathonRegistration.objects.filter(hackathon=instance.hackathon,
                                                                 registrant=instance.user.profile).first()

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -478,8 +478,9 @@ class Bounty(SuperModel):
 
     @property
     def latest_activity(self):
-        activity_indexes = ActivityIndex.objects.filter(key=f'bounty:{self.pk}').values_list('activity__pk', flat=True)
-        activity = Activity.objects.filter(pk__in=list(activity_indexes.first())).order_by('-pk')
+        # request more activityIndex items than we need to account for hidden/rinkeby/etc activity
+        activity_indexes = ActivityIndex.objects.filter(key=f'bounty:{self.pk}').values_list('activity__pk', flat=True)[0:10]
+        activity = Activity.objects.filter(pk__in=list(activity_indexes)).order_by('-pk')
         if activity.exists():
             from dashboard.router import ActivitySerializer
             return ActivitySerializer(activity.first()).data

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4164,12 +4164,14 @@ def sync_web3(request):
                     if new_bounty:
                         url = new_bounty.url
                         try:
-                            fund_ables = Activity.objects.filter(activity_type='status_update',
-                                                                 bounty=None,
-                                                                 metadata__fund_able=True,
-                                                                 metadata__resource__contains={
-                                                                     'provider': issue_url
-                                                                 })
+                            fund_ables = Activity.objects.filter(
+                                activity_type='status_update',
+                                bounty=None,
+                                metadata__fund_able=True,
+                                metadata__resource__contains={
+                                    'provider': issue_url
+                                }
+                            )
                             if fund_ables.exists():
                                 comment = f'New Bounty created {new_bounty.get_absolute_url()}'
                                 activity = fund_ables.first()

--- a/app/marketing/views.py
+++ b/app/marketing/views.py
@@ -1031,7 +1031,7 @@ def latest_activities(user):
     from retail.views import get_specific_activities
     from townsquare.tasks import increment_view_counts
     cutoff_date = timezone.now() - timezone.timedelta(days=1)
-    activities = get_specific_activities('connect', 0, user, 0)[:4]
+    activities = get_specific_activities('connect', 0, user, 0, page=1, page_size=4)[:4]
     activities_pks = list(activities.values_list('pk', flat=True))
     increment_view_counts.delay(activities_pks)
     return activities

--- a/app/marketing/views.py
+++ b/app/marketing/views.py
@@ -1027,11 +1027,13 @@ def get_hackathons():
 
         return current_hackathons, upcoming_hackathons
 
+
 def latest_activities(user):
     from retail.views import get_specific_activities
     from townsquare.tasks import increment_view_counts
     cutoff_date = timezone.now() - timezone.timedelta(days=1)
-    activities = get_specific_activities('connect', 0, user, 0, page=1, page_size=4)[:4]
+    # request more activityIndex items than we need to account for hidden/rinkeby/etc activity
+    activities = get_specific_activities('connect', 0, user, 0, page=1, page_size=10)[:4]
     activities_pks = list(activities.values_list('pk', flat=True))
     increment_view_counts.delay(activities_pks)
     return activities

--- a/app/perftools/management/commands/create_activity_cache.py
+++ b/app/perftools/management/commands/create_activity_cache.py
@@ -39,7 +39,8 @@ def create_activity_cache():
         all_tags.append([None, None, tab])
     for tag in all_tags:
         keyword = tag[2]
-        data = get_specific_activities(keyword, False, None, None, page=1, page_size=10)
+        # request more activityIndex items than we need to account for hidden/rinkeby/etc activity
+        data = get_specific_activities(keyword, False, None, None, page=1, page_size=20)
         JSONStore.objects.filter(view=view, key=keyword).all().delete()
         JSONStore.objects.create(
             view=view,

--- a/app/perftools/management/commands/create_activity_cache.py
+++ b/app/perftools/management/commands/create_activity_cache.py
@@ -39,7 +39,7 @@ def create_activity_cache():
         all_tags.append([None, None, tab])
     for tag in all_tags:
         keyword = tag[2]
-        data = get_specific_activities(keyword, False, None, None)
+        data = get_specific_activities(keyword, False, None, None, page=1, page_size=10)
         JSONStore.objects.filter(view=view, key=keyword).all().delete()
         JSONStore.objects.create(
             view=view,

--- a/app/perftools/management/commands/create_page_cache.py
+++ b/app/perftools/management/commands/create_page_cache.py
@@ -230,19 +230,19 @@ def create_activity_cache():
     print('activity.1')
     view = 'activity'
     keyword = '24hcount'
-    data = Activity.objects.filter(created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count()
+    activity_count = Activity.objects.filter(created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count()
     JSONStore.objects.filter(view=view, key=keyword).all().delete()
     JSONStore.objects.create(
         view=view,
         key=keyword,
-        data=json.loads(json.dumps(data, cls=EncodeAnything)),
+        data=json.loads(json.dumps(activity_count, cls=EncodeAnything)),
         )
 
     print('activity.2')
 
     for tag in tags:
         keyword = tag[2]
-        data = get_specific_activities(keyword, False, None, None).filter(created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count()
+        data = get_specific_activities(keyword, False, None, None, page=1, page_size=activity_count).filter(created_on__gt=timezone.now() - timezone.timedelta(hours=hours)).count()
         JSONStore.objects.filter(view=view, key=keyword).all().delete()
         JSONStore.objects.create(
             view=view,

--- a/app/retail/views.py
+++ b/app/retail/views.py
@@ -742,7 +742,7 @@ def results(request, keyword=None):
     context['avatar_url'] = static('v2/images/results_preview.gif')
     return TemplateResponse(request, 'results.html', context)
 
-def get_specific_activities(what, trending_only, user, after_pk, request=None, page=None):
+def get_specific_activities(what, trending_only, user, after_pk, request=None, page=None, page_size=10):
 
     # 1. Init
     view_count_threshold = 10
@@ -812,7 +812,6 @@ def get_specific_activities(what, trending_only, user, after_pk, request=None, p
         activity_pks = activity_pks.order_by('-id')
         # Pagination is done here
         if page:
-            page_size = 10
             start_index = (page-1) * page_size
             end_index = page * page_size
             activity_pks = activity_pks[start_index:end_index].values_list('activity_id', flat=True)

--- a/app/townsquare/views.py
+++ b/app/townsquare/views.py
@@ -20,7 +20,6 @@ from kudos.models import Token
 from marketing.mails import comment_email, mention_email, new_action_request, tip_comment_awarded_email
 from perftools.models import JSONStore
 from ratelimit.decorators import ratelimit
-from retail.views import get_specific_activities
 
 from .models import (
     Announcement, Comment, Favorite, Flag, Like, MatchRanking, MatchRound, Offer, OfferAction, PinnedPost,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR will clean up the `Activity` queries so that we're not passing every `ActivityIndex` as a `pk` into `Activity.objects.filter(...)` 

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refs: DB load on RR1 and RR2

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally (needs more testing once we have it pulled on to the cronbox to verify this fixes the problem)