### PR TITLE
GITC-610: fixes auth on portfolioItem deletion

### DIFF
--- a/app/dashboard/tests/views/test_profile_projects.py
+++ b/app/dashboard/tests/views/test_profile_projects.py
@@ -46,6 +46,47 @@ class TestProfileTabProjectCreation:
         assert response.status_code == 200
         assert "Portfolio Item added." in messages
 
+    def test_project_deleted(self, django_user_model):
+        user = django_user_model.objects.create(username="gitcoin", password="password123")
+        profile = ProfileFactory(user=user, handle="gitcoin", hide_profile=False)
+        project_data = dict(project_title="My New Project", URL="http://gitcoin.co", tags="")
+        project = PortfolioItem.objects.create(
+            profile=profile,
+            title=project_data['project_title'],
+            link=project_data['URL'],
+            tags=[]
+        )
+
+        client = Client(HTTP_USER_AGENT='chrome')
+        client.force_login(user)
+        response = client.post('/gitcoin/portfolio', { 'project_pk': project.pk })
+        messages = [m.message for m in response.context['messages']]
+
+        assert response.status_code == 200
+        assert "Portfolio Item has been deleted." in messages
+
+    def test_project_deletion_fails_when_unauthed(self, django_user_model):
+        user = django_user_model.objects.create(username="gitcoin", password="password123")
+        profile = ProfileFactory(user=user, handle="gitcoin", hide_profile=False)
+        project_data = dict(project_title="My New Project", URL="http://gitcoin.co", tags="")
+        project = PortfolioItem.objects.create(
+            profile=profile,
+            title=project_data['project_title'],
+            link=project_data['URL'],
+            tags=[]
+        )
+
+        user_unauthed = django_user_model.objects.create(username="gitcoin2", password="password123")
+        profile_unauthed = ProfileFactory(user=user_unauthed, handle="gitcoin2", hide_profile=False)
+        client = Client(HTTP_USER_AGENT='chrome')
+        client.force_login(user_unauthed)
+        response = client.post('/gitcoin/portfolio', { 'project_pk': project.pk })
+        messages = [m.message for m in response.context['messages']]
+
+        assert response.status_code == 200
+        assert "Not Authorized" in messages
+        assert "Portfolio Item has been deleted." not in messages
+
     @pytest.mark.django_db(transaction=True)
     def test_project_creation_fails_when_project_already_exists(self, django_user_model):
         user = django_user_model.objects.create(username="gitcoin", password="password123")

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2708,7 +2708,7 @@ def get_profile_tab(request, profile, tab, prev_context):
                     activities_index__key=f'profile:{profile.pk}',
                     hidden=False
                 ).order_by('-created_on')
- 
+
                 paginator = Paginator(
                     profile_filter_activities(all_activities, activity_type, activity_tabs), 10
                 )
@@ -2817,14 +2817,14 @@ def get_profile_tab(request, profile, tab, prev_context):
                 except IntegrityError:
                     messages.error(request, 'Portfolio Already Exists.')
         if pk:
-            # delete portfolio item
-            if not request.user.is_authenticated or request.user.profile.pk != profile.pk:
-                messages.error(request, 'Not Authorized')
-                return
             pi = PortfolioItem.objects.filter(pk=pk).first()
             if pi:
-                pi.delete()
-                messages.info(request, 'Portfolio Item has been deleted.')
+                # delete portfolio item
+                if request.user.is_authenticated and request.user.profile.pk == pi.profile.pk or request.user.is_staff:
+                    pi.delete()
+                    messages.info(request, 'Portfolio Item has been deleted.')
+                else:
+                    messages.error(request, 'Not Authorized')
     elif tab == 'earnings':
         context['earnings'] = Earning.objects.filter(to_profile=profile, network='mainnet', value_usd__isnull=False).order_by('-created_on')
     elif tab == 'spent':


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR will ensure that PortfolioItems can only be deleted by their owner/staff

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: #9747 / GITC-610

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Cases have been added to test both paths (success/failure on unauth'd)
