### PR TITLE
fix: use `request.headers.get` to avoid backend errors

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -3981,7 +3981,7 @@ def clr_matches(request):
 @require_POST
 def ingest_merkle_claim_to_clr_match(request):
 
-    _token = request.headers['token']
+    _token = request.headers.get('token')
 
     data = StaticJsonEnv.objects.get(key='MERKLE_CLAIM_UPLOAD').data
 


### PR DESCRIPTION
Just a little fix to avoid backend errors in case the `ingest_merkle_claim_to_clr_match` API receives a request without a token set in the headers.