### PR TITLE
fix: ensures polygon balance checks don't error out before they're meant to

### DIFF
--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -467,7 +467,7 @@ Vue.component('grantsCartEthereumPolygon', {
         const tokenIsMatic = tokenDetails && tokenDetails.name === 'MATIC';
 
         // Check user matic balance against required amount
-        if (userMaticBalance.lt(requiredAmounts[tokenSymbol].amount) && tokenIsMatic) {
+        if (userMaticBalance.toNumber() && userMaticBalance.lt(requiredAmounts[tokenSymbol].amount) && tokenIsMatic) {
           requiredAmounts[tokenSymbol].isBalanceSufficient = false;
           requiredAmounts[tokenSymbol].amount = parseFloat(((
             requiredAmounts[tokenSymbol].amount - userMaticBalance
@@ -511,7 +511,7 @@ Vue.component('grantsCartEthereumPolygon', {
             .balanceOf(userAddress)
             .call({ from: userAddress }));
 
-          if (userTokenBalance.lt(requiredAmounts[tokenSymbol].amount)) {
+          if (userTokenBalance.toNumber() && userTokenBalance.lt(requiredAmounts[tokenSymbol].amount)) {
             requiredAmounts[tokenSymbol].isBalanceSufficient = false;
             requiredAmounts[tokenSymbol].amount = parseFloat(((
               requiredAmounts[tokenSymbol].amount - userTokenBalance


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR ensures that the user holds a balance without throwing a `bn` error when they don't. 

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refs: underflow - polygon checkout thread in l2

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally