### PR TITLE
bug: ignore grant removed from round in clr calculation

### DIFF
--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -550,7 +550,7 @@ def predict_clr(save_to_db=False, from_date=None, clr_round=None, network='mainn
 
         debug_output.append({'grant': grant.id, "title": grant.title, "clr_prediction_curve": (potential_donations, potential_clr), "grants_clr": grants_clr})
 
-    invalid_clr_calculations.update(latest=False)
+    invalid_clr_calculations.update(latest=False, active=False)
     
     print(f"\nTotal execution time: {(timezone.now() - clr_calc_start_time)}\n")
 


### PR DESCRIPTION
##### Description

Currently if during a round if a grant is removed from a CLR round, the CLRCalculation is still taked into account as the latest field is marked True and hasn't been toggled back.

This PR ensures that when the clr cals are run the next time -> it toggle the `latest` flag to False for all grant's clr cals which are no longer part of the round.

##### Refers/Fixes

https://discord.com/channels/562828676480237578/907740735602851840/919793535702691890


