### PR TITLE
only return distinct grants when filtering for all ecosystem rounds

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -709,7 +709,7 @@ def get_grants_by_filters(
         if len(grant_ids):
             _grants = _grants.filter(pk__in=grant_ids)
         # apply the grant_filters
-        _grants = _grants.filter(grant_filters)
+        _grants = _grants.filter(grant_filters).distinct()
 
         # apply the grant_exludes
         if clr_round.grant_excludes:


### PR DESCRIPTION
##### Description

If a grant has multiple eligibility tags and the user filters by all ecosystem rounds by clicking `ecosystem` grants that have multiple ecosystems tags will be returned from the api multiple times

This makes sure only unique grants are returned

##### Refers/Fixes

fixes: #10333 

##### Testing

Before changes
https://user-images.githubusercontent.com/6887938/158625564-a254be26-2384-40f9-a629-6bc02ef3ed1c.mov

After
https://user-images.githubusercontent.com/6887938/158625644-1b3b436f-9776-42eb-8c32-eb372ff8a61f.mov


