### PR TITLE
Update web3Modal version

### DIFF
--- a/app/retail/templates/shared/footer_scripts.html
+++ b/app/retail/templates/shared/footer_scripts.html
@@ -51,7 +51,7 @@
   <script src="index.js" base-dir="/node_modules/@joeattardi/emoji-button/dist/"></script>
 {% endbundle %}
 
-<script src="https://cdn.jsdelivr.net/npm/web3modal@1.9.3/dist/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/web3modal@1.9.6/dist/index.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/authereum@latest/authereum.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@portis/web3@4.0.5/umd/index.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/fortmatic/dist/fortmatic.js"></script>


### PR DESCRIPTION

##### Description

Bump the web3Modal version to 1.9.6. This version of web3Modal incorporates addition of TallyHo injected provider.

##### Refers/Fixes

N/A

##### Testing

N/A
