### PR TITLE
chore: check last 10 tweet activities instead on last tweet activity

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3255,13 +3255,20 @@ def verify_user_twitter(request, handle):
         logger.error(f"error: verify_user_twitter TweepError {e}")
         return JsonResponse({
             'ok': False,
-            'msg': f'Sorry, we couldn\'t get the last tweet from @{twitter_handle}'
+            'msg': f'Sorry, we couldn\'t get the verification tweet from @{twitter_handle}'
         })
     except IndexError as e:
         logger.error(f"error: verify_user_twitter IndexError {e}")
         return JsonResponse({
             'ok': False,
-            'msg': 'Sorry, we couldn\'t retrieve the last tweet from your timeline'
+            'msg': 'Sorry, we couldn\'t retrieve the verification tweet from your timeline'
+        })
+
+
+    if not verification_tweet:
+        return JsonResponse({
+            'ok': False,
+            'msg': f'Sorry, we couldn\'t retrieve the verification tweet from your timeline'
         })
 
     if verification_tweet.retweeted or 'RT @' in verification_tweet.full_text:

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3250,6 +3250,7 @@ def verify_user_twitter(request, handle):
         for tweet in last_10_tweets:
             if tweet.full_text.startswith("I am verifying my identity as"):
                 verification_tweet = tweet
+                break
 
     except tweepy.TweepError as e:
         logger.error(f"error: verify_user_twitter TweepError {e}")


### PR DESCRIPTION
##### Description

dug into the twitter one and it looks like the api returns the tweet

> @notionport I know the founder well if you'd like an intro 🙂

Looking at the code. == > 
What we do is look at last tweet of user to see if that have the I have verified myself on gitcoin 

The issue was that the  verify tweet was posted and before our backend could verify -> annika | gitcoin replied / tweeted the above message and our backend ended up picking that up.

This PR changes to ensure we look at last 10 tweets


##### Refers/Fixes

closes https://github.com/gitcoinco/web/issues/10406

##### Testing

![Uploading Screenshot 2022-03-24 at 1.43.52 PM.png…]()
