### PR TITLE
algorand: multiple wallet fallback

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -427,7 +427,7 @@ Vue.component('grants-cart', {
     },
 
     isAlgorandExtInstalled() {
-      return window.AlgoSigner || false;
+      return window.WalletConnect || window.MyAlgoConnect || window.AlgoSigner || false;
     },
 
     isRskExtInstalled() {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

The original PR for Algorand checkout (#9953) hardcodes one wallet, although the code does have the option for us to select which one of AlgoSigner, MyAlgoConnect, or WalletConnect we want to set as the default. We want to change the logic so that the app will run through that list of wallets, see which one the user has, and then move forward with that extension.

The priority list of wallets is:

- WalletConnect
- MyAlgo Connect
- AlgoSigner

##### Refers/Fixes

closes #10240 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
