### PR TITLE
feat: open cart content on mouseover on desktop

### DIFF
--- a/app/assets/v2/js/cart-nav.js
+++ b/app/assets/v2/js/cart-nav.js
@@ -2,16 +2,17 @@ Vue.component('gc-cart-content', {
   template: '#gc-cart-content',
   delimiters: [ '[[', ']]' ],
   data: () => {
-
     return {
       items: []
     };
   },
+
   methods: {
     init: function() {
       // update items each time we open the dropdown
       this.items = CartData.loadCart();
     },
+
     removeGrantFromCart: function(grant_id) {
       // remove the item
       CartData.removeIdFromCart(grant_id);
@@ -24,19 +25,58 @@ Vue.component('gc-cart-content', {
 if (document.getElementById('gc-cart')) {
   var app = new Vue({
     delimiters: [ '[[', ']]' ],
+
     el: '#gc-cart',
+
     data: {
-      cart_data_count: CartData.length()
+      cart_data_count: CartData.length(),
     },
+
     methods: {
       updateCartCount: function(e) {
         this.cart_data_count = e.detail.list.length || 0;
-      }
+      },
+
+      onLinkMouseOver: function(e) {
+        if (this.isMobile()) {
+          return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const el = $(e.currentTarget);
+        const visible = el.parent().hasClass("show");
+        if (visible) {
+          return;
+        }
+
+        this.$refs.navCart.init()
+        el.trigger("click");
+      },
+
+      onLinkClick: function(e) {
+        if (this.isMobile()) {
+          this.$refs.navCart.init()
+          return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        window.location.href = $(e.currentTarget).attr("href");
+      },
+
+      isMobile: function() {
+        return "ontouchstart" in window;
+      },
     },
+
     mounted() {
       // watch for cartUpdates
       window.addEventListener('cartDataUpdated', this.updateCartCount);
     },
+
     beforeDestroy() {
       // unwatch cartUpdates
       window.removeEventListener('cartDataUpdated', this.updateCartCount);

--- a/app/dashboard/templates/shared/cart_nav.html
+++ b/app/dashboard/templates/shared/cart_nav.html
@@ -1,6 +1,7 @@
 <!-- nav cart icon/count + dropdown -->
 <div id="gc-cart" class="nav-item dropdown gc-cart order-md-first">
-  <a href="" class="gc-cart__icon nav-link dropdown-toggle dropdown-toggle-md-no-caret" id="cartDropdown" role="button" @click="$refs.navCart.init()"
+  <a href="{% url 'grants:cart' %}" class="gc-cart__icon nav-link dropdown-toggle dropdown-toggle-md-no-caret" id="cartDropdown" role="button"
+    @mouseover="onLinkMouseOver" @click="onLinkClick"
     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="far fa-shopping-cart fa-fw fa-lg"></i>
     <span class="pl-3 d-md-none">Cart</span>


### PR DESCRIPTION
##### Description

This PR changes the behaviour of the cart icon in the menu. 
Only on desktop we want to open the cart content on mouseover, and redirect to the cart page on click.
For mobile we keep the previous behaviour, opening the cart content on click.

 The `onLinkMouseOver` and `onLinkClick` methods don't do anything if the current platform is mobile, leaving
the management of the event to the `bootstrap` handlers.
For desktop we simulate the `click` event on `mouseover` to trigger the `bootstrap` handlers, so that we don't need to rewrite the show/hide behaviour.

##### Refers/Fixes

Closes: #10262

