### PR TITLE
jeremy/GITC-501/649

### DIFF
--- a/app/grants/templates/grants/components/card.html
+++ b/app/grants/templates/grants/components/card.html
@@ -28,7 +28,7 @@
         </div>
         <div class="col-md-7 p-3">
           <h2 class="font-subheader">
-            <a :href="grant.details_url" class="gc-font-base h5 text-black">[[ grant.title | truncate(60) ]]</a>
+            <a :href="grant.details_url" class="gc-font-base h5 text-black" target="_blank" rel="noopener noreferrer">[[ grant.title | truncate(60) ]]</a>
           </h2>
           <div>
             <div class="">
@@ -166,7 +166,7 @@
       </div>
       <div class="grant-item__content px-3">
         <h2 class="font-subheader">
-          <a :href="grant.details_url" class="gc-font-base h5 text-black">[[ grant.title | truncate(60) ]]</a>
+          <a :href="grant.details_url" class="gc-font-base h5 text-black" target="_blank" rel="noopener noreferrer">[[ grant.title | truncate(60) ]]</a>
         </h2>
         <span class="">by</span>
         <a :href="grant.admin_profile.url" :data-usercard="grant.admin_profile.handle" target="_blank" rel="noopener noreferrer">

--- a/cypress/integration/grants/test_grant_explorer.js
+++ b/cypress/integration/grants/test_grant_explorer.js
@@ -180,5 +180,26 @@ describe('Grants Explorer page', () => {
       cy.url().should('contain', 'sort_option=-sybil_score');
     });
   });
+
+  describe('selecting a grant', () => {
+    it('opens the grant in a new browser tab', () => {
+      cy.createGrantSubmission().then((response) => {
+        const grantUrl = response.body.url;
+  
+        cy.approveGrant(grantUrl);
+        cy.impersonateUser();
+        
+        cy.visit('grants/explorer');
+
+        cy.contains('Test Grant Submission')
+          .should('have.attr', 'target', '_blank')
+          .should('have.attr', 'rel', 'noopener noreferrer')
+          .then(link => {
+            cy.request(link.prop('href')).its('status').should('eq', 200);
+          });
+          
+      });
+    });
+  });
 });
   


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR resolves two separate bugs.

The first one is when a user clicks into a grant from the grants explorer, and then navigates back to the explorer, their place on the infinite scroll is lost.

The second one is when a user clicks into a grant from a collection, and then navigates back to the collection, the entire collection is not shown.

These bugs are resolved by opening the grant in new tab leaving the explorer/collection screen as is in the original tab.


https://user-images.githubusercontent.com/36638840/148140505-69faa093-8831-445b-a240-f0577b2f31d4.mov



##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
This PR contains Cypress testing
