### PR TITLE
default to switching to mainnet

### DIFF
--- a/app/assets/v2/js/grants/ingest-missing-contributions.js
+++ b/app/assets/v2/js/grants/ingest-missing-contributions.js
@@ -148,7 +148,7 @@ Vue.component('grants-ingest-contributions', {
         ({ txHash, userAddress, checkoutType } = formParams);
         
         if (checkoutType === 'eth_polygon') {
-          await setupPolygon(); // handles switching to polygon network + adding network config if doesn't exist
+          await setupPolygon('mainnet'); // handles switching to polygon network + adding network config if doesn't exist
         }
 
         // If user entered an address, verify that it matches the user's connected wallet address


### PR DESCRIPTION
##### Description

While attempting to log polygon claims, I kept getting prompted to switch to mumbai testnet instead of polygon mainnet. This always prompts user to switch to polygon mainnet

##### Refers/Fixes

fixes: #10330 

