### PR TITLE
chore: optimise CLR performance away from O(n^2)

### DIFF
--- a/app/grants/clr.py
+++ b/app/grants/clr.py
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import copy
 import time
 
+from django.db import transaction
 from django.utils import timezone
 
 import numpy as np
@@ -472,7 +473,7 @@ def apply_cap(totals, match_cap_per_grant, should_spread):
 
     return totals
 
-
+@transaction.atomic
 def predict_clr(save_to_db=False, from_date=None, clr_round=None, network='mainnet', only_grant_pk=None, what='full', use_sql=False):
     # setup
     counter = 0

--- a/app/grants/models/grant.py
+++ b/app/grants/models/grant.py
@@ -247,11 +247,9 @@ class GrantCLR(SuperModel):
 
 
     def record_clr_prediction_curve(self, grant, clr_prediction_curve):
-        for obj in self.clr_calculations.filter(grant=grant, latest=True):
-            obj.active = False
-            obj.latest = False
-            obj.save()
-
+        # update matching records
+        self.clr_calculations.filter(grant=grant, latest=True).update(active=False, latest=False)
+        # create the new record
         GrantCLRCalculation.objects.create(
             grantclr=self,
             grant=grant,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
This PR:

1. caches the `sqrts` for each contributor to reduce the need to perform the same (expensive) calc multiple times

2. changes how we pair so that our time complexity comes in at something like `O((n^2)/2)`:

```
obj = {1: 2, 2: 3, 3: 4}
contributors = []
pairs = {}
for k1, v1 in obj.items():
    for k2 in contributors:
        u_k1 = k1 if k2 > k1 else k2
        u_k2 = k2 if k2 > k1 else k1
        if u_k1 != u_k2:
            if u_k1 not in pairs:
                pairs[u_k1] = {}
            if u_k2 not in pairs[u_k1]:
                pairs[u_k1][u_k2] = 0

            pairs[u_k1][u_k2] = obj[u_k1] * obj[u_k2]

    contributors.append(k1)
```

We expect `pairs = {1: {2: 6, 3: 8}, 2: {3: 12}}`, which consists of every pair multiplied together just once, this reduces the number of calcs we need to perform by 50%. We also apply this same behaviour to the `calculate_clr` function, to save the same amount of compute there.

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally and against GR12 results

Before:
<img width="1317" alt="Screenshot 2022-01-25 at 12 44 04" src="https://user-images.githubusercontent.com/5897836/151065402-df4c6b89-e6da-429f-bdf6-b3062f060d3b.png">

After:
<img width="1312" alt="Screenshot 2022-01-25 at 13 48 43" src="https://user-images.githubusercontent.com/5897836/151065362-1484c59d-7bfd-443e-921b-fb795812b6d9.png">

