### PR TITLE
defaulting to mainnet for portis wallet, finding networkId from porti…

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1064,8 +1064,6 @@ Vue.component('grants-cart', {
         await await onConnect();
       }
 
-      // console.log({web3}, web3.eth.currentProvider, web3.eth.currentProvider.chainId, 'web3.eth.currentProvider.chainId', String(Number(web3.eth.currentProvider.chainId)), 'String(Number(web3.eth.currentProvider.chainId)');
-      // let networkId = String(Number(web3.eth.currentProvider.chainId));
       let networkName = getDataChains(this.networkId, 'chainId')[0] && getDataChains(this.networkId, 'chainId')[0].network;
 
       if (networkName == 'mainnet' && this.networkId !== '1') {

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -11,7 +11,11 @@ let appCart;
 
 document.addEventListener('dataWalletReady', async function(e) {
   appCart.$refs['cart'].network = networkName;
-  appCart.$refs['cart'].networkId = String(Number(web3.eth.currentProvider.chainId));
+  if (web3.eth.currentProvider.isPortis) {
+    appCart.$refs['cart'].networkId = web3.eth.currentProvider._portis._config.network.chainId;
+  } else {
+    appCart.$refs['cart'].networkId = String(Number(web3.eth.currentProvider.chainId));
+  }
 }, false);
 
 // needWalletConnection();
@@ -1060,10 +1064,11 @@ Vue.component('grants-cart', {
         await await onConnect();
       }
 
-      let networkId = String(Number(web3.eth.currentProvider.chainId));
-      let networkName = getDataChains(networkId, 'chainId')[0] && getDataChains(networkId, 'chainId')[0].network;
+      // console.log({web3}, web3.eth.currentProvider, web3.eth.currentProvider.chainId, 'web3.eth.currentProvider.chainId', String(Number(web3.eth.currentProvider.chainId)), 'String(Number(web3.eth.currentProvider.chainId)');
+      // let networkId = String(Number(web3.eth.currentProvider.chainId));
+      let networkName = getDataChains(this.networkId, 'chainId')[0] && getDataChains(this.networkId, 'chainId')[0].network;
 
-      if (networkName == 'mainnet' && networkId !== '1') {
+      if (networkName == 'mainnet' && this.networkId !== '1') {
         // User MetaMask must be connected to Ethereum mainnet
         try {
           await ethereum.request({
@@ -1131,6 +1136,7 @@ Vue.component('grants-cart', {
         const tokenName = selectedTokens[i];
         const tokenDetails = this.getTokenByName(tokenName, isPolygon);
 
+        console.log({ tokenDetails });
         // If native currency donation no approval is necessary, just check balance
         if (tokenDetails.name === this.nativeCurrency) {
           const userEthBalance = await web3.eth.getBalance(userAddress);

--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1134,7 +1134,6 @@ Vue.component('grants-cart', {
         const tokenName = selectedTokens[i];
         const tokenDetails = this.getTokenByName(tokenName, isPolygon);
 
-        console.log({ tokenDetails });
         // If native currency donation no approval is necessary, just check balance
         if (tokenDetails.name === this.nativeCurrency) {
           const userEthBalance = await web3.eth.getBalance(userAddress);

--- a/app/assets/v2/js/wallet.js
+++ b/app/assets/v2/js/wallet.js
@@ -44,7 +44,8 @@ function initWallet() {
     portis: {
       'package': Portis,
       options: {
-        id: 'b2345081-a47e-413a-941f-33fd645d39b3'
+        id: 'b2345081-a47e-413a-941f-33fd645d39b3',
+        network: 'mainnet'
       }
     }
   };


### PR DESCRIPTION
##### Description

It looks like, when using portis wallet, there was an issue finding the networkId which is used to filter out tokens on the checkout page. 

I also was unable to switch the portis wallet to any network beside rinkeby. While looking through the docs it looks like they are expecting a network parameter https://docs.portis.io/#/quick-start. 

##### Refers/Fixes

fixes: #10429 
