### PR TITLE
ensure default 0 response is returned if data is not provided from go…

### DIFF
--- a/app/marketing/google_analytics.py
+++ b/app/marketing/google_analytics.py
@@ -61,8 +61,13 @@ def get_response(response):
         column_header = report.get('columnHeader', {})
         dimension_headers = column_header.get('dimensions', [])
         metric_headers = column_header.get('metricHeader', {}).get('metricHeaderEntries', [])
-
-        for row in report.get('data', {}).get('rows', []):
+        
+        rows = report.get('data', {}).get('rows', [])
+        
+        if not rows:
+            return '0'
+        
+        for row in rows:
             dimensions = row.get('dimensions', [])
             date_range_values = row.get('metrics', [])
 

--- a/app/marketing/tests/test_google_analytics.py
+++ b/app/marketing/tests/test_google_analytics.py
@@ -1,0 +1,75 @@
+import pytest
+import json
+
+from marketing.google_analytics import get_response
+
+def test_google_analytics_returns_zero_value_if_expected_metric_not_returned():
+    ga_incomplete_response = '''{
+        "reports": [
+            {
+            "columnHeader": {
+                "metricHeader": {
+                "metricHeaderEntries": [
+                    {
+                    "name": "ga:sessions",
+                    "type": "INTEGER"
+                    }
+                ]
+                }
+            },
+            "data": {
+                "totals": [
+                {
+                    "values": [
+                    "0"
+                    ]
+                }
+                ]
+            }
+            }
+        ]
+    }'''
+
+    analytics = json.loads(ga_incomplete_response)
+    
+    parsed_response = get_response(analytics)
+    
+    assert parsed_response != None
+    assert parsed_response == '0'
+    
+def test_google_analytics_returns_values_with_expected_response():
+    ga_expected_response = '''{
+        "reports": [{
+            "columnHeader": {
+                "dimensions": [
+                    "ga:country"
+                ],
+                "metricHeader": {
+                    "metricHeaderEntries": [{
+                        "name": "ga:sessions",
+                        "type": "INTEGER"
+                    }]
+                }
+            },
+            "data": {
+                "totals": [{
+                    "values": [
+                        "0"
+                    ]
+                }],
+                "rows": [{
+                    "metrics": [{
+                        "values": [
+                            "2"
+                        ]
+                    }]
+                }]
+            }
+        }]
+    }
+    '''
+    analytics = json.loads(ga_expected_response)
+    
+    parsed_response = get_response(analytics)
+    
+    assert parsed_response == '2'

--- a/app/marketing/tests/test_google_analytics.py
+++ b/app/marketing/tests/test_google_analytics.py
@@ -1,7 +1,8 @@
-import pytest
 import json
 
+import pytest
 from marketing.google_analytics import get_response
+
 
 def test_google_analytics_returns_zero_value_if_expected_metric_not_returned():
     ga_incomplete_response = '''{


### PR DESCRIPTION
##### Description

There is a recurring [error](https://sentry.io/organizations/gitcoin/issues/?project=1398424&query=is%3Aunresolved+null+value+in+column+%22val%22+violates+not-null+constraint&statsPeriod=14d) that is being logged in sentry relating to requests made for google analytics data. If data is not present a null value is being returned and attempted to be saved to a column that is not nullable. 

##### Testing

This was tested locally and unit tests were written for the changed function
