### PR TITLE
GITC-665: mismatch grants token and cart

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1684,18 +1684,7 @@ Vue.component('grants-cart', {
     // Read array of grants in cart from localStorage
     let grantData = CartData.loadCart();
 
-    this.selectedETHCartToken = null;
-
-    for (var index = 0; index < grantData.length; index++) {
-      if (grantData[index].grant_donation_currency) {
-        this.selectedETHCartToken = grantData[index].grant_donation_currency;
-        break;
-      }
-    }
-
-    if (!this.selectedETHCartToken) {
-      this.selectedETHCartToken = 'DAI';
-    }
+    this.selectedETHCartToken = grantData.length > 0 && grantData[0].grant_donation_currency;
 
     const grantIds = grantData.map(grant => grant.grant_id);
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1684,7 +1684,18 @@ Vue.component('grants-cart', {
     // Read array of grants in cart from localStorage
     let grantData = CartData.loadCart();
 
-    this.selectedETHCartToken = grantData.length > 0 && grantData[0].grant_donation_currency;
+    this.selectedETHCartToken = null;
+
+    for (var index = 0; index < grantData.length; index++) {
+      if (grantData[index].grant_donation_currency) {
+        this.selectedETHCartToken = grantData[index].grant_donation_currency;
+        break;
+      }
+    }
+
+    if (!this.selectedETHCartToken) {
+      this.selectedETHCartToken = 'DAI';
+    }
 
     const grantIds = grantData.map(grant => grant.grant_id);
 
@@ -1701,7 +1712,7 @@ Vue.component('grants-cart', {
 
       // Make sure none have empty currencies, and if they do default to 5 DAI. This is done
       // to prevent the cart from getting stuck loading if a currency is empty
-      updatedGrant[grantIndex]['grant_donation_currency'] = grant.grant_donation_currency ? grant.grant_donation_currency : 'DAI';
+      updatedGrant[grantIndex]['grant_donation_currency'] = this.selectedETHCartToken;
       updatedGrant[grantIndex]['grant_donation_amount'] = grant.grant_donation_amount ? grant.grant_donation_amount : '5';
     });
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Ensure that the same token is used in calculations for the items in the checkout cart for ETH network

##### Refers/Fixes

GITC-665

##### Testing

GIVEN I have one ore more items in my cart with 0 matching and another token except DAI selected for checkout
WHEN I add another grant to the cart in the Grants Explorer
THEN I expect to see a single token in the summary (namely the one chosen in the cart)


