### PR TITLE
filter out old rounds for available matches since payout does not exist

### DIFF
--- a/app/assets/v2/js/grants/matching_funds.js
+++ b/app/assets/v2/js/grants/matching_funds.js
@@ -86,6 +86,7 @@ Vue.mixin({
         JSON.parse(document.contxt.match_payouts_abi),
         contractAddress
       );
+      // After payouts are claimed, this will return 0 which updates value of claim_tx
       const amount = await payout_contract.methods.payouts(recipientAddress).call();
 
       if (amount == 0) {
@@ -255,7 +256,9 @@ Vue.mixin({
       return grant.clr_matches.length && grant.clr_matches.filter(a => a.claim_tx).length;
     },
     canClaimMatch(grant) {
-      return grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx && a.round_number > 7).length;
+      return grant.clr_matches.length && grant.clr_matches.filter(
+        a => a.claim_tx === null &&
+        a.grant_payout).length;
     },
     filterMatchingPayout(matches) {
       return matches.filter(match => match.grant_payout);

--- a/app/assets/v2/js/grants/matching_funds.js
+++ b/app/assets/v2/js/grants/matching_funds.js
@@ -255,7 +255,7 @@ Vue.mixin({
       return grant.clr_matches.length && grant.clr_matches.filter(a => a.claim_tx).length;
     },
     canClaimMatch(grant) {
-      return grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx).length;
+      return grant.clr_matches.length && grant.clr_matches.filter(a => !a.claim_tx && a.round_number > 7).length;
     },
     filterMatchingPayout(matches) {
       return matches.filter(match => match.grant_payout);


### PR DESCRIPTION
##### Description

One user had some old QF matches, from rounds 7 and lower, which were causing previously paid out matches to show that they could be claimed. e.g. 
`{amount: 6.74208445222599
claim_tx: null
grant_payout: null
pk: 1148
ready_for_payout: true
round_number: 7}`
(https://discord.com/channels/562828676480237578/947861866644901928/947861868993732619)



Another user had a rogue clr_match associated with a non existent round: 121. Unsure how this was created.
https://discord.com/channels/562828676480237578/947992211528749086
`{claim_tx: null
grant_payout: null
pk: 2001
ready_for_payout: true
round_number: 121}`

Both of these weird matches have in common that they do not have a grant_payout. I believe a clr_match should have a grant_payout regardless of whether or not they have claimed their funds.

So this does not show clr_matches under the "Ready" tab that do not have a payout. 



##### Refers/Fixes
fixes: #10214


