### PR TITLE
bug: hide polygon tag if address is multisig

### DIFF
--- a/app/grants/templates/grants/detail/template-grant-details.html
+++ b/app/grants/templates/grants/detail/template-grant-details.html
@@ -92,7 +92,7 @@
                   class="col-auto badge badge-pill bg-lightpurple text-primary font-weight-semibold" id="wallet-zkscan-link">
                   zkSync
                 </a>
-                <a target="_blank" :href="`https://polygonscan.com/address/${grant.admin_address}`"
+                <a v-if="!grant.is_contract_address" target="_blank" :href="`https://polygonscan.com/address/${grant.admin_address}`"
                   class="col-auto badge badge-pill bg-lightpurple text-primary font-weight-semibold" id="wallet-polygonscan-link">
                   Polygon
                 </a>


### PR DESCRIPTION
##### Description

Hides polygon tag if address is multisig

##### Refers/Fixes

https://discord.com/channels/562828676480237578/952909877439770685/952909880463880192

##### Testing

Locally Tested

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/5358146/158184951-cf608d06-38ba-4636-9ff2-91ef0bf765b2.png">
