### PR TITLE
bug: ensure older claims show up after contract is drained

### DIFF
--- a/app/grants/templates/grants/components/historical_claim.html
+++ b/app/grants/templates/grants/components/historical_claim.html
@@ -16,7 +16,7 @@
         Claim Period: [[ match.grant_payout.grant_clrs[0].claim_start_date ]] - [[ match.grant_payout.grant_clrs[0].claim_end_date ]]
       </span>
     </b-col>
-    <b-col v-else-if="match.status == 'claimed'" lg="4" sm="12" class="mt-2 mt-lg-0">
+    <b-col v-else-if="match.status == 'claimed' || match.claim_tx != 'NA'" lg="4" sm="12" class="mt-2 mt-lg-0">
       <p class="text-highlight-green font-weight-bold claimed_text">
         <i class="far fa-check mr-2"></i>Claimed
       </p>
@@ -29,7 +29,10 @@
       <span class="font-body text-grey-500">[[ match.funding_withdrawal_date ]]</span>
     </b-col>
     <b-col class="text-lg-right mt-2 mt-lg-0">
-      <a v-if="match.claim_tx" :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]" target="_blank" rel="noopener noreferrer" class="transaction_text">
+      <a v-if="match.claim_tx && match.claim_tx != 'NA' "
+        :href="[[`https://etherscan.io/tx/${match.claim_tx}` ]]"
+        target="_blank" rel="noopener noreferrer" class="transaction_text"
+      >
         View Transaction<i class="far fa-external-link ml-2"></i>
       </a>
     </b-col>


### PR DESCRIPTION
##### Description

> I would add a bug here. 
e.g my grant https://gitcoin.co/grants/2922/gitcoin-governance-chinese-ecosystem-development
I have claimed GR12, but the status showed Returned to matching pool (tx is https://etherscan.io/tx/0x808152f5e0be029a351c3d03387f5075ef1b2e6b57ae2a6bdf19838901e67453)


Looks like for the older contracts (non merkle), the status is set to NA despite have a claim tx id.
The reason is the older contracts rely on a diff abi to check balance. To account for that , we need to tweak our conditions to ensure to check claim_tx_id is set before checking if status is contract is funding_withdrawn


##### Refers/Fixes

https://discord.com/channels/562828676480237578/963768450445082645/965417369801457704

##### Testing

![image](https://user-images.githubusercontent.com/5358146/163797613-2b857451-bb26-4451-bac2-516b0f26cd73.png)
