### PR TITLE
Allow smart contract wallets to obtain Proof of Humanity trust bonus

### DIFF
--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -833,7 +833,7 @@ Vue.component('poh-verify-modal', {
             </div>
             <div v-if="step === 'validation-complete'">
               <div>
-                Your Proof of Humanity verification was successful. Thank you for helping make Gitcoin mroe sybil resistant!
+                Your Proof of Humanity verification was successful. Thank you for helping make Gitcoin more sybil resistant!
               </div>
               <b-button @click="dismissVerification" variant="primary" class="btn btn-primary mt-5 px-5 float-right">Done</b-button>
             </div>

--- a/app/dashboard/poh_utils.py
+++ b/app/dashboard/poh_utils.py
@@ -2,6 +2,7 @@ POH_CONTRACT_ADDRESS = '0xC5E9dDebb09Cd64DfaCab4011A0D5cEDaf7c9BDb'
 
 _poh_contract = None
 
+
 def get_poh_contract(web3):
     global _poh_contract
     if _poh_contract is None:

--- a/app/dashboard/poh_utils.py
+++ b/app/dashboard/poh_utils.py
@@ -1,7 +1,18 @@
+import json
+
 POH_CONTRACT_ADDRESS = '0xC5E9dDebb09Cd64DfaCab4011A0D5cEDaf7c9BDb'
 
 _poh_contract = None
 
+EIP_1271_ABI = '[{"constant":true,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":false,"stateMutability":"view","type":"function"}]'
+
+def is_valid_eip_1271_signature(web3, address, hash, signature) -> bool:
+    try:
+        eip_1271_contract = web3.eth.contract(address=address, abi=json.loads(EIP_1271_ABI))
+        retval = eip_1271_contract.functions.isValidSignature(hash, signature).call()
+        return web3.toInt(retval) == 0x1626ba7e
+    except Exception as e:
+        return False
 
 def get_poh_contract(web3):
     global _poh_contract

--- a/app/dashboard/poh_utils.py
+++ b/app/dashboard/poh_utils.py
@@ -1,14 +1,12 @@
-import json
-
 POH_CONTRACT_ADDRESS = '0xC5E9dDebb09Cd64DfaCab4011A0D5cEDaf7c9BDb'
 
 _poh_contract = None
 
-EIP_1271_ABI = '[{"constant":true,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":false,"stateMutability":"view","type":"function"}]'
+EIP_1271_ABI = [{"constant":True,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":False,"stateMutability":"view","type":"function"}]
 
 def is_valid_eip_1271_signature(web3, address, hash, signature) -> bool:
     try:
-        eip_1271_contract = web3.eth.contract(address=address, abi=json.loads(EIP_1271_ABI))
+        eip_1271_contract = web3.eth.contract(address=address, abi=EIP_1271_ABI)
         retval = eip_1271_contract.functions.isValidSignature(hash, signature).call()
         return web3.toInt(retval) == 0x1626ba7e
     except Exception as e:

--- a/app/dashboard/poh_utils.py
+++ b/app/dashboard/poh_utils.py
@@ -2,16 +2,6 @@ POH_CONTRACT_ADDRESS = '0xC5E9dDebb09Cd64DfaCab4011A0D5cEDaf7c9BDb'
 
 _poh_contract = None
 
-EIP_1271_ABI = [{"constant":True,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":False,"stateMutability":"view","type":"function"}]
-
-def is_valid_eip_1271_signature(web3, address, hash, signature) -> bool:
-    try:
-        eip_1271_contract = web3.eth.contract(address=address, abi=EIP_1271_ABI)
-        retval = eip_1271_contract.functions.isValidSignature(hash, signature).call()
-        return web3.toInt(retval) == 0x1626ba7e
-    except Exception as e:
-        return False
-
 def get_poh_contract(web3):
     global _poh_contract
     if _poh_contract is None:

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -3244,28 +3244,41 @@ def verify_user_twitter(request, handle):
                 'msg': msg
             })
 
-        last_tweet = api.user_timeline(screen_name=twitter_handle, count=1, tweet_mode="extended",
-                                       include_rts=False, exclude_replies=False)[0]
+        verification_tweet = None
+        last_10_tweets = api.user_timeline(screen_name=twitter_handle, count=10, tweet_mode="extended",
+                                       include_rts=False, exclude_replies=False)
+        for tweet in last_10_tweets:
+            if tweet.full_text.startswith("I am verifying my identity as"):
+                verification_tweet = tweet
+                break
+
     except tweepy.TweepError as e:
         logger.error(f"error: verify_user_twitter TweepError {e}")
         return JsonResponse({
             'ok': False,
-            'msg': f'Sorry, we couldn\'t get the last tweet from @{twitter_handle}'
+            'msg': f'Sorry, we couldn\'t get the verification tweet from @{twitter_handle}'
         })
     except IndexError as e:
         logger.error(f"error: verify_user_twitter IndexError {e}")
         return JsonResponse({
             'ok': False,
-            'msg': 'Sorry, we couldn\'t retrieve the last tweet from your timeline'
+            'msg': 'Sorry, we couldn\'t retrieve the verification tweet from your timeline'
         })
 
-    if last_tweet.retweeted or 'RT @' in last_tweet.full_text:
+
+    if not verification_tweet:
+        return JsonResponse({
+            'ok': False,
+            'msg': f'Sorry, we couldn\'t retrieve the verification tweet from your timeline'
+        })
+
+    if verification_tweet.retweeted or 'RT @' in verification_tweet.full_text:
         return JsonResponse({
             'ok': False,
             'msg': f'We get a retweet from your last status, at this moment we don\'t supported retweets.'
         })
 
-    full_text = html.unescape(last_tweet.full_text)
+    full_text = html.unescape(verification_tweet.full_text)
     expected_msg = verify_text_for_tweet(handle)
 
     # Twitter replaces the URL with a shortened version, which is what it returns
@@ -7160,7 +7173,6 @@ def verify_user_poh(request, handle):
             'ok': False,
             'msg': 'Ethereum address is already registered.',
         })
-
 
     if not is_registered_on_poh(web3, signer):
         return JsonResponse({

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -7160,13 +7160,14 @@ def verify_user_poh(request, handle):
     signer = w3.eth.account.recoverHash(message_hash, signature=signature)
     if eth_address != signer:
         # recoverHash() will fail if the address is a smart contract wallet. Check for EIP-1271 compliance
-        if not is_valid_eip_1271_signature(web3, web3.toChecksumAddress(eth_address), message_hash, signature):
+        if is_valid_eip_1271_signature(web3, web3.toChecksumAddress(eth_address), message_hash, signature):
+            # We got a valid EIP-1271 signature from eth_address, so we can trust it.
+            signer = eth_address
+        else:
             return JsonResponse({
                 'ok': False,
                 'msg': 'Invalid signature',
             })
-        # We got a valid EIP-1271 signature from eth_address, so we can trust it.
-        signer = eth_address
 
     if Profile.objects.filter(poh_handle=signer).exists():
         return JsonResponse({

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -91,7 +91,7 @@ from economy.utils import ConversionRateNotFoundError, convert_amount, convert_t
 from eth_account.messages import defunct_hash_message
 from eth_utils import is_address, is_same_address
 from git.utils import get_auth_url, get_issue_details, get_url_dict, get_user, is_github_token_valid, search_users
-from grants.utils import get_clr_rounds_metadata
+from grants.utils import get_clr_rounds_metadata, is_valid_eip_1271_signature
 from kudos.models import Token
 from kudos.utils import humanize_name
 # from mailchimp3 import MailChimp
@@ -130,7 +130,7 @@ from .models import (
     Question, SearchHistory, Sponsor, Tool, TribeMember, UserAction, UserVerificationModel,
 )
 from .notifications import maybe_market_to_email, maybe_market_to_github
-from .poh_utils import is_registered_on_poh, is_valid_eip_1271_signature
+from .poh_utils import is_registered_on_poh
 from .router import HackathonEventSerializer, TribesSerializer
 from .utils import (
     apply_new_bounty_deadline, get_bounty, get_bounty_id, get_context, get_custom_avatars, get_hackathon_events,

--- a/app/grants/abi/eip_1271_abi.py
+++ b/app/grants/abi/eip_1271_abi.py
@@ -1,0 +1,1 @@
+EIP_1271_ABI = [{"constant":True,"inputs":[{"name":"_messageHash","type":"bytes32"},{"name":"_signature","type":"bytes"}],"name":"isValidSignature","outputs":[{"name":"magicValue","type":"bytes4"}],"payable":False,"stateMutability":"view","type":"function"}]

--- a/app/grants/utils.py
+++ b/app/grants/utils.py
@@ -463,3 +463,12 @@ def bsci_script(csv: str) -> tuple:
 
 def isNaN(string):
     return string != string
+
+def is_valid_eip_1271_signature(web3, address, hash, signature) -> bool:
+    from grants.abi.eip_1271_abi import EIP_1271_ABI
+    try:
+        eip_1271_contract = web3.eth.contract(address=address, abi=EIP_1271_ABI)
+        retval = eip_1271_contract.functions.isValidSignature(hash, signature).call()
+        return web3.toInt(retval) == 0x1626ba7e
+    except Exception as e:
+        return False


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
Fixes an issue where smart contract wallets can't properly sign the trust bonus verification for proof of humanity. The solution is to attempt to call IsValidSignature() on the wallet address if the usual recoverHash() method fails. I tested specifically on an Argent wallet, but in theory, as long as the wallet supports eip-1271, this should work.

Note: I'm very new to interacting with these tech stacks (python, smart contracts), so the more guidance anyone can provide, the better! Thanks!

- Also includes minor typo fix
##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
EIP-1271 https://eips.ethereum.org/EIPS/eip-1271
Argent wallet support for EIP-1271 https://docs.argent.xyz/wallet-connect-and-argent#message-signature

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Wasn't able to locate existing tests around similar code, but would be happy to add them if provided some guidance