### PR TITLE
GITC-327: GitHub caching extension

### DIFF
--- a/app/dashboard/notifications.py
+++ b/app/dashboard/notifications.py
@@ -436,7 +436,7 @@ def maybe_market_to_github(bounty, event_name, profile_pairs=None):
         # Handle creating or updating comments if profiles are provided.
         if event_name in ['work_started', 'work_submitted'] and profile_pairs:
             if comment_id is not None:
-                patch_issue_comment(comment_id, username, repo, msg)
+                patch_issue_comment(issue_num, comment_id, username, repo, msg)
             else:
                 response = post_issue_comment(username, repo, issue_num, msg)
                 if response.id:
@@ -448,7 +448,7 @@ def maybe_market_to_github(bounty, event_name, profile_pairs=None):
         # Handle deleting comments if no profiles are provided.
         elif event_name in ['work_started'] and not profile_pairs:
             if comment_id:
-                delete_issue_comment(comment_id, username, repo)
+                delete_issue_comment(issue_num, comment_id, username, repo)
                 if event_name == 'work_started':
                     bounty.interested_comment = None
                 elif event_name == 'work_done':

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -6354,12 +6354,6 @@ def fulfill_bounty_v1(request):
         response['message'] = 'error: missing fulfiller_address'
         return JsonResponse(response)
 
-    event_name = 'work_submitted'
-    record_bounty_activity(bounty, user, event_name)
-    maybe_market_to_email(bounty, event_name)
-    profile_pairs = build_profile_pairs(bounty)
-    maybe_market_to_github(bounty, event_name, profile_pairs)
-
     if bounty.bounty_state != 'work_submitted':
         bounty.bounty_state = 'work_submitted'
         bounty.idx_status = 'submitted'
@@ -6398,6 +6392,14 @@ def fulfill_bounty_v1(request):
 
     if project:
         project.save()
+
+    # The helpers to send out notifications, comments, etc ... should
+    # be called after all is saved in DB. Otherwise some messages might be incomplete.
+    event_name = 'work_submitted'
+    record_bounty_activity(bounty, user, event_name)
+    maybe_market_to_email(bounty, event_name)
+    profile_pairs = build_profile_pairs(bounty)
+    maybe_market_to_github(bounty, event_name, profile_pairs)
 
     response = {
         'status': 204,

--- a/app/git/models.py
+++ b/app/git/models.py
@@ -41,10 +41,16 @@ class GitCache(SuperModel):
     class Category:
         USER = "user"
         REPO = "repo"
+        ISSUE = "issue"
+        COMMIT_COMMENT = "commit_comment"
+        ISSUE_COMMENT = "commit_comment"
 
     CATEGORY_CHOICES = [
         (Category.USER, 'User'),
         (Category.REPO, 'Repository'),
+        (Category.ISSUE, 'Issue'),
+        (Category.COMMIT_COMMENT, 'Commit Comment'),
+        (Category.ISSUE_COMMENT, 'Issue Comment'),
     ]
 
     handle = models.CharField(max_length=200, null=False, blank=True)
@@ -58,16 +64,73 @@ class GitCache(SuperModel):
         """Return the string representation of a model."""
         return f"[{self.category}] {self.handle}"
 
-    @classmethod
-    def get_user(self, handle):
-        """Utility function to retreive a user object"""
-        try:
-            return self.objects.get(category=GitCache.Category.USER, handle=handle)
-        except self.DoesNotExist:
-            raise
-
     def update_data(self, data):
         """Update the data field if it has changed."""
         if self.data != data:
             self.data = data
             self.save()
+
+    @classmethod
+    def create_user_cache(self, user):
+        """Create a user cache object"""
+        return GitCache(handle=user, category=GitCache.Category.REPO)
+
+    @classmethod
+    def get_user(self, handle):
+        """Utility function to retreive a user object"""
+        try:
+            return self.objects.get(handle=handle, category=GitCache.Category.USER)
+        except self.DoesNotExist:
+            raise
+
+    @classmethod
+    def create_repo_cache(self, user, repo):
+        """Create a repository cache object"""
+        return GitCache(handle=f"{user}/{repo}", category=GitCache.Category.REPO)
+
+    @classmethod
+    def get_repo(self, user, repo):
+        """Utility function to retreive a repo object"""
+        try:
+            return self.objects.get(handle=f"{user}/{repo}", category=GitCache.Category.REPO)
+        except self.DoesNotExist:
+            raise
+
+    @classmethod
+    def create_issue_cache(self, user, repo, issue):
+        """Create a issue cache object"""
+        return GitCache(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
+
+    @classmethod
+    def get_issue(self, user, repo, issue):
+        """Utility function to retreive an issue object"""
+        try:
+            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
+        except self.DoesNotExist:
+            raise
+
+    @classmethod
+    def create_commit_comment_cache(self, user, repo, comment):
+        """Create a commit comment cache object"""
+        return GitCache(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_OMMENT)
+
+    @classmethod
+    def get_commit_comment(self, user, repo, comment):
+        """Utility function to retreive an commit comment object"""
+        try:
+            return self.objects.get(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_OMMENT)
+        except self.DoesNotExist:
+            raise
+
+    @classmethod
+    def create_issue_comment_cache(self, user, repo, issue, comment):
+        """Create a issue comment cache object"""
+        return GitCache(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_OMMENT)
+
+    @classmethod
+    def get_issue_comment(self, user, repo, issue, comment):
+        """Utility function to retreive an issue comment object"""
+        try:
+            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_OMMENT)
+        except self.DoesNotExist:
+            raise

--- a/app/git/models.py
+++ b/app/git/models.py
@@ -42,14 +42,12 @@ class GitCache(SuperModel):
         USER = "user"
         REPO = "repo"
         ISSUE = "issue"
-        COMMIT_COMMENT = "commit_comment"
-        ISSUE_COMMENT = "commit_comment"
+        ISSUE_COMMENT = "issue_comment"
 
     CATEGORY_CHOICES = [
         (Category.USER, 'User'),
         (Category.REPO, 'Repository'),
         (Category.ISSUE, 'Issue'),
-        (Category.COMMIT_COMMENT, 'Commit Comment'),
         (Category.ISSUE_COMMENT, 'Issue Comment'),
     ]
 
@@ -106,19 +104,6 @@ class GitCache(SuperModel):
         """Utility function to retreive an issue object"""
         try:
             return self.objects.get(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
-        except self.DoesNotExist:
-            raise
-
-    @classmethod
-    def create_commit_comment_cache(self, user, repo, comment):
-        """Create a commit comment cache object"""
-        return GitCache(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_COMMENT)
-
-    @classmethod
-    def get_commit_comment(self, user, repo, comment):
-        """Utility function to retreive an commit comment object"""
-        try:
-            return self.objects.get(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_COMMENT)
         except self.DoesNotExist:
             raise
 

--- a/app/git/models.py
+++ b/app/git/models.py
@@ -112,25 +112,25 @@ class GitCache(SuperModel):
     @classmethod
     def create_commit_comment_cache(self, user, repo, comment):
         """Create a commit comment cache object"""
-        return GitCache(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_OMMENT)
+        return GitCache(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_COMMENT)
 
     @classmethod
     def get_commit_comment(self, user, repo, comment):
         """Utility function to retreive an commit comment object"""
         try:
-            return self.objects.get(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_OMMENT)
+            return self.objects.get(handle=f"{user}/{repo}/commit_comment/{comment}", category=GitCache.Category.COMMIT_COMMENT)
         except self.DoesNotExist:
             raise
 
     @classmethod
     def create_issue_comment_cache(self, user, repo, issue, comment):
         """Create a issue comment cache object"""
-        return GitCache(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_OMMENT)
+        return GitCache(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_COMMENT)
 
     @classmethod
     def get_issue_comment(self, user, repo, issue, comment):
         """Utility function to retreive an issue comment object"""
         try:
-            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_OMMENT)
+            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_COMMENT)
         except self.DoesNotExist:
             raise

--- a/app/git/models.py
+++ b/app/git/models.py
@@ -69,53 +69,53 @@ class GitCache(SuperModel):
             self.save()
 
     @classmethod
-    def create_user_cache(self, user):
+    def create_user_cache(cls, user):
         """Create a user cache object"""
         return GitCache(handle=user, category=GitCache.Category.REPO)
 
     @classmethod
-    def get_user(self, handle):
+    def get_user(cls, handle):
         """Utility function to retreive a user object"""
         try:
-            return self.objects.get(handle=handle, category=GitCache.Category.USER)
-        except self.DoesNotExist:
+            return cls.objects.get(handle=handle, category=GitCache.Category.USER)
+        except cls.DoesNotExist:
             raise
 
     @classmethod
-    def create_repo_cache(self, user, repo):
+    def create_repo_cache(cls, user, repo):
         """Create a repository cache object"""
         return GitCache(handle=f"{user}/{repo}", category=GitCache.Category.REPO)
 
     @classmethod
-    def get_repo(self, user, repo):
+    def get_repo(cls, user, repo):
         """Utility function to retreive a repo object"""
         try:
-            return self.objects.get(handle=f"{user}/{repo}", category=GitCache.Category.REPO)
-        except self.DoesNotExist:
+            return cls.objects.get(handle=f"{user}/{repo}", category=GitCache.Category.REPO)
+        except cls.DoesNotExist:
             raise
 
     @classmethod
-    def create_issue_cache(self, user, repo, issue):
+    def create_issue_cache(cls, user, repo, issue):
         """Create a issue cache object"""
         return GitCache(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
 
     @classmethod
-    def get_issue(self, user, repo, issue):
+    def get_issue(cls, user, repo, issue):
         """Utility function to retreive an issue object"""
         try:
-            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
-        except self.DoesNotExist:
+            return cls.objects.get(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE)
+        except cls.DoesNotExist:
             raise
 
     @classmethod
-    def create_issue_comment_cache(self, user, repo, issue, comment):
+    def create_issue_comment_cache(cls, user, repo, issue, comment):
         """Create a issue comment cache object"""
         return GitCache(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_COMMENT)
 
     @classmethod
-    def get_issue_comment(self, user, repo, issue, comment):
+    def get_issue_comment(cls, user, repo, issue, comment):
         """Utility function to retreive an issue comment object"""
         try:
-            return self.objects.get(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_COMMENT)
-        except self.DoesNotExist:
+            return cls.objects.get(handle=f"{user}/{repo}/issue/{issue}/{comment}", category=GitCache.Category.ISSUE_COMMENT)
+        except cls.DoesNotExist:
             raise

--- a/app/git/tests/models/test_git_cache.py
+++ b/app/git/tests/models/test_git_cache.py
@@ -1,6 +1,7 @@
 import pytest
 from git.models import GitCache
 from git.tests.factories.git_cache_factory import GitCacheFactory
+from faker import Faker
 
 
 @pytest.mark.django_db
@@ -14,16 +15,150 @@ class TestGitCache:
 
         assert isinstance(git_cache, GitCache)
 
+    def test_create_user_cache(self):
+        """Test create_user_cache helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+
+        git_cache = GitCache.create_user_cache(user)
+        assert git_cache.handle == user
+        assert git_cache.category == GitCache.Category.USER
+
+    def test_create_user_cache(self):
+        """Test create_repo_cache helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+
+        git_cache = GitCache.create_repo_cache(user, repo)
+        assert git_cache.handle == f"{user}/{repo}"
+        assert git_cache.category == GitCache.Category.REPO
+
+    def test_create_issue_cache(self):
+        """Test create_issue_cache helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        issue = fake.pyint()
+
+        git_cache = GitCache.create_issue_cache(user, repo, issue)
+        assert git_cache.handle == f"{user}/{repo}/issue/{issue}"
+        assert git_cache.category == GitCache.Category.ISSUE
+
+    def test_create_issue_comment_cache(self):
+        """Test create_issue_comment_cache helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        issue = fake.pyint()
+        comment = fake.pyint()
+
+        git_cache = GitCache.create_issue_comment_cache(user, repo, issue, comment)
+
+        assert git_cache.handle == f"{user}/{repo}/issue/{issue}/{comment}"
+        assert git_cache.category == GitCache.Category.ISSUE_COMMENT
+
+    def test_create_commit_comment_cache(self):
+        """Test create_commit_comment_cache helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        comment = fake.pyint()
+
+        git_cache = GitCache.create_commit_comment_cache(user, repo, comment)
+
+        assert git_cache.handle == f"{user}/{repo}/commit_comment/{comment}"
+        assert git_cache.category == GitCache.Category.COMMIT_COMMENT
+
     def test_get_user(self):
         """Test get_user helper function."""
+        fake = Faker()
 
-        git_cache = GitCacheFactory()
-        git_cache.category = GitCache.Category.USER
-        handle = git_cache.handle
+        user = fake.user_name()
+        binary_data = fake.text().encode('utf-8')
+
+        git_cache = GitCache(handle=f"{user}", category=GitCache.Category.USER, data=binary_data)
         git_cache.save()
 
-        saved = GitCache.get_user(handle)
-        assert git_cache.id == saved.id
+        saved = GitCache.get_user(user)
+        assert saved.id == git_cache.id
+        assert saved.category == GitCache.Category.USER
+        assert bytes(saved.data) == binary_data
+
+    def test_get_repo(self):
+        """Test get_repo helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        binary_data = fake.text().encode('utf-8')
+
+        git_cache = GitCache(handle=f"{user}/{repo}", category=GitCache.Category.REPO, data=binary_data)
+        git_cache.save()
+
+        saved = GitCache.get_repo(user, repo)
+        assert saved.id == git_cache.id
+        assert saved.category == GitCache.Category.REPO
+        assert bytes(saved.data) == binary_data
+
+    def test_get_issue(self):
+        """Test get_issue helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        issue = fake.pyint()
+        binary_data = fake.text().encode('utf-8')
+
+        git_cache = GitCache(handle=f"{user}/{repo}/issue/{issue}", category=GitCache.Category.ISSUE, data=binary_data)
+        git_cache.save()
+
+        saved = GitCache.get_issue(user, repo, issue)
+        assert saved.id == git_cache.id
+        assert saved.category == GitCache.Category.ISSUE
+        assert bytes(saved.data) == binary_data
+
+    def test_get_issue_comment(self):
+        """Test get_issue_comment helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        issue = fake.pyint()
+        comment = fake.pyint()
+        binary_data = fake.text().encode('utf-8')
+
+        git_cache = GitCache(handle=f"{user}/{repo}/issue/{issue}/{comment}",
+                             category=GitCache.Category.ISSUE_COMMENT, data=binary_data)
+        git_cache.save()
+
+        saved = GitCache.get_issue_comment(user, repo, issue, comment)
+        assert saved.id == git_cache.id
+        assert saved.category == GitCache.Category.ISSUE_COMMENT
+        assert bytes(saved.data) == binary_data
+
+    def test_get_commit_comment(self):
+        """Test get_commit_comment helper function."""
+        fake = Faker()
+
+        user = fake.user_name()
+        repo = fake.user_name()
+        comment = fake.pyint()
+        binary_data = fake.text().encode('utf-8')
+
+        git_cache = GitCache(handle=f"{user}/{repo}/commit_comment/{comment}",
+                             category=GitCache.Category.COMMIT_COMMENT, data=binary_data)
+        git_cache.save()
+
+        saved = GitCache.get_commit_comment(user, repo, comment)
+        assert saved.id == git_cache.id
+        assert saved.category == GitCache.Category.COMMIT_COMMENT
+        assert bytes(saved.data) == binary_data
 
     def test_update_data(self):
         """Test update_data helper function."""

--- a/app/git/tests/models/test_git_cache.py
+++ b/app/git/tests/models/test_git_cache.py
@@ -62,19 +62,6 @@ class TestGitCache:
         assert git_cache.handle == f"{user}/{repo}/issue/{issue}/{comment}"
         assert git_cache.category == GitCache.Category.ISSUE_COMMENT
 
-    def test_create_commit_comment_cache(self):
-        """Test create_commit_comment_cache helper function."""
-        fake = Faker()
-
-        user = fake.user_name()
-        repo = fake.user_name()
-        comment = fake.pyint()
-
-        git_cache = GitCache.create_commit_comment_cache(user, repo, comment)
-
-        assert git_cache.handle == f"{user}/{repo}/commit_comment/{comment}"
-        assert git_cache.category == GitCache.Category.COMMIT_COMMENT
-
     def test_get_user(self):
         """Test get_user helper function."""
         fake = Faker()
@@ -140,24 +127,6 @@ class TestGitCache:
         saved = GitCache.get_issue_comment(user, repo, issue, comment)
         assert saved.id == git_cache.id
         assert saved.category == GitCache.Category.ISSUE_COMMENT
-        assert bytes(saved.data) == binary_data
-
-    def test_get_commit_comment(self):
-        """Test get_commit_comment helper function."""
-        fake = Faker()
-
-        user = fake.user_name()
-        repo = fake.user_name()
-        comment = fake.pyint()
-        binary_data = fake.text().encode('utf-8')
-
-        git_cache = GitCache(handle=f"{user}/{repo}/commit_comment/{comment}",
-                             category=GitCache.Category.COMMIT_COMMENT, data=binary_data)
-        git_cache.save()
-
-        saved = GitCache.get_commit_comment(user, repo, comment)
-        assert saved.id == git_cache.id
-        assert saved.category == GitCache.Category.COMMIT_COMMENT
         assert bytes(saved.data) == binary_data
 
     def test_update_data(self):


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This extends caching of github objects to repos, issues, comment.

##### Refers/Fixes

GITC-327 GITC-569

##### Testing

GIVEN I have successfully logged in to Gitcoin
WHEN I create a new Bounty
THEN All the information is correctly pulled from Github when I provide the github issue url (Issue Title and Details) and a comment with the issue status is posted in the github issue "Issue Status: 1. Open 2. Started 3. Submitted 4. Done ..." 

GIVEN I have a bounty linked to a github issue
WHEN I cancel the bounty
THEN A comment about the cancelation is posted in the github issue

GIVEN I create a contest bounty (multiple contributors)
WHEN each contributor submits his work
THEN each submission of work is reflected in a github comment on the bounty issue (a single comment, aggregating the information of all submissions)

