### PR TITLE
Reindex elastic to only inlcude active grant 

### DIFF
--- a/app/grants/tasks.py
+++ b/app/grants/tasks.py
@@ -115,7 +115,7 @@ def update_grant_metadata(self, grant_id, retry: bool = True) -> None:
 
     print(lineno(), round(time.time(), 2))
     from search.models import SearchResult
-    if instance.pk:
+    if instance.pk and instance.active and not instance.hidden:
         SearchResult.objects.update_or_create(
             source_type=ContentType.objects.get(app_label='grants', model='grant'),
             source_id=instance.pk,

--- a/app/search/management/commands/create_search_index_with_active_grants.py
+++ b/app/search/management/commands/create_search_index_with_active_grants.py
@@ -15,20 +15,11 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
-<<<<<<< HEAD
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from grants.models import Grant
 from search.models import SearchResult
-=======
-from django.core.management.base import BaseCommand
-from django.contrib.contenttypes.models import ContentType
-
-from search.models import SearchResult
-from grants.models import Grant
->>>>>>> 2fdf19976a (added command to update searchresult model to only include active grants, and index those results into elastic search)
-
 
 class Command(BaseCommand):
     help = 'uploads latest search results into elasticsearch'
@@ -68,8 +59,5 @@ class Command(BaseCommand):
                 sr.put_on_elasticsearch(index_name)
             except Exception as e:
                 print('failed:', e)
-<<<<<<< HEAD
+
         print('indexing complete')
-=======
-        print('indexing complete')
->>>>>>> 2fdf19976a (added command to update searchresult model to only include active grants, and index those results into elastic search)

--- a/app/search/management/commands/create_search_index_with_active_grants.py
+++ b/app/search/management/commands/create_search_index_with_active_grants.py
@@ -15,11 +15,19 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
+<<<<<<< HEAD
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from grants.models import Grant
 from search.models import SearchResult
+=======
+from django.core.management.base import BaseCommand
+from django.contrib.contenttypes.models import ContentType
+
+from search.models import SearchResult
+from grants.models import Grant
+>>>>>>> 2fdf19976a (added command to update searchresult model to only include active grants, and index those results into elastic search)
 
 
 class Command(BaseCommand):
@@ -60,4 +68,8 @@ class Command(BaseCommand):
                 sr.put_on_elasticsearch(index_name)
             except Exception as e:
                 print('failed:', e)
+<<<<<<< HEAD
         print('indexing complete')
+=======
+        print('indexing complete')
+>>>>>>> 2fdf19976a (added command to update searchresult model to only include active grants, and index those results into elastic search)

--- a/app/search/management/commands/create_search_index_with_active_grants.py
+++ b/app/search/management/commands/create_search_index_with_active_grants.py
@@ -1,0 +1,63 @@
+'''
+    Copyright (C) 2021 Gitcoin Core
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+'''
+from django.core.management.base import BaseCommand
+from django.contrib.contenttypes.models import ContentType
+
+from search.models import SearchResult
+from grants.models import Grant
+
+
+class Command(BaseCommand):
+    help = 'uploads latest search results into elasticsearch'
+
+    def add_arguments(self, parser):
+        parser.add_argument('index_name', type=str, help='the name of the new elastic index')
+
+    def create_grant_records(self):
+        for grant in Grant.objects.filter(active=True, hidden=False):
+            SearchResult.objects.update_or_create(
+                source_type=ContentType.objects.get(app_label='grants', model='grant'),
+                source_id=grant.pk,
+                defaults={
+                    "created_on":grant.created_on,
+                    "title":grant.title,
+                    "description":grant.description,
+                    "url":grant.url,
+                    "visible_to":None,
+                    'img_url': grant.logo.url if grant.logo else None,
+                }
+            )
+
+    def handle(self, *args, **options):
+        index_name = options['index_name']
+
+        # delete existing grants from search results
+        SearchResult.objects.filter(source_type_id=82).delete()
+        print('deleted old grant search results')
+
+        # Create rows for existing search results
+        self.create_grant_records()
+        print('created new search results for grants')
+
+        for sr in SearchResult.objects.all():
+            print(sr.pk)
+            try:
+                sr.put_on_elasticsearch(index_name)
+            except Exception as e:
+                print('failed:', e)
+        print('indexing complete')

--- a/app/search/management/commands/create_search_index_with_active_grants.py
+++ b/app/search/management/commands/create_search_index_with_active_grants.py
@@ -15,11 +15,11 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 '''
-from django.core.management.base import BaseCommand
 from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
 
-from search.models import SearchResult
 from grants.models import Grant
+from search.models import SearchResult
 
 
 class Command(BaseCommand):

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -28,7 +28,7 @@ class SearchResult(SuperModel):
         grant = Grant.objects.get(pk=self.source_id)
         return grant.active and not grant.hidden
         
-    def put_on_elasticsearch(self):
+    def put_on_elasticsearch(self, index='search-index'):
         if self.visible_to:
             return None
 
@@ -50,7 +50,7 @@ class SearchResult(SuperModel):
             'timestamp': timezone.now(),
             'source_type': source_type,
         }
-        res = es.index(index="search-index", id=self.pk, body=doc)
+        res = es.index(index=index, id=self.pk, body=doc)
 
 
 def search(query, page=0, num_results=500):
@@ -58,6 +58,7 @@ def search(query, page=0, num_results=500):
         return {}
     es = Elasticsearch([settings.ELASTIC_SEARCH_URL])
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant
+    # index name will need updated once index is ready to be searched
     res = es.search(index="search-index", body={
       "from" : page, "size" : num_results,
       "query": {

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -5,8 +5,8 @@ from django.db import models
 from django.utils import timezone
 
 from economy.models import SuperModel
-from grants.models import Grant
 from elasticsearch import Elasticsearch
+from grants.models import Grant
 
 
 class SearchResult(SuperModel):


### PR DESCRIPTION
##### Description

Deleted and inactive grants were being returned from search results. This adds a new command to create a new index that only includes active grants. It also should check for grants being active and/or hidden before it saves them and indexes them into the search model as well as the elastic index. A new index had to be created since grants were being deleted from the django admin and it was impossible to detect which grants had been deleted.

This is the command to create the new index: docker-compose exec web python3 app/manage.py create_search_index_with_active_grants {index-name}. 

Once this is merged the command should be ran to create the new index. Once the index is created we should be able to merge https://github.com/gitcoinco/web/pull/10557

##### Refers/Fixes

Fixes: #10478 

