### PR TITLE
Ensure no duplicate files are generated by the bundle django command.

### DIFF
--- a/app/dashboard/management/commands/bundle.py
+++ b/app/dashboard/management/commands/bundle.py
@@ -3,7 +3,7 @@ import re
 import shutil
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.template import Context, Template
 from django.template.loaders.app_directories import get_app_template_dirs
 
@@ -111,7 +111,14 @@ class Command(BaseCommand):
                         block = block.render(bundleContext)
 
                         # render the template (producing a bundle file)
-                        rendered[render(block, kind, 'file', name, True)] = True
+                        rendered_tag = render(block, kind, 'file', name, True)
+                        if rendered_tag in rendered:
+                            error = '-- X - duplicate: "%s"\ntemplate: "%s"\nblock:"%s"' % (rendered_tag, template, block)
+                            raise CommandError(error)
+                            
+                        rendered[rendered_tag] = True
+            except CommandError:
+                raise
             except Exception as e:
                 print('-- X - failed to parse %s: %s' % (template, e))
                 pass

--- a/app/dashboard/templates/bounty/details.html
+++ b/app/dashboard/templates/bounty/details.html
@@ -531,7 +531,7 @@
 
   <script src="/dynamic/js/tokens_dynamic.js"></script>
 
-  {% bundle merge_js file libs %}
+  {% bundle merge_js file bounty_details_libs %}
     <script src="index.min.js" base-dir="/node_modules/ipfs-api/dist/"></script>
     <script src="highlight.min.js" base-dir="/node_modules/@highlightjs/cdn-assets/"></script>
     <script src="markdown-it.min.js" base-dir="/node_modules/markdown-it/dist/"></script>

--- a/app/dashboard/templates/bounty/details2.html
+++ b/app/dashboard/templates/bounty/details2.html
@@ -1142,7 +1142,7 @@
       {% include 'shared/current_profile.html' %}
     </div>
 
-    {% bundle merge_js file libs %}
+    {% bundle merge_js file bounty_details2_libs %}
       <script src="highlight.min.js" base-dir="/node_modules/@highlightjs/cdn-assets/"></script>
       <script src="markdown-it.min.js" base-dir="/node_modules/markdown-it/dist/"></script>
       <script src="daterangepicker.js" base-dir="/node_modules/daterangepicker/"></script>

--- a/app/dashboard/templates/bounty/new_bounty.html
+++ b/app/dashboard/templates/bounty/new_bounty.html
@@ -24,7 +24,7 @@
     {% include 'shared/cards.html' %}
     <meta name="title" content="Create Funded Issue/Bounty | Gitcoin">
     <meta name="description" content="Instructions for creating an issue and posting a bounty to Gitcoin so developers across the world can discover your bounty and start working on your issue.">
-    {% bundle css file new_bounty %}
+    {% bundle css file new_bounty_style %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/quickstart.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/activity_stream.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/tag.scss" %} />
@@ -739,7 +739,7 @@
           ]
       </script>
 
-      {% bundle merge_js file libs %}
+      {% bundle merge_js file new_bounty_libs %}
         <script src="index.min.js" base-dir="/node_modules/ipfs-api/dist/"></script>
         <script src="highlight.min.js" base-dir="/node_modules/@highlightjs/cdn-assets/"></script>
         <script src="markdown-it.min.js" base-dir="/node_modules/markdown-it/dist/"></script>

--- a/app/dashboard/templates/dashboard/hackathon/projects.html
+++ b/app/dashboard/templates/dashboard/hackathon/projects.html
@@ -21,7 +21,7 @@
   <head>
     {% include 'shared/head.html' %}
     {% include 'shared/cards_pic.html' %}
-    {% bundle css file howitworks %}
+    {% bundle css file hackathon_projects_howitworks %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/howitworks.scss" %} />
     {% endbundle %}
     <style>

--- a/app/dashboard/templates/dashboard/index-vue.html
+++ b/app/dashboard/templates/dashboard/index-vue.html
@@ -786,7 +786,7 @@
           <slot></slot>
         </select>
       </script>
-      {% bundle merge_js file new_bounty %}
+      {% bundle merge_js file app_dashboard %}
         <script src="markdown-it.min.js" base-dir="/node_modules/markdown-it/dist/"></script>
       {% endbundle %}
       {{orgs|json_script:"sponsor-list"}}

--- a/app/dashboard/templates/onepager/send2.html
+++ b/app/dashboard/templates/onepager/send2.html
@@ -50,7 +50,7 @@
 {% endblock %}
 <!-- Main -->
 {% block 'main' %}
-{% bundle css file tooltip_hover %}
+{% bundle css file tooltip_hover_send2 %}
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/tooltip_hover.scss" %} />
 {% endbundle %}
 <style>

--- a/app/dashboard/templates/profiles/profile.html
+++ b/app/dashboard/templates/profiles/profile.html
@@ -138,7 +138,7 @@
         {% endif %}
       </script>
 
-      {% bundle merge_js file jitsi %}
+      {% bundle merge_js file profile_jitsi %}
         <script src="external_api.min.js" base-dir="/node_modules/lib-jitsi-meet-dist/dist"></script>
       {% endbundle %}
 

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -1304,7 +1304,7 @@
     <script defer src='https://cdn.jsdelivr.net/npm/quill@1.3.6/dist/quill.min.js'></script>
     <script defer src='https://cdn.jsdelivr.net/npm/vue-quill-editor@3.0.6/dist/vue-quill-editor.js'></script>
     {{currentProfile|json_script:"current-profile"}}
-    {% bundle merge_js file jitsi %}
+    {% bundle merge_js file jitsi_tribes %}
       <script src="external_api.min.js" base-dir="/node_modules/lib-jitsi-meet-dist/dist"></script>
     {% endbundle %}
     <script src='{% static "v2/js/pages/profile-tribes.js" %}'></script>

--- a/app/dataviz/templates/cohort.html
+++ b/app/dataviz/templates/cohort.html
@@ -48,7 +48,7 @@
   <!-- code to include the highcharts and jQuery libraries goes here -->
   <!-- load_charts filter takes a comma-separated list of id's where -->
   <!-- the charts need to be rendered to               -->
-  {% bundle merge_js file jquery %}
+  {% bundle merge_js file jquery_cohort %}
     <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
   {% endbundle %}
 </head>

--- a/app/dataviz/templates/dataviz/admin_graph.html
+++ b/app/dataviz/templates/dataviz/admin_graph.html
@@ -21,7 +21,7 @@
 {% load i18n admin_static static bundle %}
 
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file admin_dashboard_graph %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}
@@ -38,7 +38,7 @@
 {% block content %}
   <head>
   <meta charset="utf-8">
-  {% bundle merge_js file jquery %}
+  {% bundle merge_js file jquery_admin_graph %}
     <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
   {% endbundle %}
   <script src="//d3js.org/d3.v2.min.js?2.9.3"></script>

--- a/app/dataviz/templates/dataviz/graph.html
+++ b/app/dataviz/templates/dataviz/graph.html
@@ -20,11 +20,11 @@
 
 <head>
   <meta charset="utf-8">
-  {% bundle merge_js file jquery %}
+  {% bundle merge_js file jquery_admin_dashboard_graph %}
     <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
   {% endbundle %}
   <script src="//d3js.org/d3.v2.min.js?2.9.3"></script>
-  {% bundle css file admin_dashboard %}
+  {% bundle css file dataviz_graph %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
   <style>

--- a/app/dataviz/templates/dataviz/mesh.html
+++ b/app/dataviz/templates/dataviz/mesh.html
@@ -17,7 +17,7 @@
 {% endcomment %}
 {% load i18n static bundle %}
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file admin_dashboard_mesh %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}

--- a/app/dataviz/templates/dataviz/scatterplot_stripped.html
+++ b/app/dataviz/templates/dataviz/scatterplot_stripped.html
@@ -19,7 +19,7 @@ body {
 }
 </style>
 
-{% bundle merge_js file jquery %}
+{% bundle merge_js file jquery_scatterplot_stripped %}
   <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
 {% endbundle %}
 <script src="//d3js.org/d3.v3.min.js"></script>

--- a/app/dataviz/templates/funnel.html
+++ b/app/dataviz/templates/funnel.html
@@ -21,7 +21,7 @@
 {% load i18n static bundle %}
 
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file admin_dashboard_funnel %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}
@@ -48,7 +48,7 @@
   <!-- code to include the highcharts and jQuery libraries goes here -->
   <!-- load_charts filter takes a comma-separated list of id's where -->
   <!-- the charts need to be rendered to               -->
-  {% bundle merge_js file jquery %}
+  {% bundle merge_js file jquery_funnel %}
     <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
   {% endbundle %}
 </head>

--- a/app/dataviz/templates/stats.html
+++ b/app/dataviz/templates/stats.html
@@ -17,7 +17,7 @@
 {% endcomment %}
 {% load i18n static bundle %}
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file admin_dashboard_stats %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}
@@ -51,7 +51,7 @@
   <!-- code to include the highcharts and jQuery libraries goes here -->
   <!-- load_charts filter takes a comma-separated list of id's where -->
   <!-- the charts need to be rendered to                             -->
-  {% bundle merge_js file jquery %}
+  {% bundle merge_js file jquery_stats %}
     <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
   {% endbundle %}
   {% if format == 'chart' %}

--- a/app/grants/templates/grants/cart-vue.html
+++ b/app/grants/templates/grants/cart-vue.html
@@ -285,7 +285,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       document.disablePolygon = '{{ disablePolygon }}' === 'true';
 
     </script>
-    {% bundle merge_js file qrcode %}
+    {% bundle merge_js file grants_cart_qrcode %}
       <script src="qrcode.min.js" base-dir="/node_modules/qrcodejs/"></script>
     {% endbundle %}
     <script src="/dynamic/js/tokens_dynamic.js"></script>

--- a/app/grants/templates/grants/collage.html
+++ b/app/grants/templates/grants/collage.html
@@ -9,7 +9,7 @@
 
 </div>
 
-{% bundle merge_js file jquery %}
+{% bundle merge_js file collage_jquery %}
   <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
 {% endbundle %}
 

--- a/app/grants/templates/grants/detail/_index.html
+++ b/app/grants/templates/grants/detail/_index.html
@@ -463,7 +463,7 @@
       {% include 'shared/footer_scripts.html' with slim=1 ignore_inject_web3=1 %}
       <script src='https://cdn.jsdelivr.net/npm/quill@1.3.6/dist/quill.min.js'></script>
       <script src='https://cdn.jsdelivr.net/npm/vue-quill-editor@3.0.6/dist/vue-quill-editor.js'></script>
-      {% bundle js file quill-image-extend-module %}
+      {% bundle js file grants-details-quill-image-extend-module %}
         <script>
           // use webpack to build ImageExtend
           import { QuillWatch, ImageExtend } from 'quill-image-extend-module';

--- a/app/grants/templates/grants/explorer.html
+++ b/app/grants/templates/grants/explorer.html
@@ -19,7 +19,7 @@ along with this program. If not, see
 <head>
   {% include 'shared/head.html' with slim=1 %}
   {% include 'shared/cards_pic.html' %}
-  {% bundle css file grants %}
+  {% bundle css file grants_explorer %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/search_bar.scss" %} />
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/kudos/styles.scss" %} />
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/grants/card.scss" %} />

--- a/app/grants/templates/grants/landing/index.html
+++ b/app/grants/templates/grants/landing/index.html
@@ -19,7 +19,7 @@ along with this program. If not, see
 <head>
   {% include 'shared/head.html' with slim=1 %}
   {% include 'shared/cards_pic.html' %}
-  {% bundle css file grants %}
+  {% bundle css file grants_landing %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/search_bar.scss" %} />
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/kudos/styles.scss" %} />
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/grants/card.scss" %} />
@@ -167,7 +167,7 @@ along with this program. If not, see
   {{grant_bg.inline_css|json_script:"inline_css"}}
   <script src='https://cdn.jsdelivr.net/npm/quill@1.3.6/dist/quill.min.js'></script>
   <script src='https://cdn.jsdelivr.net/npm/vue-quill-editor@3.0.6/dist/vue-quill-editor.js'></script>
-  {% bundle js file quill-image-extend-module %}
+  {% bundle js file grants-landing-quill-image-extend-module %}
     <script>
       // use webpack to build ImageExtend
       import { QuillWatch, ImageExtend } from 'quill-image-extend-module';
@@ -228,7 +228,7 @@ along with this program. If not, see
   <script src="{% static "v2/js/grants/_detail-component.js" %}"></script>
   <!-- <script src="{% static "v2/js/grants/funding.js" %}"></script> -->
   <script src="{% static "v2/js/grants/landingpage.js" %}"></script>
-  {% bundle merge_js file discover_grants_svgs %}
+  {% bundle merge_js file discover_grants_landing_svgs %}
     <script src="{% static "v2/js/lib/svgator_player.js" %}"></script>
     <script>
       // undiscovered gems

--- a/app/grants/templates/grants/new_match.html
+++ b/app/grants/templates/grants/new_match.html
@@ -22,7 +22,7 @@
   <head>
     {% include 'shared/head.html' with slim=1 %}
     {% include 'shared/cards.html' %}
-    {% bundle css file grants_simple %}
+    {% bundle css file grants_simple_new_match %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/grants/new.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/tabs.scss" %} />
     {% endbundle %}

--- a/app/kudos/templates/kudos_details.html
+++ b/app/kudos/templates/kudos_details.html
@@ -195,7 +195,7 @@
       </section>
 
       {% include 'shared/footer.html' %}
-      {% bundle merge_js file tweenlite %}
+      {% bundle merge_js file tweenlite_kudos %}
         <script src="gsap.min.js" base-dir="/node_modules/gsap/dist"></script>
       {% endbundle %}
       {% include 'shared/footer_scripts.html' with slim=1 %}
@@ -204,7 +204,7 @@
       <script src="{% static "v2/js/amounts.js" %}"></script>
       <script src="{% static "v2/js/eth-price.js" %}"></script>
       {% include 'shared/activity_scripts.html' %}
-      {% bundle css file activity_stream %}
+      {% bundle css file kudos_details_activity_stream %}
         <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/activity_stream.scss" %} />
       {% endbundle %}
       <script src="{% static "v2/js/status.js" %}"></script>

--- a/app/kudos/templates/kudos_marketplace.html
+++ b/app/kudos/templates/kudos_marketplace.html
@@ -4,7 +4,7 @@
   <head>
     {% include 'shared/head.html' %}
     {% include 'shared/cards_pic.html' %}
-    {% bundle css file kudos_styles %}
+    {% bundle css file kudos_styles_marketplace %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/kudos/styles.scss" %} />
     {% endbundle %}
   </head>

--- a/app/kudos/templates/transaction/base.html
+++ b/app/kudos/templates/transaction/base.html
@@ -20,7 +20,7 @@
   <head>
     {% include 'shared/head.html' %}
     {% include 'shared/cards_pic.html' %}
-    {% bundle css file kudos_styles %}
+    {% bundle css file kudos_styles_transaction %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/kudos/styles.scss" %} />
     {% endbundle %}
     <script>

--- a/app/kudos/templates/transaction/receive.html
+++ b/app/kudos/templates/transaction/receive.html
@@ -18,7 +18,7 @@
 {% load i18n static kudos_extras bundle %}
 {% block 'scripts' %}
 
-  {% bundle merge_js file receive %}
+  {% bundle merge_js file receive_kudos %}
     <script src="index.min.js" base-dir="/node_modules/ipfs-api/dist/"></script>
     <script src="secrets.min.js" base-dir="/node_modules/secrets.js-grempe/"></script>
     <script src="{% static "v2/js/ipfs.js" %}"></script>

--- a/app/kudos/templates/transaction/send.html
+++ b/app/kudos/templates/transaction/send.html
@@ -21,7 +21,7 @@
 
   <script src="/dynamic/js/tokens_dynamic.js"></script>
 
-  {% bundle merge_js file send %}
+  {% bundle merge_js file send_kudos %}
     <script src="index.min.js" base-dir="/node_modules/ipfs-api/dist/"></script>
     <script src="secrets.min.js" base-dir="/node_modules/secrets.js-grempe/"></script>
     <script src="{% static "v2/js/tokens.js" %}"></script>

--- a/app/quests/templates/quests/index.html
+++ b/app/quests/templates/quests/index.html
@@ -579,7 +579,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock %}
 
 {% block 'scripts' %}
-  {% bundle merge_js file unveil %}
+  {% bundle merge_js file quests_unveil %}
     <script src="jquery.unveil.js" base-dir="/node_modules/jquery-unveil/"></script>
   {% endbundle %}
   <script src="{% static "v2/js/pages/quests.index.js" %}"></script>

--- a/app/quests/templates/quests/new.html
+++ b/app/quests/templates/quests/new.html
@@ -247,7 +247,7 @@
   $('[data-toggle="tooltip"]').bootstrapTooltip();
 </script>
 
-{% bundle merge_js file unveil %}
+{% bundle merge_js file quests_new_unveil %}
   <script src="jquery.unveil.js" base-dir="/node_modules/jquery-unveil/"></script>
 {% endbundle %}
 <script>

--- a/app/retail/templates/admin/index.html
+++ b/app/retail/templates/admin/index.html
@@ -18,7 +18,7 @@
 {% endcomment %}
 {% load i18n static bundle %}
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file retail_admin_dashboard %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}

--- a/app/retail/templates/bounties/contributor.html
+++ b/app/retail/templates/bounties/contributor.html
@@ -29,7 +29,7 @@
     (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
     })(window,document.documentElement,'async-hide','dataLayer',4000,
     {'GTM-NP2J8TX':true});</script>
-    {% bundle css file howitworks %}
+    {% bundle css file howitworks_contributor %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/landing_page.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/howitworks.scss" %} />
     {% endbundle %}

--- a/app/retail/templates/bounties/contributor/activity.html
+++ b/app/retail/templates/bounties/contributor/activity.html
@@ -15,7 +15,7 @@
   along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endcomment %}
 {% load i18n static bundle %}
-{% bundle css file activity_stream %}
+{% bundle css file bounties_activity_stream %}
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/activity_stream.scss" %} />
 {% endbundle %}
 <style>

--- a/app/retail/templates/email_unsubscribed.html
+++ b/app/retail/templates/email_unsubscribed.html
@@ -49,7 +49,7 @@
 </body>
 
 <!-- jQuery -->
-{% bundle merge_js file jquery %}
+{% bundle merge_js file jquery_email_unsubscribe %}
   <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
 {% endbundle %}
 

--- a/app/retail/templates/gas_guzzler.html
+++ b/app/retail/templates/gas_guzzler.html
@@ -2,7 +2,7 @@
 {% load i18n static bundle %}
 {% block 'scripts' %}
 
-{% bundle merge_js file jquery %}
+{% bundle merge_js file jquery_gas_guzzler %}
   <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
 {% endbundle %}
 

--- a/app/retail/templates/gas_history.html
+++ b/app/retail/templates/gas_history.html
@@ -1,7 +1,7 @@
 {% extends 'onepager/base.html' %}
 {% load i18n static date_fromisoformat timesince_fromisoformat bundle %}
 {% block 'scripts' %}
-{% bundle merge_js file jquery %}
+{% bundle merge_js file jquery_gas_history %}
   <script src="jquery.min.js" base-dir="/node_modules/jquery/dist/"></script>
 {% endbundle %}
 <script src="{% static "v2/js/pages/hackathon-list.js" %}"></script>

--- a/app/retail/templates/jtbd/connect.html
+++ b/app/retail/templates/jtbd/connect.html
@@ -25,7 +25,7 @@ along with this program. If not,see
   {% include 'shared/head.html' %}
   {% include 'shared/cards_pic.html' %}
 
-  {% bundle css file jtbd %}
+  {% bundle css file jtbd_connect %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/jtbd.scss" %} />
   {% endbundle %}
 </head>

--- a/app/retail/templates/jtbd/earn.html
+++ b/app/retail/templates/jtbd/earn.html
@@ -25,11 +25,11 @@ along with this program. If not,see
   {% include 'shared/head.html' %}
   {% include 'shared/cards_pic.html' %}
 
-  {% bundle css file jtbd %}
+  {% bundle css file jtbd_earn %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/jtbd.scss" %} />
   {% endbundle %}
 
-  {% bundle css file jtbd_earn %}
+  {% bundle css file jtbd_tag_earn %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/tag.scss" %} />
   {% endbundle %}
 </head>

--- a/app/retail/templates/jtbd/fund.html
+++ b/app/retail/templates/jtbd/fund.html
@@ -24,7 +24,7 @@ along with this program. If not,see
   {% include 'shared/head.html' %}
   {% include 'shared/cards_pic.html' %}
 
-  {% bundle css file jtbd %}
+  {% bundle css file jtbd_fund %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/jtbd.scss" %} />
   {% endbundle %}
 </head>

--- a/app/retail/templates/jtbd/learn.html
+++ b/app/retail/templates/jtbd/learn.html
@@ -24,7 +24,7 @@ along with this program. If not,see
   {% include 'shared/head.html' %}
   {% include 'shared/cards_pic.html' %}
 
-  {% bundle css file jtbd %}
+  {% bundle css file jtbd_learn %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/jtbd.scss" %} />
   {% endbundle %}
 </head>

--- a/app/retail/templates/newtoken.html
+++ b/app/retail/templates/newtoken.html
@@ -17,7 +17,7 @@
 {% endcomment %}
 {% load i18n static bundle %}
 {% block body %}
-{% bundle css file onepagesubmit %}
+{% bundle css file retail_new_token %}
   <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/onepagesubmit.scss" %} />
 {% endbundle %}
 <div class="container-fluid">

--- a/app/retail/templates/process_accesscode_request.html
+++ b/app/retail/templates/process_accesscode_request.html
@@ -20,7 +20,7 @@
 {% load i18n static bundle %}
 
 {% block extrastyle %}{{ block.super }}
-  {% bundle css file admin_dashboard %}
+  {% bundle css file proc_accesscode_req_admin_dashboard %}
     <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/admin/dashboard.scss" %} />
   {% endbundle %}
 {% endblock %}

--- a/app/retail/templates/results.html
+++ b/app/retail/templates/results.html
@@ -601,7 +601,7 @@
       {% include 'shared/footer_scripts.html' %}
 
 
-      {% bundle merge_js file unveil %}
+      {% bundle merge_js file retail_unveil %}
         <script src="jquery.unveil.js" base-dir="/node_modules/jquery-unveil/"></script>
       {% endbundle %}
     </div>

--- a/app/retail/templates/styleguide_components.html
+++ b/app/retail/templates/styleguide_components.html
@@ -23,7 +23,7 @@
   <head>
     {% include 'shared/head.html' %}
     <script src="//cdn.quilljs.com/1.3.6/quill.core.js"></script>
-    {% bundle css file new_grant %}
+    {% bundle css file new_grant_guide %}
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/lib/quill.bubble.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/lib/quill.snow.scss" %} />
       <link rel="stylesheet" type="text/x-scss" href={% static "v2/scss/grants/new.scss" %} />

--- a/app/townsquare/templates/townsquare/new.html
+++ b/app/townsquare/templates/townsquare/new.html
@@ -149,7 +149,7 @@
   $('[data-toggle="tooltip"]').bootstrapTooltip();
 </script>
 
-{% bundle merge_js file unveil %}
+{% bundle merge_js file townswuare_new_unveil %}
   <script src="jquery.unveil.js" base-dir="/node_modules/jquery-unveil/"></script>
 {% endbundle %}
 <script>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

This is an issue in our new path to production, as we drop the hashes that are appended to bundle files. 

Those hashes depend on the environment where they are run (on the static configuration), and since we will generate the bundles in the GHA workflow, the hashes calculated will be different compared to the ones that are calculated in production, staging or review environment.

Since the filenames specified in the `{% bundle ... ` are duplicate (uniqueness was only ensured by the hashes) we must rename all duplicate occurrences.

In order to ensure that no such duplicate slips through, I have also modified the `bundle` command to fail when a duplicate is encountered on generation (see screenshot below).

Changes:
- have added a check in the command that raises an error if a file with duplicate name is generated
- have adjusted all {% bundle ... %} tag usage, and set unique file name

<!-- Describe your changes here. -->

##### Refers/Fixes

No specific issue exists, This is a change required for our path to production.
<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

Has been tested locally & in the gha workflow

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

When a duplicate is encountered, this will generate an error and stop the pipeline:
<img width="949" alt="image" src="https://user-images.githubusercontent.com/8137830/165582291-e888c561-38c5-4ea8-861d-bcd4f65b2ef3.png">

