### PR TITLE
looping over tenants when creating totals

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -164,9 +164,11 @@ Vue.component('grants-cart', {
       let vm = this;
 
       var grantsTentantsCount = vm.grantData.reduce(function(result, grant) {
-        var currentCount = result[grant.tenants] || 0;
+        grant.tenants.forEach((tenant) => {
+          var currentCount = result[tenant] || 0;
 
-        result[grant.tenants] = currentCount + 1;
+          result[tenant] = currentCount + 1;
+        });
         return result;
       }, {});
 


### PR DESCRIPTION
##### Description

If there were more than one blockchains associated with a grant it was not calculating grant totals correctly

##### Refers/Fixes

fixes: #10354

##### Testing

https://user-images.githubusercontent.com/6887938/158905330-2a7123dd-5754-4936-b98f-feab7aa31cce.mov


