### PR TITLE
accessing cached count for collections card

### DIFF
--- a/app/grants/templates/grants/components/collection.html
+++ b/app/grants/templates/grants/components/collection.html
@@ -49,7 +49,7 @@
               </template>
               <div class="d-inline-flex overflow-hidden" style="height:84px; width:50px;" v-if="collection.grants.length > 4">
                 <div :class="`d-flex m-auto p-1`">
-                  <p class="text-muted font-smaller-3 mb-0">+[[ (collection.count - 4) ]]</p>
+                  <p class="text-muted font-smaller-3 mb-0">+[[ (collection.cache.count - 4) ]]</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
##### Description

This should remove the nan value and show the remainder count

before
![jUMJBgCUWg thumb](https://user-images.githubusercontent.com/6887938/150607167-da6a5c19-cf25-45ff-805d-de34e9aab033.png)

after
<img width="1076" alt="Screen Shot 2022-01-21 at 3 22 01 PM" src="https://user-images.githubusercontent.com/6887938/150607970-3f38709f-d022-4c03-a272-ee09d7c9e01b.png">

