### PR TITLE
Pinning the ccxt version to the last version that seems to install in…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 bs4
-ccxt
+ccxt==1.72.98
 cryptocompare==0.6
 cryptography==2.3
 celery==4.4.0


### PR DESCRIPTION
… our docker env. Newer version requier newer setuptools

<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

We do not seem to fulfil the prerequisites for latest version of `ccxt`:

<img width="2091" alt="image" src="https://user-images.githubusercontent.com/8137830/155688632-43956793-b24f-4832-9cfa-26073b0d62dd.png">


##### Refers/Fixes

Building the docker environment for local dev (and container deployments).

##### Testing

Has been tested locally, the error shown in the screenshot above does not happen any more.
