### PR TITLE
fix: ensures we don't drop brightID from trust-bonus tab for non-staff users

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2990,11 +2990,6 @@ def get_profile_tab(request, profile, tab, prev_context):
             }
         ]
 
-        # TODO: REMOVE
-        is_staff = request.user.is_staff if request.user else False
-        if not is_staff:
-            del services[1]
-
         # pass as JSON in the context
         context['services'] = json.dumps(services)
         # Tentatively Coming Soon


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR ensures we don't incorrectly drop the BrightID service from the data fed to the trust-bonus tab (this is a regression following the removal of Quadratic Diplomacy from the trust-bonus options).

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: #10173

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

![localhost_8000_bobjiang_trust](https://user-images.githubusercontent.com/5897836/155243860-da4f0a32-ff4b-49aa-ac72-67a5ed63dafa.png)

