### PR TITLE
hide claims which have 0 amount for grant owner

### DIFF
--- a/app/assets/v2/js/grants/matching_funds.js
+++ b/app/assets/v2/js/grants/matching_funds.js
@@ -38,7 +38,7 @@ Vue.mixin({
           {
               "id": 149,
               "title": "Rotki - The portfolio tracker and accounting tool that protects your privacy",
-              "admin_address": "0x9531C059098e3d194fF87FebB587aB07B30B1306",
+              "admin_address": "0x3257284FF47cbcB0c59BD522B40A34D5f748117D",
               "clr_matches": [
                   {
                       "pk": 6520,

--- a/app/assets/v2/js/grants/matching_funds.js
+++ b/app/assets/v2/js/grants/matching_funds.js
@@ -26,272 +26,16 @@ Vue.mixin({
     async fetchGrants() {
       let vm = this;
 
-      this.loading = true;
+      vm.loading = true;
 
       // fetch owned grants with clr matches
       const url = '/grants/v1/api/clr-matches/';
 
       try {
         let result = await (await fetch(url)).json();
-        // TODO: REMOVE
-        result = [
-          {
-              "id": 149,
-              "title": "Rotki - The portfolio tracker and accounting tool that protects your privacy",
-              "admin_address": "0x3257284FF47cbcB0c59BD522B40A34D5f748117D",
-              "clr_matches": [
-                  {
-                      "pk": 6520,
-                      "amount": 99988.1229070029,
-                      "round_number": 12,
-                      "claim_tx": null,
-                      "grant_payout": {
-                          "status": "ready",
-                          "contract_address": "0xAB8d71d59827dcc90fEDc5DDb97f87eFfB1B1A5B",
-                          "payout_token": "DAI",
-                          "funding_withdrawal_date": null,
-                          "grant_clrs": [
-                              {
-                                  "display_text": "Advocacy",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "Polygon",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "Climate Change",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "Longevity",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "zkTech",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "Forefront",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR12 - Main",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              }
-                          ],
-                          "network": "mainnet"
-                      },
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 5611,
-                      "amount": 10368.02716,
-                      "round_number": 11,
-                      "claim_tx": null,
-                      "grant_payout": {
-                          "status": "ready",
-                          "contract_address": "0x0EbD2E2130b73107d0C45fF2E16c93E7e2e10e3a",
-                          "payout_token": "DAI",
-                          "funding_withdrawal_date": null,
-                          "grant_clrs": [
-                              {
-                                  "display_text": "GR11 - Latin America",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - Africa",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - dGov",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - NFT",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - Community",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - dApp",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - Infra",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 -Retroactive Funding",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR11 - Gitcoin DAO",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              }
-                          ],
-                          "network": "mainnet"
-                      },
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 4077,
-                      "amount": 26331.6051518633,
-                      "round_number": 10,
-                      "claim_tx": null,
-                      "grant_payout": {
-                          "status": "ready",
-                          "contract_address": "0x3ebAFfe01513164e638480404c651E885cCA0AA4",
-                          "payout_token": "DAI",
-                          "funding_withdrawal_date": null,
-                          "grant_clrs": [
-                              {
-                                  "display_text": "GR10 - Latin America",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR10 - Community",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR10 - Building Gitcoin",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR10 - NFT",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR10 - Infra",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              },
-                              {
-                                  "display_text": "GR10 - dApp",
-                                  "is_active": false,
-                                  "claim_start_date": null,
-                                  "claim_end_date": null
-                              }
-                          ],
-                          "network": "mainnet"
-                      },
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 2653,
-                      "amount": 5375.79707337043,
-                      "round_number": 9,
-                      "claim_tx": null,
-                      "grant_payout": {
-                          "status": "ready",
-                          "contract_address": "0x3342e3737732d879743f2682a3953a730ae4f47c",
-                          "payout_token": "DAI",
-                          "funding_withdrawal_date": null,
-                          "grant_clrs": [],
-                          "network": "mainnet"
-                      },
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 1942,
-                      "amount": 7792.5155898565,
-                      "round_number": 8,
-                      "claim_tx": null,
-                      "grant_payout": {
-                          "status": "funding_withdrawn",
-                          "contract_address": "0xf2354570bE2fB420832Fb7Ff6ff0AE0dF80CF2c6",
-                          "payout_token": "DAI",
-                          "funding_withdrawal_date": null,
-                          "grant_clrs": [],
-                          "network": "mainnet"
-                      },
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 1382,
-                      "amount": 3027.0,
-                      "round_number": 4,
-                      "claim_tx": null,
-                      "grant_payout": null,
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 1231,
-                      "amount": 21721.2278151826,
-                      "round_number": 7,
-                      "claim_tx": null,
-                      "grant_payout": null,
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 905,
-                      "amount": 2507.67587322087,
-                      "round_number": 6,
-                      "claim_tx": null,
-                      "grant_payout": null,
-                      "ready_for_payout": true
-                  },
-                  {
-                      "pk": 325,
-                      "amount": 3165.09486017034,
-                      "round_number": 5,
-                      "claim_tx": null,
-                      "grant_payout": null,
-                      "ready_for_payout": true
-                  }
-              ],
-              "logo_url": [
-                  "https://c.gitcoin.co/grants/55489dd9b0bb55d2454115c8ad6f6b6f/rotkehlchen_logo.png"
-              ],
-              "details_url": "/grants/149/rotki-the-portfolio-tracker-and-accounting-tool-t"
-          }
-        ]
 
         // update claim status + format date fields
-        result.map(async grant => {
+        result.map(grant => {
           grant.clr_matches.map(async m => {
             if (m.grant_payout) {
               m.grant_payout.funding_withdrawal_date = m.grant_payout.funding_withdrawal_date
@@ -305,14 +49,20 @@ Vue.mixin({
               const claimData = await vm.checkClaimStatus(m, grant.admin_address);
 
               m.status = claimData.status;
+
+              // check to ensure we don't allow users to claim if balance is 0
+              if (!m.claim_tx && m.status == 'no-balance-to-claim') {
+                m.claim_tx = 'NA';
+              }
+
               m.claim_date = claimData.timestamp ? moment.unix(claimData.timestamp).format('MMM D, Y') : null;
             }
           });
         });
 
-        this.grants = result;
+        vm.grants = result;
 
-        this.loading = false;
+        vm.loading = false;
 
       } catch (e) {
         console.error(e);
@@ -335,9 +85,10 @@ Vue.mixin({
         contractAddress
       );
       const amount = await payout_contract.methods.payouts(recipientAddress).call();
+
       if (amount == 0) {
-        status = 'no-claim';
-        return  { status, timestamp };
+        status = 'no-balance-to-claim';
+        return { status, timestamp };
       }
 
       if (!txHash) {

--- a/app/assets/v2/js/grants/matching_funds.js
+++ b/app/assets/v2/js/grants/matching_funds.js
@@ -33,6 +33,262 @@ Vue.mixin({
 
       try {
         let result = await (await fetch(url)).json();
+        // TODO: REMOVE
+        result = [
+          {
+              "id": 149,
+              "title": "Rotki - The portfolio tracker and accounting tool that protects your privacy",
+              "admin_address": "0x9531C059098e3d194fF87FebB587aB07B30B1306",
+              "clr_matches": [
+                  {
+                      "pk": 6520,
+                      "amount": 99988.1229070029,
+                      "round_number": 12,
+                      "claim_tx": null,
+                      "grant_payout": {
+                          "status": "ready",
+                          "contract_address": "0xAB8d71d59827dcc90fEDc5DDb97f87eFfB1B1A5B",
+                          "payout_token": "DAI",
+                          "funding_withdrawal_date": null,
+                          "grant_clrs": [
+                              {
+                                  "display_text": "Advocacy",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "Polygon",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "Climate Change",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "Longevity",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "zkTech",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "Forefront",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR12 - Main",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              }
+                          ],
+                          "network": "mainnet"
+                      },
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 5611,
+                      "amount": 10368.02716,
+                      "round_number": 11,
+                      "claim_tx": null,
+                      "grant_payout": {
+                          "status": "ready",
+                          "contract_address": "0x0EbD2E2130b73107d0C45fF2E16c93E7e2e10e3a",
+                          "payout_token": "DAI",
+                          "funding_withdrawal_date": null,
+                          "grant_clrs": [
+                              {
+                                  "display_text": "GR11 - Latin America",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - Africa",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - dGov",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - NFT",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - Community",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - dApp",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - Infra",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 -Retroactive Funding",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR11 - Gitcoin DAO",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              }
+                          ],
+                          "network": "mainnet"
+                      },
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 4077,
+                      "amount": 26331.6051518633,
+                      "round_number": 10,
+                      "claim_tx": null,
+                      "grant_payout": {
+                          "status": "ready",
+                          "contract_address": "0x3ebAFfe01513164e638480404c651E885cCA0AA4",
+                          "payout_token": "DAI",
+                          "funding_withdrawal_date": null,
+                          "grant_clrs": [
+                              {
+                                  "display_text": "GR10 - Latin America",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR10 - Community",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR10 - Building Gitcoin",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR10 - NFT",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR10 - Infra",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              },
+                              {
+                                  "display_text": "GR10 - dApp",
+                                  "is_active": false,
+                                  "claim_start_date": null,
+                                  "claim_end_date": null
+                              }
+                          ],
+                          "network": "mainnet"
+                      },
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 2653,
+                      "amount": 5375.79707337043,
+                      "round_number": 9,
+                      "claim_tx": null,
+                      "grant_payout": {
+                          "status": "ready",
+                          "contract_address": "0x3342e3737732d879743f2682a3953a730ae4f47c",
+                          "payout_token": "DAI",
+                          "funding_withdrawal_date": null,
+                          "grant_clrs": [],
+                          "network": "mainnet"
+                      },
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 1942,
+                      "amount": 7792.5155898565,
+                      "round_number": 8,
+                      "claim_tx": null,
+                      "grant_payout": {
+                          "status": "funding_withdrawn",
+                          "contract_address": "0xf2354570bE2fB420832Fb7Ff6ff0AE0dF80CF2c6",
+                          "payout_token": "DAI",
+                          "funding_withdrawal_date": null,
+                          "grant_clrs": [],
+                          "network": "mainnet"
+                      },
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 1382,
+                      "amount": 3027.0,
+                      "round_number": 4,
+                      "claim_tx": null,
+                      "grant_payout": null,
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 1231,
+                      "amount": 21721.2278151826,
+                      "round_number": 7,
+                      "claim_tx": null,
+                      "grant_payout": null,
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 905,
+                      "amount": 2507.67587322087,
+                      "round_number": 6,
+                      "claim_tx": null,
+                      "grant_payout": null,
+                      "ready_for_payout": true
+                  },
+                  {
+                      "pk": 325,
+                      "amount": 3165.09486017034,
+                      "round_number": 5,
+                      "claim_tx": null,
+                      "grant_payout": null,
+                      "ready_for_payout": true
+                  }
+              ],
+              "logo_url": [
+                  "https://c.gitcoin.co/grants/55489dd9b0bb55d2454115c8ad6f6b6f/rotkehlchen_logo.png"
+              ],
+              "details_url": "/grants/149/rotki-the-portfolio-tracker-and-accounting-tool-t"
+          }
+        ]
 
         // update claim status + format date fields
         result.map(async grant => {
@@ -71,11 +327,23 @@ Vue.mixin({
       let status = 'not-found';
       let timestamp = null;
 
+      web3 = new Web3(`wss://mainnet.infura.io/ws/v3/${document.contxt.INFURA_V3_PROJECT_ID}`);
+
+      // check if contract has funds for recipientAddress
+      const payout_contract = await new web3.eth.Contract(
+        JSON.parse(document.contxt.match_payouts_abi),
+        contractAddress
+      );
+      const amount = await payout_contract.methods.payouts(recipientAddress).call();
+      if (amount == 0) {
+        status = 'no-claim';
+        return  { status, timestamp };
+      }
+
       if (!txHash) {
         return { status, timestamp };
       }
 
-      web3 = new Web3(`wss://mainnet.infura.io/ws/v3/${document.contxt.INFURA_V3_PROJECT_ID}`);
 
       let tx = await web3.eth.getTransaction(txHash);
 

--- a/app/grants/templates/grants/matching_funds.html
+++ b/app/grants/templates/grants/matching_funds.html
@@ -139,7 +139,7 @@
                 </b-row>
                 <div v-if="grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx).length">
                   <template v-for="match in grant.clr_matches">
-                    <b-row v-if="match.grant_payout &&  match.status != 'no-claim' && !match.claim_tx " :key="match.pk" class="mt-4 align-items-center">
+                    <b-row v-if="match.grant_payout && !match.claim_tx " :key="match.pk" class="mt-4 align-items-center">
                       <b-col lg="4" sm="12">
                         <span class="font-bigger-1 text-grey-500" id="grant-clrs">[[ stringifyClrs(match.grant_payout.grant_clrs) ]] (GR[[ match.round_number ]])</span>
                       </b-col>
@@ -443,12 +443,22 @@
                         <span class="font-body text-grey-500">[[ match.funding_withdrawal_date ]]</span>
                       </b-col>
                       <b-col class="text-lg-right mt-2 mt-lg-0">
-                        <a v-if="match.claim_tx" :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]" target="_blank" rel="noopener noreferrer" class="d-lg-block d-none font-body">
-                          View Transaction<i class="far fa-external-link ml-2"></i>
-                        </a>
-                        <a v-if="match.claim_tx" :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]" target="_blank" rel="noopener noreferrer" class="d-lg-none d-block font-subheader">
-                          View Transaction<i class="far fa-external-link ml-2"></i>
-                        </a>
+                        <template v-if="match.claim_tx == 'NA'">
+                          <a :href="[[`https://etherscan.io/address/${match.grant_payout.contract_address}/#events`]]" target="_blank" rel="noopener noreferrer" class="d-lg-block d-none font-body">
+                            View Contract Event<i class="far fa-external-link ml-2"></i>
+                          </a>
+                          <a :href="[[`https://etherscan.io/address/${match.grant_payout.contract_address}/#events`]]" target="_blank" rel="noopener noreferrer" class="d-lg-none d-block font-subheader">
+                            View Contract Event<i class="far fa-external-link ml-2"></i>
+                          </a>
+                        </template>
+                        <template v-else>
+                          <a :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]" target="_blank" rel="noopener noreferrer" class="d-lg-block d-none font-body">
+                            View Transaction<i class="far fa-external-link ml-2"></i>
+                          </a>
+                          <a :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]" target="_blank" rel="noopener noreferrer" class="d-lg-none d-block font-subheader">
+                            View Transaction<i class="far fa-external-link ml-2"></i>
+                          </a>
+                        </template>
                       </b-col>
                     </b-row>
                   </template>

--- a/app/grants/templates/grants/matching_funds.html
+++ b/app/grants/templates/grants/matching_funds.html
@@ -139,7 +139,7 @@
                 </b-row>
                 <div v-if="grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx).length">
                   <template v-for="match in grant.clr_matches">
-                    <b-row v-if="match.grant_payout && !match.claim_tx" :key="match.pk" class="mt-4 align-items-center">
+                    <b-row v-if="match.grant_payout &&  match.status != 'no-claim' && !match.claim_tx " :key="match.pk" class="mt-4 align-items-center">
                       <b-col lg="4" sm="12">
                         <span class="font-bigger-1 text-grey-500" id="grant-clrs">[[ stringifyClrs(match.grant_payout.grant_clrs) ]] (GR[[ match.round_number ]])</span>
                       </b-col>


### PR DESCRIPTION
##### Description

https://discord.com/channels/562828676480237578/932141631778467881/932161852841033748

**Note:** 
- ~hardcoded data has to be removed~
- this currently doesn't work as expected cause the UI is updated after a delay. (THIS NEEDS A FOLLOW UP STORY)

The situation is applicable for users who have claimed funds on etherscan and we don't have a record of it on our UI.
The fix here is to until we have a solution in place , we check the contract to check if balance is 0 and if so , we show the txn in the history and not ready to claim

As we don't have the claim tx in our DB. -> we just redirect them to the events log on etherscan





![Untitled](https://user-images.githubusercontent.com/5358146/149903666-29ab1442-71fd-4ddf-b56b-1d9871ca6f1f.gif)
