### PR TITLE
fix: ensure elasticsearch full_search field contains spaces between keywords

### DIFF
--- a/app/search/management/commands/update_search_index.py
+++ b/app/search/management/commands/update_search_index.py
@@ -34,9 +34,15 @@ class Command(BaseCommand):
         if sync_type == 'create':
             for sr in SearchResult.objects.all():
                 print(sr.pk)
-                sr.put_on_elasticsearch()
+                try:
+                    sr.put_on_elasticsearch()
+                except Exception as e:
+                    print('failed:', e)
         elif sync_type == 'update':
             then = timezone.now() - timezone.timedelta(hours=1)
             for sr in SearchResult.objects.filter(modified_on__gt=then):
                 print(sr.pk)
-                sr.put_on_elasticsearch()
+                try:
+                    sr.put_on_elasticsearch()
+                except Exception as e:
+                    print('failed:', e)

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -30,7 +30,7 @@ class SearchResult(SuperModel):
 
         es = Elasticsearch([settings.ELASTIC_SEARCH_URL])
         source_type  = str(str(self.source_type).replace('token', 'kudos')).title()
-        full_search = f"{self.title}{self.description}{source_type}"
+        full_search = f"{self.title} {self.description} {source_type}"
         doc = {
             'title': self.title,
             'description': self.description,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

Currently we concat the title and description, but elasticsearch's `match` method is using a keyword index. 

eg this works:
https://gitcoin.co/api/v0.1/search/?term=otterscanotterscan

but this doesn't
https://gitcoin.co/api/v0.1/search/?term=otterscan

This PR alters the elasticsearch `full_search` field so that each keyword definitely has a space between it, once merged we will need to recreate the index.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Fixes: #9785

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Tested against the prod es instance
