### PR TITLE
updated logic to show matching funds if clr_matches.transaction_id is…

### DIFF
--- a/app/grants/templates/grants/matching_funds.html
+++ b/app/grants/templates/grants/matching_funds.html
@@ -137,7 +137,7 @@
                     </div>
                   </div>
                 </b-row>
-                <div v-if="grant.clr_matches.length && grant.clr_matches.filter(a => a.claim_tx).length === 0">
+                <div v-if="grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx).length">
                   <b-row v-for="match in grant.clr_matches" :key="match.pk" class="mt-4 align-items-center">
                     <b-col lg="4" sm="12">
                       <span class="font-bigger-1 text-grey-500" id="grant-clrs">[[ stringifyClrs(match.grant_payout.grant_clrs) ]] (GR[[ match.round_number ]])</span>


### PR DESCRIPTION
##### Description

updated logic to show matching funds and claim button if clr_matches.transaction_id is null for referenced clr

Should fix 
https://discord.com/channels/562828676480237578/932570484195860520

I tested my changes against mocked responses for DefiLab_xyz and zkApe

These are screenshots for the mocked clr matches:
<img width="1220" alt="Screen Shot 2022-01-17 at 3 15 21 PM" src="https://user-images.githubusercontent.com/6887938/149843244-87eef072-b40d-4efd-af0e-71a3ff721a6a.png">
<img width="1236" alt="Screen Shot 2022-01-17 at 2 21 01 PM" src="https://user-images.githubusercontent.com/6887938/149843251-7c627d99-dd08-4e4b-94e6-ecf7e6873999.png">


