### PR TITLE
add carousel extension to make gr13 banner clickable

### DIFF
--- a/app/assets/v2/js/carousel-extensions.js
+++ b/app/assets/v2/js/carousel-extensions.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  $(".carousel .carousel-item").on("click", function(event) {
+    if (event.target.tagName.toLowerCase() === 'a') {
+      return;
+    }
+
+    event.preventDefault();
+
+    const href = $(event.currentTarget).data('carousel-item-href');
+
+    if (href !== undefined) {
+      document.location.href = href;
+    }
+  });
+})

--- a/app/assets/v2/js/carousel-extensions.js
+++ b/app/assets/v2/js/carousel-extensions.js
@@ -13,4 +13,4 @@ $(document).ready(function() {
       document.location.href = href;
     }
   });
-})
+});

--- a/app/assets/v2/js/carousel-extensions.js
+++ b/app/assets/v2/js/carousel-extensions.js
@@ -1,11 +1,10 @@
 $(document).ready(function() {
-  $(".carousel .carousel-item").on("click", function(event) {
+  $('.carousel .carousel-item').on('click', function(event) {
     if (event.target.tagName.toLowerCase() === 'a') {
       return;
     }
 
     event.preventDefault();
-
     const href = $(event.currentTarget).data('carousel-item-href');
 
     if (href !== undefined) {

--- a/app/assets/v2/js/carousel-extensions.js
+++ b/app/assets/v2/js/carousel-extensions.js
@@ -1,11 +1,13 @@
 $(document).ready(function() {
-  $('.carousel .carousel-item').on('click', function(event) {
+  const dataAttr = 'carousel-item-href';
+
+  $(`.carousel .carousel-item[data-${dataAttr}]`).on('click', function(event) {
     if (event.target.tagName.toLowerCase() === 'a') {
       return;
     }
 
     event.preventDefault();
-    const href = $(event.currentTarget).data('carousel-item-href');
+    const href = $(event.currentTarget).data(dataAttr);
 
     if (href !== undefined) {
       document.location.href = href;

--- a/app/assets/v2/scss/jtbd.scss
+++ b/app/assets/v2/scss/jtbd.scss
@@ -20,6 +20,9 @@
   }
   .carousel-inner {
     min-height: 500px;
+    .carousel-item[data-carousel-item-href] {
+      cursor: pointer;
+    }
   }
   .grants {
     display: flex;

--- a/app/retail/templates/home/index2021.html
+++ b/app/retail/templates/home/index2021.html
@@ -135,7 +135,7 @@
           <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
         </ol>
         <div class="carousel-inner">
-          <div class="carousel-item active" data-carousel-item-href="{% url 'grants:cart' %}">
+          <div class="carousel-item active" data-carousel-item-href="{% url 'grants:grants' %}">
             <div class="grants">
               <div class="d-flex flex-column justify-content-around container">
                 <h3 class="dates gc-font-heading">March 9-24, 2022</h3>

--- a/app/retail/templates/home/index2021.html
+++ b/app/retail/templates/home/index2021.html
@@ -135,7 +135,7 @@
           <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
         </ol>
         <div class="carousel-inner">
-          <div class="carousel-item active">
+          <div class="carousel-item active" data-carousel-item-href="{% url 'grants:cart' %}">
             <div class="grants">
               <div class="d-flex flex-column justify-content-around container">
                 <h3 class="dates gc-font-heading">March 9-24, 2022</h3>

--- a/app/retail/templates/shared/footer_scripts.html
+++ b/app/retail/templates/shared/footer_scripts.html
@@ -81,6 +81,7 @@
 
 {% bundle merge_js file main %}
   <script src="{% static "v2/js/base.js" %}"></script>
+  <script src="{% static "v2/js/carousel-extensions.js" %}"></script>
   <script src="{% static "v2/js/mautic.js" %}"></script>
   <script src="{% static "v2/js/ajax-helper.js" %}"></script>
   <script src="{% static "v2/js/cart-data.js" %}"></script>


### PR DESCRIPTION
##### Description

As describe in #10302 we want any click in the GR13 banner to redirect to `/grants` unless the user clicks on the `Explore Grants` button, which sends the user to `/grants/explorer`.

Since [nested links are illegal](https://www.w3.org/TR/html401/struct/links.html#h-12.2.2), we cannot have an `a` tag that wraps the full carousel item which contains another link button. 

A solution could be having an absolute `a` with `width` and `height` 100% and the carousel inner element again with absolute position placed on top of it. This solution can already have problems depending on the inner content, and in this specific case it can break some other parts given that the carousel `js` and `css` are implemented in the external bootstrap lib.

For this reason I added a simple extension to the carousel in `js` that makes clickable any carousel item element with the `data-carousel-item-href` attribute redirecting to its value.

##### Refers/Fixes

Fixes: #10302
