### PR TITLE
GITC-670: Allow snoozing notifications even if there are no actions by the user …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     language: system
     entry: sh -c 'npm run stylelint:fix'
     files: .css$
-- repo: git://github.com/pre-commit/mirrors-isort
+- repo: https://github.com/pre-commit/mirrors-isort.git
   sha: 'v4.3.4'
   hooks:
   - id: isort

--- a/app/marketing/management/commands/expiration_start_work.py
+++ b/app/marketing/management/commands/expiration_start_work.py
@@ -103,10 +103,20 @@ class Command(BaseCommand):
                         last_heard_from_user_days = None
 
                         if not actions:
-                            should_warn_user = True
-                            should_delete_interest = False
-                            last_heard_from_user_days = (timezone.now() - interest_day_0).days
+                            last_action_by_user = interest_day_0
                             print(" - no actions")
+
+                            # some small calcs
+                            snooze_time = timezone.timedelta(days=bounty.snooze_warnings_for_days)
+                            delta_now_vs_last_action = timezone.now() - snooze_time - last_action_by_user
+                            last_heard_from_user_days = delta_now_vs_last_action.days
+
+                            # decide action params
+                            should_warn_user = last_heard_from_user_days >= num_days_back_to_warn
+                            should_delete_interest = last_heard_from_user_days >= num_days_back_to_delete_interest
+                            should_ignore = last_heard_from_user_days >= num_days_back_to_ignore_bc_mods_got_it
+
+                            print(f"- its been {last_heard_from_user_days} days since user expressed insterest, and we could not find any actions")
                         else:
                             # example format: 2018-01-26T17:56:31Z'
                             action_times = [

--- a/app/marketing/tests/management/commands/test_expiration_start_work.py
+++ b/app/marketing/tests/management/commands/test_expiration_start_work.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """
+import csv
+import io
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -52,6 +54,61 @@ actions_warning = [
         'event': 'commented',
     }
 ]
+
+# The following CSV contains the expected behavior, when we are sneding notifications:
+# Columns:
+#   user_handle_prefix - just some prefix to which we add the row number (starting with 1) and create a test profile
+#   interest_days_back - number of days back, when the interest of the user in a bounty was registered
+#   accepted_days_back - number of days back, when the interest of the user was accepted
+#   snooze_days - the number of days to snooze notifications for the bounty
+#   last_action_days_back - number of days back since the last action was performed
+#   expect_expire_warning - do we expect warning ?
+#   expect_expired_notification - do we expect expired notification ?
+#   comment - just some comment for the line, this is not used in the TC
+#
+#   Boolean values: True for true / any other value means false
+#   Where numeric value is expected: if None, the setting will be ignored
+
+CSV_NOTIFICATION_EXPECTATIONS = """\
+user_handle_prefix,interest_days_back,accepted_days_back,snooze_days,last_action_days_back,expect_expire_warning,expect_expired_notification, comment
+fred_        , 2                  , 1                     , None        , None                        , False                       , False
+fred_        , 3                  , 2                     , None        , None                        , False                       , False
+fred_        , 4                  , 3                     , None        , None                        , True                        , False
+fred_        , 4                  , 3                     , 10          , None                        , False                       , False
+fred_        , 5                  , 4                     , None        , None                        , False                       , False
+fred_        , 6                  , 5                     , None        , None                        , True                        , False , I would not expect notification here - I would expect on day 6 since acceptance
+fred_        , 6                  , 5                     , 10          , None                        , False                       , False
+fred_        , 7                  , 6                     , None        , None                        , False                       , True
+fred_        , 7                  , 6                     , 10          , None                        , False                       , False
+fred_        , 8                  , 7                     , None        , None                        , False                       , False
+fred_        , 9                  , 8                     , None        , None                        , False                       , True
+fred_        , 9                  , 8                     , 10          , None                        , False                       , False
+fred_        , 10                 , 9                     , None        , None                        , False                       , False
+fred_        , 11                 , 10                    , None        , None                        , False                       , False
+fred_        , 12                 , 11                    , None        , None                        , False                       , False
+fred_        , 13                 , 12                    , None        , 1                           , False                       , False
+fred_        , 13                 , 12                    , None        , 2                           , False                       , False
+fred_        , 13                 , 12                    , None        , 3                           , True                        , False
+fred_        , 13                 , 12                    , 10          , 3                           , False                       , False
+fred_        , 13                 , 12                    , None        , 4                           , True                        , False
+fred_        , 13                 , 12                    , 10          , 4                           , False                       , False
+fred_        , 13                 , 12                    , None        , 5                           , True                        , False
+fred_        , 13                 , 12                    , 10          , 5                           , False                       , False
+fred_        , 13                 , 12                    , None        , 6                           , False                       , True
+fred_        , 13                 , 12                    , None        , 7                           , False                       , True
+fred_        , 13                 , 12                    , None        , 8                           , False                       , True
+fred_        , 13                 , 12                    , None        , 9                           , False                       , False
+fred_        , 12                 , 12                    , None        , None                        , False                       , False
+fred_        , 9                  , 9                     , None        , None                        , False                       , False
+fred_        , 6                  , 6                     , None        , None                        , False                       , True
+fred_        , 30                 , 30                    , 50          , None                        , False                       , False
+fred_        , 30                 , 30                    , None        , 3                           , True                        , False
+fred_        , 30                 , 30                    , None        , 6                           , False                       , True
+fred_        , 30                 , 30                    , 50          , 6                           , False                       , False
+fred_        , 30                 , 30                    , 50          , 51                          , False                       , False
+"""
+
+
 
 
 class TestExpirationStartWork(TestCase):
@@ -264,3 +321,89 @@ class TestExpirationStartWork(TestCase):
 
         assert mock_bounty_startwork_expire_warning.call_count == 1
         assert mock_bounty_startwork_expired.call_count == 0
+
+    def test_notifications(self):
+        print(CSV_NOTIFICATION_EXPECTATIONS)
+        dict_reader = csv.DictReader(io.StringIO(CSV_NOTIFICATION_EXPECTATIONS), delimiter=",")
+        idx = 0
+        for csv_dict in dict_reader:
+            idx += 1
+            d = {k: v.strip() if v else v for k, v in csv_dict.items()}
+            d["user_handle"] = d["user_handle_prefix"] + str(idx)
+            print(d)
+            user_handle = d["user_handle"]
+            interest_days_back = int(d["interest_days_back"]) if d["interest_days_back"] != "None" else None
+            accepted_days_back = int(d["accepted_days_back"]) if d["accepted_days_back"] != "None" else None
+            snooze_days = int(d["snooze_days"]) if d["snooze_days"] != "None" else None
+            last_action_days_back = int(d["last_action_days_back"]) if d["last_action_days_back"] != "None" else None
+            expected_warning_call_count = 1 if d["expect_expire_warning"] == "True" else 0
+            expected_expired_call_count = 1 if d["expect_expired_notification"] == "True" else 0
+            profile = Profile.objects.create(
+                data={},
+                handle=user_handle,
+                email=f'{user_handle}@bar.com'
+            )
+
+            interest = Interest.objects.create(
+                profile=profile
+            )
+            interest.created = timezone.now() - timedelta(days=interest_days_back)
+            if accepted_days_back:
+                interest.acceptance_date = timezone.now() - timedelta(days=accepted_days_back)
+            interest.save()
+
+            bounty = Bounty.objects.create(
+                title='foo',
+                value_in_token=3,
+                token_name='USDT',
+                web3_created=datetime(2008, 10, 31),
+                github_url='https://github.com/gitcoinco/web/issues/1/',
+                token_address='0x0',
+                issue_description='hello world',
+                bounty_owner_github_username='flintstone',
+                is_open=True,
+                accepted=True,
+                expires_date=timezone.now() + timedelta(days=1, hours=1),
+                idx_project_length=5,
+                project_length='Months',
+                bounty_type='Feature',
+                experience_level='Intermediate',
+                raw_data={},
+                idx_status='open',
+                bounty_owner_email='john@bar.com',
+                current_bounty=True,
+                network='mainnet',
+                permission_type='approval',
+            )
+
+            if snooze_days:
+                bounty.snooze_warnings_for_days = snooze_days
+
+            bounty.interested.add(interest)
+            bounty.save()
+
+            actions_expired = []
+
+            if last_action_days_back:
+                actions_expired = [{
+                    'user': {
+                        'login': user_handle
+                    },
+                    'created_at': (timezone.now() - timedelta(days=last_action_days_back)).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'event': 'commented',
+                }]
+
+            with patch.object(marketing.management.commands.expiration_start_work, 'get_interested_actions', return_value=actions_expired) as mock_get_interested_actions:
+                with patch.object(marketing.management.commands.expiration_start_work, 'bounty_startwork_expire_warning', return_value=actions_expired) as mock_bounty_startwork_expire_warning:
+                    with patch.object(marketing.management.commands.expiration_start_work, 'bounty_startwork_expired', return_value=actions_expired) as mock_bounty_startwork_expired:
+                        
+                        Command().handle()
+
+                        print("GERI mock_get_interested_actions.call_count", mock_get_interested_actions.call_count)
+                        print("GERI mock_bounty_startwork_expire_warning.call_count", mock_bounty_startwork_expire_warning.call_count)
+                        print("GERI mock_bounty_startwork_expired.call_count", mock_bounty_startwork_expired.call_count)
+
+                        assert mock_bounty_startwork_expired.call_count == expected_expired_call_count
+                        assert mock_bounty_startwork_expire_warning.call_count == expected_warning_call_count
+
+            interest.delete()


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

For a user that is interested but for whom we could not detect any actions, we do apply the snoozing, and we count the snoozing days since the day he was accepted.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
GITC-670

##### Testing

This has been tested locally

GIVEN i have funded an issue
WHEN i snooze notifications FOR X DAYS
THEN no comments should be left for the same X days that it was snoozed for
AND all notification should be snoozed

Snooze bot looking at Start Date:
GIVEN i have funded an issue
WHEN i snooze notifications AND the user has not performed any action
THEN the snooze day count should look at the contributors Start Date to determine when notifications should resume


