### PR TITLE
fix: prevents race-condition on search() and improves elasticsearch result ordering

### DIFF
--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -4,7 +4,7 @@ if (document.getElementById('gc-search')) {
     el: '#gc-search',
     data: {
       term: '',
-      results: [],
+      results: {},
       page: 0,
       total: 0,
       perPage: 100,
@@ -29,7 +29,8 @@ if (document.getElementById('gc-search')) {
         'Kudos': 'Kudos',
         'Quest': 'Quests',
         'Page': 'Pages'
-      }
+      },
+      fetchController: new AbortController()
     },
     mounted() {
       this.search();
@@ -48,46 +49,76 @@ if (document.getElementById('gc-search')) {
           $('.has-search input[type=text]').focus();
         }, 100);
       },
+      clear: function() {
+        this.results = {};
+        this.page = 0;
+        this.total = 0;
+      },
       dirty: async function(e) {
-        this.isDirty = true;
+        // only abort if we're not dirty
+        if (!this.isDirty) {
+          // mark as dirty
+          this.isDirty = true;
+          // clear state
+          this.clear();
+          // abort previous fetch request
+          this.fetchController.abort();
+          // setup a new AbortController
+          this.fetchController = new AbortController();
+        }
       },
       search: async function(e) {
-        let vm = this;
-        let thisDate = new Date();
+        const vm = this;
+        // use Date to enforce
+        const thisDate = new Date();
+        // use signal to kill fetch req
+        const { signal } = vm.fetchController;
 
+        // clear fetch state
         vm.isDirty = false;
-        // prevent 2x search at once
+
+        // prevent 2x search at once (ignores second request with same intel)
         if (vm.isLoading) {
           return;
         }
 
-        // clear state on new search term
-        if (vm.term !== vm.searchTerm) {
-          vm.results = {};
-          vm.page = 0;
-          vm.total = 0;
-        }
-
         // get results from the api and group
         if (vm.term.length >= 4) {
+          // mark as reloading
           vm.isLoading = true;
+          // mark thisDate against component to check for race conditions
           document.current_search = thisDate;
-
-          const response = await fetchData(
+          // fetch the response from the api
+          fetch(
             `/api/v0.1/search/?term=${vm.term}&page=${vm.page}`,
-            'GET'
-          );
-
-          if (document.current_search == thisDate) {
-            vm.results = groupBySource(response.results, vm.term !== vm.searchTerm ? {} : vm.results);
-            vm.searchTerm = vm.term;
-            vm.total = response.total;
-            vm.page = response.page;
-            vm.perPage = response.perPage;
-          }
-          vm.isLoading = false;
+            {
+              method: 'GET',
+              signal: signal
+            }
+          ).then((res) => {
+            if (document.current_search == thisDate) {
+              res.json().then((response) => {
+                vm.results = groupBySource(response.results, vm.term !== vm.searchTerm ? {} : vm.results);
+                vm.searchTerm = vm.term;
+                vm.total = response.total;
+                vm.page = response.page;
+                vm.perPage = response.perPage;
+                // clear loading states
+                vm.isLoading = false;
+              });
+            }
+          }).catch(() => {
+            if (document.current_search == thisDate) {
+              // clear the results
+              vm.clear();
+              // clear loading states
+              vm.isLoading = false;
+            }
+          });
         } else {
-          vm.results = {};
+          // clear the results
+          vm.clear();
+          // clear loading states
           vm.isLoading = false;
         }
       }

--- a/app/assets/v2/scss/gc-utilities.scss
+++ b/app/assets/v2/scss/gc-utilities.scss
@@ -121,6 +121,10 @@
 }
 
 // hover effects
+.disable-hover-underline:hover {
+  text-decoration: none!important
+}
+
 .hover-underline:not(:disabled):not(.disabled):not(.active):hover {
   text-decoration: underline!important
 }

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -26,7 +26,7 @@
     <div class="has-search p-3">
       <form v-on:submit.prevent="search">
         <input type="text" class="form-control font-caption" v-model="term" @input="dirty" placeholder="Search Gitcoin">
-        <input type="submit" class="form-control font-caption mx-2" @click="search" value="Go">
+        <input type="submit" class="form-control font-caption mx-2" value="Go">
       </form>
     </div>
     <template v-if="term.length < 4">
@@ -79,7 +79,15 @@
       </div>
       <template v-if="hasMoreResults">
         <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
-          <a class="link cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
+          <template v-if="isLoading">
+            <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
+              <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
+              Fetching result
+            </a>
+          </template>
+          <template v-else>
+            <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
+          </template>
         </div>
       </template>
     </template>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR prevents race-conditions from appearing on `search()` by preventing resubmissions and adds `boosts` to the elasticsearch query to help order the results. 

We're currently boosting on the `title` (by 10) and if the `source_type="grant"` (by 2), this promotes results with the wildcard search term in the `title` to the top and then pushes those which relate to `grants` slightly higher so that the first results we get back should point to `grants` whose titles best fit the given search term.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refs: https://github.com/gitcoinco/web/pull/10298

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally and against the prod elasticsearch instance.