### PR TITLE
fix: `get_notifications()` fixes

### DIFF
--- a/app/gitcoinbot/management/commands/get_notifications.py
+++ b/app/gitcoinbot/management/commands/get_notifications.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             for notification in notifications:
                 if hasattr(notification, '_subject') and notification.reason == 'mention':
                     try:
-                        url = notification.subject.url
+                        url = notification.subject.url if notification.subject.url else ''
                         url = url.replace('/repos', '')
                         url = url.replace('//api.github', '//github')
                         latest_comment_url = notification.subject.latest_comment_url

--- a/app/gitcoinbot/management/commands/get_notifications.py
+++ b/app/gitcoinbot/management/commands/get_notifications.py
@@ -44,13 +44,14 @@ class Command(BaseCommand):
                         url = url.replace('/repos', '')
                         url = url.replace('//api.github', '//github')
                         latest_comment_url = notification.subject.latest_comment_url
-                        if latest_comment_url is None:
+                        if not latest_comment_url:
                             print("no latest comment url")
                             continue
                         _org_name = org_name(url)
                         _repo_name = repo_name(url)
                         _issue_number = issue_number(url)
-                        if not latest_comment_url:
+
+                        if not _issue_number.isnumeric():
                             continue
                         _comment_id = latest_comment_url.split('/')[-1]
                         comment = get_issue_comments(_org_name, _repo_name, _issue_number, _comment_id)
@@ -66,7 +67,7 @@ class Command(BaseCommand):
                             is_from_gitcoinbot = settings.GITHUB_API_USER in comment_from
                             if num_reactions == 0 and not is_from_gitcoinbot:
                                 print("unprocessed")
-                                post_issue_comment_reaction(_org_name, _repo_name, _comment_id, 'heart')
+                                post_issue_comment_reaction(_org_name, _repo_name, _issue_number, _comment_id, 'heart')
                     except RateLimitExceededException as e:
                         logging.debug(e)
                         print(e)


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR:

1. ensures the notification subject `url` is defined before attempting to `.replace()` on it
2. ensures non-numeric comments are ignored (as they throw when passing through `get_issue_comments()` util)
3. adds a missing positional to the `post_issue_comment_reaction()` call

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refs: #10031 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested locally