### PR TITLE
Fix back navigation in grant creation flow

### DIFF
--- a/app/assets/v2/js/grants/_new.js
+++ b/app/assets/v2/js/grants/_new.js
@@ -332,16 +332,14 @@ Vue.mixin({
       this.$set(this.form, inputField.id, extracted);
     },
     updateNav: function(direction) {
-      if(direction === 1) {
+      if (direction === 1) {
         if (this.step === this.currentSteps.length) {
           this.submitForm();
           return;
         }
         this.step += direction;
-      } else {
-        if(this.step > 1){ 
-          this.step += direction;
-        }
+      } else if (this.step > 1) {
+        this.step += direction;
       }
     }
   },

--- a/app/assets/v2/js/grants/_new.js
+++ b/app/assets/v2/js/grants/_new.js
@@ -332,11 +332,17 @@ Vue.mixin({
       this.$set(this.form, inputField.id, extracted);
     },
     updateNav: function(direction) {
-      if (this.step === this.currentSteps.length) {
-        this.submitForm();
-        return;
+      if(direction === 1) {
+        if (this.step === this.currentSteps.length) {
+          this.submitForm();
+          return;
+        }
+        this.step += direction;
+      } else {
+        if(this.step > 1){ 
+          this.step += direction;
+        }
       }
-      this.step += direction;
     }
   },
   watch: {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This fixes back navigation in the grant creation flow, when the user is in the last step.
2 cases need to be handled separately:
1. the user clicks the right button (for next) -> need to check if we submit form 
3. the user clicks the left button (go back) -> need to check if we are on the first page

##### Refers/Fixes

No ticket open for this. I have noticed this as I was implementing the same flow for bounties, and did not want to walk by it.
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Has been tested locally.
https://www.loom.com/share/dd5388b2126d4513a03cdc0e50c2b854


