### PR TITLE
fix cannot read properties of undefined

### DIFF
--- a/app/assets/v2/js/data-chains.js
+++ b/app/assets/v2/js/data-chains.js
@@ -4,6 +4,45 @@
 var dataChains =
 [
   {
+    "name": "Binance Smart Chain Mainnet",
+    "chain": "BSC",
+    "rpc": [
+      "https://bsc-dataseed1.binance.org",
+      "https://bsc-dataseed2.binance.org",
+      "https://bsc-dataseed3.binance.org",
+      "https://bsc-dataseed4.binance.org",
+      "https://bsc-dataseed1.defibit.io",
+      "https://bsc-dataseed2.defibit.io",
+      "https://bsc-dataseed3.defibit.io",
+      "https://bsc-dataseed4.defibit.io",
+      "https://bsc-dataseed1.ninicoin.io",
+      "https://bsc-dataseed2.ninicoin.io",
+      "https://bsc-dataseed3.ninicoin.io",
+      "https://bsc-dataseed4.ninicoin.io",
+      "wss://bsc-ws-node.nariox.org"
+    ],
+    "faucets": [
+      "https://free-online-app.com/faucet-for-eth-evm-chains/"
+    ],
+    "nativeCurrency": {
+      "name": "Binance Chain Native Token",
+      "symbol": "BNB",
+      "decimals": 18
+    },
+    "infoURL": "https://www.binance.org",
+    "shortName": "bnb",
+    "chainId": 56,
+    "networkId": 56,
+    "slip44": 714,
+    "explorers": [
+      {
+        "name": "bscscan",
+        "url": "https://bscscan.com",
+        "standard": "EIP3091"
+      }
+    ]
+  },
+  {
     "name": "Bitcoin Mainnet",
     "chainId": 0,
     "shortName": "btc",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/761285/164970933-6781a53d-d5e6-4101-abec-d80e6a8e3587.png)

##### Description

If MetaMask selected `BSC` got  `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'split') at fetchAccountDat`

##### Refers/Fixes

#9701

##### Testing

The expected result is the absence of the specified error in the console if network is selected `BSC` in the MetaMask
