### PR TITLE
fix: pin ipfshttpclient at v0.7.0

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,6 +14,6 @@ idna==2.7
 django-test-plus==1.1.1
 git+https://github.com/google/yapf.git#egg=yapf
 django-debug-toolbar
-ipfshttpclient==0.6.0
+git+https://github.com/ipfs-shipyard/py-ipfs-http-client.git@52c1d2a28a43fb020d4d6375be2b8d432267c37d#egg=ipfshttpclient
 dj_static==0.0.6
 livereload==2.6.3


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR pins `ipfshttpclient` at v0.7.0 for GHA workflow

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refs: failing CI