### PR TITLE
updated disable and polygon modal display logic

### DIFF
--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -218,7 +218,7 @@ Vue.component('grantsCartEthereumPolygon', {
     },
 
     // Send a batch transfer based on donation inputs
-    async checkoutWithPolygon() {
+    async checkoutWithPolygon(onlyPolygon) {
       // Prompt web3 login if not connected
       if (!provider) {
         await onConnect();
@@ -270,7 +270,7 @@ Vue.component('grantsCartEthereumPolygon', {
         }
 
         // If some grants are multisig, we display modal to prompt the split of the cart
-        if (this.multisigGrants.length > 0 && this.multisigGrants.length < this.grantsByTenant.length) {
+        if (!onlyPolygon && this.multisigGrants.length > 0 && this.multisigGrants.length < this.grantsByTenant.length) {
           this.polygon.showModal = true;
           return;
         }

--- a/app/grants/templates/grants/cart/eth_checkout_button.html
+++ b/app/grants/templates/grants/cart/eth_checkout_button.html
@@ -55,11 +55,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </b-dropdown-item-button>
 
       <!-- CHECKOUT WITH POLYGON -->
+      <!--
+        Disabled logic checks if there are multisig grants.
+        If multisig grants check that not all of them are multisig grants
+        If all of the grants are multisig disable button
+        If only a portion are multisig, fo not disable button
+      -->
       <b-dropdown-item-button
         v-if="!isPolygonDown"
         aria-labelledby="js-polygonfundGrants-button"
-        :disabled="activeCheckout !== undefined || grantsUnderMinimalContribution?.length > 0 || multisigGrants.length > 0"
-        :aria-disabled="(activeCheckout !== undefined || grantsUnderMinimalContribution?.length > 0 || multisigGrants.length > 0) ? 'true' : 'false'"
+        :disabled="activeCheckout !== undefined || grantsUnderMinimalContribution?.length > 0 || (multisigGrants.length > 0 && !(multisigGrants.length < grantsByTenant.length))"
+        :aria-disabled="(activeCheckout !== undefined || grantsUnderMinimalContribution?.length > 0 || (multisigGrants.length > 0 && !(multisigGrants.length < grantsByTenant.length)))"
       >
         <grants-cart-ethereum-polygon
           inline-template
@@ -76,10 +82,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- Checkout with Polygon button -->
             <button
               class="btn p-0 checkout-logo"
-              :disabled="multisigGrants.length > 0"
-              :aria-disabled="multisigGrants.length > 0"
+              :disabled="(multisigGrants.length > 0 && !(multisigGrants.length < grantsByTenant.length))"
+              :aria-disabled="(multisigGrants.length > 0 && !(multisigGrants.length < grantsByTenant.length))"
               id="js-polygonfundGrants-button"
-              @click="checkoutWithPolygon"
+              @click="checkoutWithPolygon(false)"
             >
             <svg class="polygon-logo" width="18" height="15" viewBox="0 0 18 15" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M13.5937 4.56702C13.2656 4.38791 12.8437 4.38791 12.4687 4.56702L9.84375 6.04463L8.0625 6.98493L5.48437 8.46254C5.15625 8.64164 4.73438 8.64164 4.35938 8.46254L2.34375 7.29836C2.01562 7.11926 1.78125 6.76105 1.78125 6.35806V4.11926C1.78125 3.76105 1.96875 3.40284 2.34375 3.17896L4.35938 2.05956C4.6875 1.88045 5.10937 1.88045 5.48437 2.05956L7.5 3.22373C7.82812 3.40284 8.0625 3.76105 8.0625 4.16403V5.64164L9.84375 4.65657V3.13418C9.84375 2.77597 9.65625 2.41776 9.28125 2.19388L5.53125 0.0894065C5.20312 -0.089698 4.78125 -0.089698 4.40625 0.0894065L0.5625 2.23866C0.1875 2.41776 0 2.77597 0 3.13418V7.34314C0 7.70135 0.1875 8.05956 0.5625 8.28344L4.35938 10.3879C4.6875 10.567 5.10937 10.567 5.48437 10.3879L8.0625 8.95508L9.84375 7.97L12.4219 6.53717C12.75 6.35806 13.1719 6.35806 13.5469 6.53717L15.5625 7.65657C15.8906 7.83567 16.125 8.19388 16.125 8.59687V10.8357C16.125 11.1939 15.9375 11.5521 15.5625 11.776L13.5937 12.8954C13.2656 13.0745 12.8437 13.0745 12.4687 12.8954L10.4531 11.776C10.125 11.5969 9.89062 11.2387 9.89062 10.8357V9.40284L8.10937 10.3879V11.8655C8.10937 12.2237 8.29687 12.5819 8.67187 12.8058L12.4687 14.9103C12.7969 15.0894 13.2187 15.0894 13.5937 14.9103L17.3906 12.8058C17.7187 12.6267 17.9531 12.2685 17.9531 11.8655V7.61179C17.9531 7.25358 17.7656 6.89538 17.3906 6.6715L13.5937 4.56702Z" fill="#6F3FF5"/>
@@ -149,7 +155,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <button
           class="rounded btn btn-primary checkout-logo p-2 w-100"
           :disabled="activeCheckout !== undefined || grantsUnderMinimalContribution?.length > 0"
-          @click="checkoutWithPolygon"
+          @click="checkoutWithPolygon(true)"
         >
         Polygon Checkout
       </button>


### PR DESCRIPTION
##### Description

It looks like after splitting multisig and non multisig grants for polygon checkout the split modal was continuing to display. This should only show polygon multisig modal if it is called from the ethereum checkout page

##### Refers/Fixes

fixes: #10380

##### Testing


https://user-images.githubusercontent.com/6887938/159502620-78a53173-2ed3-4396-b524-24bcfae98c78.mov

