### PR TITLE
additional filter updates

### DIFF
--- a/app/assets/v2/js/grants/_detail.js
+++ b/app/assets/v2/js/grants/_detail.js
@@ -10,9 +10,15 @@ Vue.mixin({
       const amountReceived = Vue.filter('round')(grant.amount_received || 0);
       const amountRecievedInRound = Vue.filter('round')(grant.amount_received_in_round || 0);
 
+      grant.clr_prediction_curve = grant.clr_prediction_curve.map((prediction) => {
+        prediction[0] = Vue.filter('round')(prediction[0] || 0);
+        prediction[1] = Vue.filter('round')(prediction[1] || 0);
+        prediction[2] = Vue.filter('round')(prediction[2] || 0);
+        return prediction;
+      });
+      grant.last_update = Vue.filter('moment')(grant.last_update);
       grant.amount_received = Vue.filter('formatNumber')(amountReceived);
       grant.amount_received_in_round = Vue.filter('formatNumber')(amountRecievedInRound);
-
       return grant;
     },
     fetchGrantDetails: function(id) {

--- a/app/grants/templates/grants/detail/template-grant-details.html
+++ b/app/grants/templates/grants/detail/template-grant-details.html
@@ -251,7 +251,7 @@
           <div class="col-12 col-md-5 col-md-auto mb-3 mb-md-1 text-grey-400">
             <i class="fas fa-stopwatch text-grey-400"></i>
             <span class="py-1 px-2 font-weight-normal mr-2">
-              Updated [[grant.last_update | moment]]
+              Updated [[grant.last_update]]
             </span>
           </div>
 
@@ -292,7 +292,7 @@
               </span>
             </div>
             <div v-if="grant?.clr_prediction_curve?.[0]?.[1] > 0" class="col col-4">
-              <h2 class="text-secondary">+$[[ grant?.clr_prediction_curve?.[0]?.[1] || 0 | round | formatNumber ]]</h2>
+              <h2 class="text-secondary">+$[[ grant?.clr_prediction_curve?.[0]?.[1] | formatNumber ]]</h2>
               <span>estimated QF matching</span>
               <i
                 class="fas fa-info-circle text-grey-400 mx-1 cursor-pointer"
@@ -511,7 +511,7 @@
                     </p>
                   </div>
                 </b-tooltip>
-                <span class="text-secondary"><b>$[[prediction[2] || 0 | round]] match</b></span>
+                <span class="text-secondary"><b>$[[ prediction[2] ]] match</b></span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
##### Description

Multiple users (on desktop and mobile) are reporting seeing extra decimals for the contribution amounts when on the grant details page. Screenshots below

This formats values when data is received instead of in the template

##### Refers/Fixes

fixes: #10367

