### PR TITLE
fix: ensure only successfull contributions are sent

### DIFF
--- a/app/git/tests/models/test_git_cache.py
+++ b/app/git/tests/models/test_git_cache.py
@@ -1,7 +1,7 @@
 import pytest
+from faker import Faker
 from git.models import GitCache
 from git.tests.factories.git_cache_factory import GitCacheFactory
-from faker import Faker
 
 
 @pytest.mark.django_db

--- a/app/git/tests/test_utils.py
+++ b/app/git/tests/test_utils.py
@@ -19,25 +19,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
-from github import NamedUser, Repository, IssueComment, Issue
 
 from django.conf import settings
 from django.test.utils import override_settings
 from django.utils import timezone
-from git.models import GitCache
-from faker import Faker
 
 import responses
 from faker import Faker
 from git.models import GitCache
 from git.tests.factories.git_cache_factory import GitCacheFactory
 from git.utils import (
-    HEADERS, TOKEN_URL, _get_user, build_auth_dict, delete_issue_comment, get_github_emails, get_github_primary_email,
-    get_issue_comments, get_issue_timeline_events, github_connect, is_github_token_valid, org_name, patch_issue_comment,
-    post_issue_comment, post_issue_comment_reaction, repo_url, reset_token, revoke_token, _get_user, _get_repo, _get_issue,
-    _get_issue_comment
+    HEADERS, TOKEN_URL, _get_issue, _get_issue_comment, _get_repo, _get_user, build_auth_dict, delete_issue_comment,
+    get_github_emails, get_github_primary_email, get_issue_comments, get_issue_timeline_events, github_connect,
+    is_github_token_valid, org_name, patch_issue_comment, post_issue_comment, post_issue_comment_reaction, repo_url,
+    reset_token, revoke_token,
 )
-from github import NamedUser
+from github import Issue, IssueComment, NamedUser, Repository
 from test_plus.test import TestCase
 
 

--- a/app/retail/emails.py
+++ b/app/retail/emails.py
@@ -121,6 +121,8 @@ def render_new_contributions_email(grant):
     hours_ago = 12
     network = get_default_network()
     contributions = grant.contributions.filter(
+        success=True,
+        tx_cleared=True,
         created_on__gt=timezone.now() - timezone.timedelta(hours=hours_ago),
         subscription__network=network
     )


### PR DESCRIPTION
##### Description


The grant contribution summary email takes into account all contributions sent in 12 hours and sends it to the grant owner.
Currently we take into account all grants contributions (ignoring the txn status) 

It makes sense to use only successful contributions and not include contributions where the : 
- txn ID cannot be found on the chain (user does something funny / uses wrong network)
- txn ID is in a pending state 
