### PR TITLE
GITC-696: ensure only mainnet tokens loads in bounty

### DIFF
--- a/app/assets/v2/js/pages/new_bounty.js
+++ b/app/assets/v2/js/pages/new_bounty.js
@@ -528,7 +528,21 @@ Vue.mixin({
 
         }
       });
+    },
+    /**
+     * Filters tokens by vm.networkId
+     * @param {*} tokens
+     * @returns {*} tokens
+     */
+    filterByNetworkId: function(tokens) {
+      let vm = this;
 
+      if (vm.networkId) {
+        tokens = tokens.filter((token) => {
+          return String(token.networkId) === vm.networkId;
+        });
+      }
+      return tokens;
     },
     submitForm: async function(event) {
       event.preventDefault();
@@ -730,6 +744,12 @@ Vue.mixin({
         result = vm.filterByNetwork.filter((item) => {
           return String(item.chainId) === vm.chainId;
         });
+
+        if (vm.chainId == '1') {
+          // allow only mainnet tokens in ETH chain
+          vm.networkId = '1';
+          result = vm.filterByNetworkId(result);
+        }
       }
       return result;
     }


### PR DESCRIPTION
##### Description

Introduces helper function that allows bounty and hackthon to show only mainnet tokens on eth and not polygon

##### Refers/Fixes
GITC-696

##### Testing


![Untitled](https://user-images.githubusercontent.com/5358146/146935264-0368dcb6-5881-457e-8c0f-fefd37399cea.gif)
