### PR TITLE
don't show web3 modal on cart page init and tab change

### DIFF
--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -197,6 +197,11 @@ Vue.component('grantsCartEthereumPolygon', {
 
     // Send a batch transfer based on donation inputs
     async checkoutWithPolygon() {
+      // Prompt web3 login if not connected
+      if (!provider) {
+        await onConnect();
+      }
+
       const bulkCheckoutAddressPolygon = this.getBulkCheckoutAddress();
 
       try {

--- a/app/assets/v2/js/cart-ethereum-zksync.js
+++ b/app/assets/v2/js/cart-ethereum-zksync.js
@@ -194,6 +194,11 @@ Vue.component('grantsCartEthereumZksync', {
 
     // Send a batch transfer based on donation inputs
     async checkoutWithZksync() {
+      // Prompt web3 login if not connected
+      if (!provider) {
+        await onConnect();
+      }
+
       try {
         // Ensure wallet is connected
         if (!web3) {
@@ -346,7 +351,12 @@ Vue.component('grantsCartEthereumZksync', {
     },
 
     // Checkout With zkSync
-    checkoutWithzkSync() {
+    async checkoutWithzkSync() {
+      // Prompt web3 login if not connected
+      if (!provider) {
+        await onConnect();
+      }
+
       const selectedETHCartToken = appCart.$refs.cart.selectedETHCartToken;
       const unsuportedCheckoutZkSync = !appCart.$refs.cart.zkSyncSupportedTokens.includes(selectedETHCartToken);
 

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -602,7 +602,7 @@ Vue.component('grants-cart', {
       this.polygonEstimatedGasCost = data.polygonEstimatedGasCost;
     },
 
-    tabChange: async function(input, promptModal = true) {
+    tabChange: async function(input) {
       let vm = this;
 
       vm.tabSelected = vm.$refs.tabs.tabs[input].id;
@@ -615,13 +615,6 @@ Vue.component('grants-cart', {
         default:
         case 'ETH':
           vm.chainId = '1';
-          if (promptModal) {
-            if (!web3Modal) {
-              needWalletConnection();
-            } else if (!provider) {
-              await onConnect();
-            }
-          }
           break;
         case 'ZCASH':
           vm.chainId = '123123';
@@ -793,7 +786,7 @@ Vue.component('grants-cart', {
       CartData.removeIdFromCart(id);
       this.grantData = CartData.loadCart();
       update_cart_title();
-      this.tabChange(this.tabIndex, promptModal = false);
+      this.tabChange(this.tabIndex);
     },
 
     updatePaymentStatus(grant_id, step = 'waiting', txnid, additionalAttributes) {

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -965,7 +965,7 @@ Vue.component('grants-cart', {
     async initializeStandardCheckout() {
       // Prompt web3 login if not connected
       if (!provider) {
-        return await onConnect();
+        await await onConnect();
       }
 
       let networkId = String(Number(web3.eth.currentProvider.chainId));


### PR DESCRIPTION
##### Description

When the cart is initialized and when a tab is selected, the `tabChange` method is called.
This method was opening the web3 dialog by default, or waiting to connect to web3 in case it was already opened.
I removed that part so that the dialog is opened only at the final checkout action if needed. 
The final checkout action is already doing the same check, opening the dialog in case the wallet is not connected.
##### Refers/Fixes

Fixes: #9991 