### PR TITLE
initiate sentry logging within celery taskapp

### DIFF
--- a/app/taskapp/celery.py
+++ b/app/taskapp/celery.py
@@ -1,4 +1,5 @@
 import os
+import environ
 
 from django.apps import AppConfig, apps
 from django.conf import settings
@@ -6,10 +7,23 @@ from django.conf import settings
 from celery import Celery
 from celery.signals import setup_logging
 
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+
+env = environ.Env(DEBUG=(bool, False), )  # set default values and casting
+# Sentry
+SENTRY_DSN = env.str('SENTRY_DSN', default='')
+SENTRY_JS_DSN = env.str('SENTRY_JS_DSN', default=SENTRY_DSN)
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
 
 app = Celery('app')
 
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_JS_DSN,
+        integrations=[CeleryIntegration()]
+    )
 
 class CeleryConfig(AppConfig):
     name = 'taskapp'


### PR DESCRIPTION
##### Description

if we can get sentry working on celery tasks, then when theres a long running query we could just go in and pg_terminate_backend(pid) the long queries and watch in the senry logs which job fails.

https://docs.sentry.io/platforms/python/guides/celery/configuration/integrations/django/

When testing locally with debug=True I received output saying sentry was successfully installed.


<img width="837" alt="Screen Shot 2022-01-20 at 2 49 09 PM" src="https://user-images.githubusercontent.com/6887938/150429934-21041be1-ffbd-4339-a332-713ab6b1fdb8.png">

