### PR TITLE
10480 change result amount logic

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -897,6 +897,7 @@ TIP_PAYOUT_PRIVATE_KEY = env('TIP_PAYOUT_PRIVATE_KEY', default='0x00De4B13153673
 
 
 ELASTIC_SEARCH_URL = env('ELASTIC_SEARCH_URL', default='')
+ACTIVE_ELASTIC_INDEX = env('ACTIVE_ELASTIC_INDEX', default='')
 
 account_sid = env('TWILIO_ACCOUNT_SID', default='')
 auth_token = env('TWILIO_AUTH_TOKEN', default='')

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -897,7 +897,7 @@ TIP_PAYOUT_PRIVATE_KEY = env('TIP_PAYOUT_PRIVATE_KEY', default='0x00De4B13153673
 
 
 ELASTIC_SEARCH_URL = env('ELASTIC_SEARCH_URL', default='')
-ACTIVE_ELASTIC_INDEX = env('ACTIVE_ELASTIC_INDEX', default='')
+ACTIVE_ELASTIC_INDEX = env('ACTIVE_ELASTIC_INDEX', default='search-index-1')
 
 account_sid = env('TWILIO_ACCOUNT_SID', default='')
 auth_token = env('TWILIO_AUTH_TOKEN', default='')

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -41,6 +41,14 @@ if (document.getElementById('gc-search')) {
     computed: {
       hasMoreResults() {
         return this.page !== false && this.total && this.page * this.perPage < this.total;
+      },
+      totalResultCount() {
+        let total = 0;
+
+        Object.keys(this.totals).forEach((key) => {
+          total += this.totals[key];
+        });
+        return total;
       }
     },
     methods: {

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -61,17 +61,12 @@ if (document.getElementById('gc-search')) {
       },
       hasMoreResults() {
         return this.page !== false && this.total && this.page * this.perPage < this.total;
-      },
-      totalResultCount() {
-        let total = 0;
-
-        Object.keys(this.totals).forEach((key) => {
-          total += this.totals[key];
-        });
-        return total;
       }
     },
     methods: {
+      checkForMoreResults: function(source_type) {
+        console.log({ source_type });
+      },
       init: function() {
         setTimeout(() => {
           $('.has-search input[type=text]').focus();

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -48,6 +48,11 @@ if (document.getElementById('gc-search')) {
       this.search();
     },
     computed: {
+      currentTotal() {
+        const sourceType = this.source_types[this.currentTab];
+
+        return this.totals[sourceType];
+      },
       hasMoreResults() {
         const sourceType = this.source_types[this.currentTab];
         const page = this.currentTab > 0 ? this.tabPageCount[sourceType] : this.page;

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -109,7 +109,7 @@ if (document.getElementById('gc-search')) {
                 vm.results = groupBySource(response.results, vm.term !== vm.searchTerm ? {} : vm.results);
                 vm.searchTerm = vm.term;
                 vm.totals = response.totals;
-                vm.page = response.page;
+                vm.page = !response.page ? 0 : response.page;
                 vm.perPage = response.perPage;
                 // clear loading states
                 vm.isLoading = false;

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -60,13 +60,13 @@ if (document.getElementById('gc-search')) {
         return page;
       },
       hasMoreResults() {
-        return this.page !== false && this.total && this.page * this.perPage < this.total;
+        const sourceType = this.source_types[this.currentTab];
+        const page = this.currentTab > 0 ? this.tabPageCount[sourceType] : this.page;
+
+        return page !== false && this.totals[sourceType] && page * this.perPage < this.totals[sourceType];
       }
     },
     methods: {
-      checkForMoreResults: function(source_type) {
-        console.log({ source_type });
-      },
       init: function() {
         setTimeout(() => {
           $('.has-search input[type=text]').focus();

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -192,7 +192,7 @@ if (document.getElementById('gc-search')) {
                 }
                 vm.searchTerm = vm.term;
                 vm.totals = response.totals;
-                vm.page = response.page;
+                vm.page = !response.page ? 0 : response.page;
                 vm.perPage = response.perPage;
                 // clear loading states
                 vm.isLoading = false;

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -60,7 +60,15 @@ if (document.getElementById('gc-search')) {
         return page;
       },
       hasMoreResults() {
-        return this.currentPage !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
+        return this.page !== false && this.total && this.page * this.perPage < this.total;
+      },
+      totalResultCount() {
+        let total = 0;
+
+        Object.keys(this.totals).forEach((key) => {
+          total += this.totals[key];
+        });
+        return total;
       }
     },
     methods: {

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -60,7 +60,7 @@ if (document.getElementById('gc-search')) {
         return page;
       },
       hasMoreResults() {
-        return this.page !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
+        return this.currentPage !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
       }
     },
     methods: {

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -187,7 +187,7 @@ if (document.getElementById('gc-search')) {
                 }
                 vm.searchTerm = vm.term;
                 vm.totals = response.totals;
-                vm.page = !response.page ? 0 : response.page;
+                vm.page = response.page;
                 vm.perPage = response.perPage;
                 // clear loading states
                 vm.isLoading = false;

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -100,7 +100,7 @@ if (document.getElementById('gc-search')) {
               res.json().then((response) => {
                 vm.results = groupBySource(response.results, vm.term !== vm.searchTerm ? {} : vm.results);
                 vm.searchTerm = vm.term;
-                vm.total = response.total;
+                vm.totals = response.totals;
                 vm.page = response.page;
                 vm.perPage = response.perPage;
                 // clear loading states

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -60,10 +60,7 @@ if (document.getElementById('gc-search')) {
         return page;
       },
       hasMoreResults() {
-        const sourceType = this.source_types[this.currentTab];
-        const page = this.currentTab > 0 ? this.tabPageCount[sourceType] : this.page;
-
-        return page !== false && this.totals[sourceType] && page * this.perPage < this.totals[sourceType];
+        return this.page !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
       }
     },
     methods: {

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -41,17 +41,12 @@ if (document.getElementById('gc-search')) {
     computed: {
       hasMoreResults() {
         return this.page !== false && this.total && this.page * this.perPage < this.total;
-      },
-      totalResultCount() {
-        let total = 0;
-
-        Object.keys(this.totals).forEach((key) => {
-          total += this.totals[key];
-        });
-        return total;
       }
     },
     methods: {
+      checkForMoreResults: function(source_type) {
+        console.log({ source_type });
+      },
       init: function() {
         setTimeout(() => {
           $('.has-search input[type=text]').focus();

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -49,13 +49,13 @@ if (document.getElementById('gc-search')) {
     },
     computed: {
       hasMoreResults() {
-        return this.page !== false && this.total && this.page * this.perPage < this.total;
+        const sourceType = this.source_types[this.currentTab];
+        const page = this.currentTab > 0 ? this.tabPageCount[sourceType] : this.page;
+
+        return page !== false && this.totals[sourceType] && page * this.perPage < this.totals[sourceType];
       }
     },
     methods: {
-      checkForMoreResults: function(source_type) {
-        console.log({ source_type });
-      },
       init: function() {
         setTimeout(() => {
           $('.has-search input[type=text]').focus();

--- a/app/assets/v2/js/search.js
+++ b/app/assets/v2/js/search.js
@@ -60,7 +60,7 @@ if (document.getElementById('gc-search')) {
         return page;
       },
       hasMoreResults() {
-        return this.page !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
+        return this.currentPage !== false && this.totals[this.sourceType] && this.page * this.perPage < this.totals[this.sourceType];
       }
     },
     methods: {
@@ -98,9 +98,12 @@ if (document.getElementById('gc-search')) {
         const vm = this;
 
         vm.currentTab = index;
+
         if (index > 0) {
+          vm.tabPageCount[source_type] = 0;
           vm.search_type(source_type);
         } else {
+          vm.page = 0;
           vm.search();
         }
       },
@@ -124,7 +127,11 @@ if (document.getElementById('gc-search')) {
             }
           ).then((res) => {
             res.json().then((response) => {
-              vm.results.push(...response.results);
+              if (vm.tabPageCount[type] === 0) {
+                vm.results = response.results;
+              } else {
+                vm.results.push(...response.results);
+              }
               vm.isTypeSearchLoading = false;
               vm.tabPageCount[type] = response.page;
             });
@@ -170,7 +177,11 @@ if (document.getElementById('gc-search')) {
           ).then((res) => {
             if (document.current_search == thisDate) {
               res.json().then((response) => {
-                vm.results.push(...response.results);
+                if (vm.page === 0) {
+                  vm.results = response.results;
+                } else {
+                  vm.results.push(...response.results);
+                }
                 vm.searchTerm = vm.term;
                 vm.totals = response.totals;
                 vm.page = response.page;
@@ -198,18 +209,6 @@ if (document.getElementById('gc-search')) {
   });
 }
 document.current_search = new Date();
-
-const groupBySource = (results, prev_results) => {
-  let grouped_result = prev_results || {};
-
-  results.map(result => {
-    const source_type = result.source_type;
-
-    grouped_result['All'] ? grouped_result['All'].push(result) : grouped_result['All'] = [result];
-    grouped_result[source_type] ? grouped_result[source_type].push(result) : grouped_result[source_type] = [result];
-  });
-  return grouped_result;
-};
 
 $(document).on('click', '.gc-search .dropdown-menu', function(event) {
   event.stopPropagation();

--- a/app/assets/v2/scss/search.scss
+++ b/app/assets/v2/scss/search.scss
@@ -22,7 +22,7 @@
 }
 
 .gc-search-box.dropdown-menu {
-  width: 520px;
+  width: 540px;
   background-color: #ffffff;
   border-radius: 4px;
   top: 2.3rem;

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -45,6 +45,7 @@
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="currentTab = index" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
             <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
+            <span v-else-if="source_type === 'All'">([[ totalResultCount ]])</span>
             <span v-else>(0)</span>
           </a>
         </li>

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -86,7 +86,7 @@
             </a>
           </template>
           <template v-else>
-            <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
+            <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ currentTotal ]])...</a>
           </template>
         </div>
       </template>

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -75,9 +75,19 @@
               </li>
             </template>
           </ul>
-          <!-- <template v-if="checkForMoreResults(source_type)">
-
-          </template> -->
+          <template v-if="checkForMoreResults(source_type)">
+            <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
+              <template v-if="isLoading">
+                <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
+                  <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
+                  Fetching result
+                </a>
+              </template>
+              <template v-else>
+                <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
+              </template>
+            </div>
+          </template>
         </div>
       </div>
       <template v-if="hasMoreResults">

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -75,19 +75,6 @@
               </li>
             </template>
           </ul>
-          <template v-if="checkForMoreResults(source_type)">
-            <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
-              <template v-if="isLoading">
-                <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
-                  <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
-                  Fetching result
-                </a>
-              </template>
-              <template v-else>
-                <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
-              </template>
-            </div>
-          </template>
         </div>
       </div>
       <template v-if="hasMoreResults">

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -43,7 +43,7 @@
     <template v-else-if="Object.keys(results).length">
       <ul class="nav nav-tabs mt-1 gc-search-nav d-flex" role="tablist">
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
-          <a class="nav-link nav-line gc-search-tab__title px-1" @click="currentTab = index" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
+          <a class="nav-link nav-line gc-search-tab__title px-1" @click="change_tab(index, source_type)" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
             <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
             <span v-else>(0)</span>
           </a>
@@ -52,8 +52,8 @@
       <div class="tab-content clearfix">
         <div class="tab-pane" :class="{active: currentTab === index}" v-bind:id="source_type" v-for='(source_type, index) in source_types' :key="index">
           <ul class="gc-search-result mb-0">
-            <template v-if="results && results[source_type]">
-              <li v-for="result in results[source_type]" class="gc-search-result__content p-3" :key="result.id">
+            <template v-if="results">
+              <li v-for="result in results" class="gc-search-result__content p-3" :key="result.id">
                <a :href="[[ result.url ]]" class="d-flex">
                   <img class="gc-search__avatar my-auto mr-3" :src="[[ result.img_url ]]" :alt="result.title" />
                   <div>
@@ -75,9 +75,19 @@
               </li>
             </template>
           </ul>
-          <!-- <template v-if="checkForMoreResults(source_type)">
-
-          </template> -->
+          <template v-if="checkForMoreResults(source_type)">
+            <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
+              <template v-if="isLoading">
+                <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
+                  <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
+                  Fetching result
+                </a>
+              </template>
+              <template v-else>
+                <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
+              </template>
+            </div>
+          </template>
         </div>
       </div>
       <template v-if="hasMoreResults">

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -45,7 +45,6 @@
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="currentTab = index" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
             <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
-            <span v-else-if="source_type === 'All'">([[ totalResultCount ]])</span>
             <span v-else>(0)</span>
           </a>
         </li>
@@ -76,6 +75,9 @@
               </li>
             </template>
           </ul>
+          <!-- <template v-if="checkForMoreResults(source_type)">
+
+          </template> -->
         </div>
       </div>
       <template v-if="hasMoreResults">

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -75,19 +75,6 @@
               </li>
             </template>
           </ul>
-          <template v-if="checkForMoreResults(source_type)">
-            <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
-              <template v-if="isLoading">
-                <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
-                  <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
-                  Fetching result
-                </a>
-              </template>
-              <template v-else>
-                <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ total ]])...</a>
-              </template>
-            </div>
-          </template>
         </div>
       </div>
       <template v-if="hasMoreResults">
@@ -105,7 +92,7 @@
       </template>
     </template>
 
-    <template v-else-if="isLoading">
+    <template v-else-if="isLoading || isTypeSearchLoading">
       <p class="text-center font-smaller-2 gc-search-result__description">
         <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
         Fetching result

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -40,7 +40,7 @@
         Click 'Go' to Search.
       </p>
     </template>
-    <template v-else-if="Object.keys(results).length">
+    <template v-else-if="results.length">
       <ul class="nav nav-tabs mt-1 gc-search-nav d-flex" role="tablist">
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="change_tab(index, source_type)" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
@@ -86,7 +86,7 @@
             </a>
           </template>
           <template v-else>
-            <a class="cursor-pointer" @click="search">Load more results (showing [[ page * perPage ]] of [[ currentTotal ]])...</a>
+            <a class="cursor-pointer" @click="search">Load more results (showing [[ currentPage * perPage ]] of [[ currentTotal ]])...</a>
           </template>
         </div>
       </template>

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -45,6 +45,7 @@
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="change_tab(index, source_type)" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
             <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
+            <span v-else-if="source_type === 'All'">([[ totalResultCount ]])</span>
             <span v-else>(0)</span>
           </a>
         </li>

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -45,7 +45,6 @@
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="change_tab(index, source_type)" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
             <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
-            <span v-else-if="source_type === 'All'">([[ totalResultCount ]])</span>
             <span v-else>(0)</span>
           </a>
         </li>
@@ -76,6 +75,9 @@
               </li>
             </template>
           </ul>
+          <!-- <template v-if="checkForMoreResults(source_type)">
+
+          </template> -->
         </div>
       </div>
       <template v-if="hasMoreResults">

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -44,7 +44,7 @@
       <ul class="nav nav-tabs mt-1 gc-search-nav d-flex" role="tablist">
         <li class="nav-item flex-grow-1 text-center" v-for='(source_type, index) in source_types' :key="index">
           <a class="nav-link nav-line gc-search-tab__title px-1" @click="currentTab = index" :class="{active: currentTab === index}" v-bind:href="'#' + source_type" data-toggle="tab">[[ labels[source_type] ]]
-            <span v-if="typeof results[source_type] !== 'undefined'">([[ results[source_type].length ]])</span>
+            <span v-if="typeof totals[source_type] !== 'undefined'">([[ totals[source_type] ]])</span>
             <span v-else>(0)</span>
           </a>
         </li>

--- a/app/dashboard/templates/shared/search.html
+++ b/app/dashboard/templates/shared/search.html
@@ -79,14 +79,14 @@
       </div>
       <template v-if="hasMoreResults">
         <div class="gc-search-more-results bg-white border-grey border-top-1 bottom-0 font-smaller-2 pb-3 position-sticky pt-3 text-center">
-          <template v-if="isLoading">
+          <template v-if="isLoading || isTypeSearchLoading">
             <a class="text-muted cursor-none disable-hover-underline" @click.prevent="false">
               <i class="font-smaller-1 fas fa-spinner fa-pulse mr-1"></i>
               Fetching result
             </a>
           </template>
           <template v-else>
-            <a class="cursor-pointer" @click="search">Load more results (showing [[ currentPage * perPage ]] of [[ currentTotal ]])...</a>
+            <a class="cursor-pointer" @click="loadMoreResults">Load more results (showing [[ currentPage * perPage ]] of [[ currentTotal ]])...</a>
           </template>
         </div>
       </template>

--- a/app/search/management/commands/create_search_index_with_active_grants.py
+++ b/app/search/management/commands/create_search_index_with_active_grants.py
@@ -60,5 +60,4 @@ class Command(BaseCommand):
                 sr.put_on_elasticsearch(index_name)
             except Exception as e:
                 print('failed:', e)
-
         print('indexing complete')

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -93,7 +93,7 @@ def search_by_type(query, content_type, page=0, num_results=500):
 
 
 def search(query, page=0, num_results=500):
-    if not settings.ELASTIC_SEARCH_URL:
+    if not settings.ELASTIC_SEARCH_URL and not settings.ELASTIC_SEARCH_URL:
         return {}
     es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils import timezone
 
 from economy.models import SuperModel
-from grants.models import Grant
 from elasticsearch import Elasticsearch
 from grants.models import Grant
 

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -38,7 +38,7 @@ class SearchResult(SuperModel):
             if not active_grant:
                 return None
 
-        es = Elasticsearch([settings.ELASTIC_SEARCH_URL])
+        es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
         source_type = str(str(self.source_type).replace('token', 'kudos')).title()
         full_search = f"{self.title} {self.description} {source_type}"
         doc = {
@@ -56,11 +56,11 @@ class SearchResult(SuperModel):
         res = es.index(index=index, id=self.pk, body=doc)
 
 def search_by_type(query, content_type, page=0, num_results=500):
-    if not settings.ELASTIC_SEARCH_URL:
+    if not settings.ELASTIC_SEARCH_URL and not settings.ACTIVE_ELASTIC_INDEX:
         return {}
 
     es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
-    res = es.search(index="search-index-1", body={
+    res = es.search(index=settings.ACTIVE_ELASTIC_INDEX, body={
         "from": page, "size": num_results,
         "query": {
             "bool": {
@@ -94,12 +94,12 @@ def search_by_type(query, content_type, page=0, num_results=500):
 
 
 def search(query, page=0, num_results=500):
-    if not settings.ELASTIC_SEARCH_URL:
+    if not settings.ELASTIC_SEARCH_URL and not settings.ELASTIC_SEARCH_URL:
         return {}
     es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant
     # index name will need updated once index is ready to be searched
-    res = es.search(index="search-index-1", body={
+    res = es.search(index=settings.ACTIVE_ELASTIC_INDEX, body={
         "from": page, "size": num_results,
         "query": {
             "bool": {

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from economy.models import SuperModel
+from grants.models import Grant
 from elasticsearch import Elasticsearch
 from grants.models import Grant
 

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -94,7 +94,7 @@ def search_by_type(query, content_type, page=0, num_results=500):
 
 
 def search(query, page=0, num_results=500):
-    if not settings.ELASTIC_SEARCH_URL and not settings.ELASTIC_SEARCH_URL:
+    if not settings.ELASTIC_SEARCH_URL:
         return {}
     es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils import timezone
 
 from economy.models import SuperModel
-from grants.models import Grant
 from elasticsearch import Elasticsearch
 from grants.models import Grant
 
@@ -60,7 +59,7 @@ def search_by_type(query, content_type, page=0, num_results=500):
     if not settings.ELASTIC_SEARCH_URL:
         return {}
 
-    es = Elasticsearch('web-elasticsearch-1:9200')
+    es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     res = es.search(index="search-index-1", body={
         "from": page, "size": num_results,
         "query": {
@@ -95,10 +94,9 @@ def search_by_type(query, content_type, page=0, num_results=500):
 
 
 def search(query, page=0, num_results=500):
-    print(query, 'queryqueryquery', page, num_results, 'page, num_resultspage, num_results')
     if not settings.ELASTIC_SEARCH_URL:
         return {}
-    es = Elasticsearch('web-elasticsearch-1:9200')
+    es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant
     # index name will need updated once index is ready to be searched
     res = es.search(index="search-index-1", body={

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -49,6 +49,7 @@ class SearchResult(SuperModel):
             'img_url': self.img_url,
             'timestamp': timezone.now(),
             'source_type': source_type,
+            'source_type_id': self.source_type_id
         }
         res = es.index(index=index, id=self.pk, body=doc)
 
@@ -56,7 +57,7 @@ class SearchResult(SuperModel):
 def search(query, page=0, num_results=500):
     if not settings.ELASTIC_SEARCH_URL:
         return {}
-    es = Elasticsearch([settings.ELASTIC_SEARCH_URL])
+    es = Elasticsearch('web-elasticsearch-1:9200')
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant
     # index name will need updated once index is ready to be searched
     res = es.search(index="search-index", body={
@@ -80,6 +81,13 @@ def search(query, page=0, num_results=500):
             }
           ],
           "minimum_should_match": "1"
+        }
+      },
+      "aggs": {
+        "search-totals": {
+          "terms": {
+            "field": "source_type_id"
+          }
         }
       }
     })

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -93,7 +93,7 @@ def search_by_type(query, content_type, page=0, num_results=500):
 
 
 def search(query, page=0, num_results=500):
-    if not settings.ELASTIC_SEARCH_URL and not settings.ELASTIC_SEARCH_URL:
+    if not settings.ELASTIC_SEARCH_URL and not settings.ACTIVE_ELASTIC_INDEX:
         return {}
     es = Elasticsearch(settings.ELASTIC_SEARCH_URL)
     # queries for wildcarded paginated results using boosts to lift by title and source_type=grant

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -49,6 +49,7 @@ class SearchResult(SuperModel):
             'img_url': self.img_url,
             'timestamp': timezone.now(),
             'source_type': source_type,
+            # in order to aggregate totals by type an int needs to be indexed as opposed to a string
             'source_type_id': self.source_type_id
         }
         res = es.index(index=index, id=self.pk, body=doc)

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from economy.models import SuperModel
+from grants.models import Grant
 from elasticsearch import Elasticsearch
 from grants.models import Grant
 
@@ -28,7 +29,6 @@ class SearchResult(SuperModel):
     def check_for_active_grant(self):
         grant = Grant.objects.get(pk=self.source_id)
         return grant.active and not grant.hidden
-
     def put_on_elasticsearch(self, index='search-index'):
         if self.visible_to:
             return None

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -50,7 +50,14 @@ def format_totals(aggregations):
     # Get content types for search results that were returned
     content_types = ContentType.objects.filter(pk__in=type_keys).values('id', 'app_label', 'model')
 
-    
+    mapped_labels = {
+        82: 'Grant',
+        16: 'Bounty',
+        25: 'Profile',
+        73: 'Kudos',
+        133: 'Quest'
+        # pages??? I'm not sure
+    }
     totals = {}
     total_all = 0
     for content_type in content_types:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -52,10 +52,10 @@ def format_totals(aggregations):
         # find total based on content type
         bucket_index = buckets.index(next(filter(lambda n: n.get('key') == content_type['id'], buckets)))
         bucket = buckets[bucket_index]
-        bucket['label'] = mapped_labels[bucket['key']]
-        # link app_label to search total
-        totals[mapped_labels[bucket['key']]] = bucket['doc_count']
-
+        if bucket['key']:
+            bucket['label'] = mapped_labels[bucket['key']]
+            # link mapped_labels to search total
+            totals[mapped_labels[bucket['key']]] = bucket['doc_count']
     return totals
 
 def search_helper(request, keyword='', page=0, per_page=100):
@@ -84,11 +84,14 @@ def search_helper(request, keyword='', page=0, per_page=100):
             )
     # return results + meta
     except Exception as e:
+        print(e, 'eeeeeee')
         logger.exception(e)
     finally:
+        print(settings.DEBUG, results_totals, 'settings.DEBUG, results_totalssettings.DEBUG, results_totals')
         if not settings.DEBUG or results_totals:
             return return_results, results_totals, next_page
 
+    print('fetch not elasticccc')
     # fetch the results for the given keyword
     raw_results = SearchResult.objects.filter(Q(title__icontains=keyword) | Q(description__icontains=keyword))
     if request.user.is_authenticated:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -81,7 +81,7 @@ def search_helper(request, keyword='', search_type=None, page=0, per_page=100):
     try:
         all_result_sets = None
         if search_type:
-            # collect the results from elasticsearch instance
+            # collect the results from elasticsearch instance based on content type
             all_result_sets = search_by_type(keyword, get_type_id(search_type), page, per_page)    
         else:
             # collect the results from elasticsearch instance

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.contrib.contenttypes.models import ContentType
 
 from dashboard.models import SearchHistory
 from ratelimit.decorators import ratelimit

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -50,14 +50,7 @@ def format_totals(aggregations):
     # Get content types for search results that were returned
     content_types = ContentType.objects.filter(pk__in=type_keys).values('id', 'app_label', 'model')
 
-    mapped_labels = {
-        82: 'Grant',
-        16: 'Bounty',
-        25: 'Profile',
-        73: 'Kudos',
-        133: 'Quest',
-        120: 'Page'
-    }
+    
     totals = {}
     total_all = 0
     for content_type in content_types:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -2,10 +2,10 @@ import json
 import logging
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import render
-from django.contrib.contenttypes.models import ContentType
 
 from dashboard.models import SearchHistory
 from ratelimit.decorators import ratelimit

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -106,14 +106,11 @@ def search_helper(request, keyword='', search_type=None, page=0, per_page=100):
             )
     # return results + meta
     except Exception as e:
-        print(e, 'eeeeeee')
         logger.exception(e)
     finally:
-        print(settings.DEBUG, results_totals, 'settings.DEBUG, results_totalssettings.DEBUG, results_totals')
         if not settings.DEBUG or results_totals:
             return return_results, results_totals, next_page
 
-    print('fetch not elasticccc')
     # fetch the results for the given keyword
     raw_results = SearchResult.objects.filter(Q(title__icontains=keyword) | Q(description__icontains=keyword))
     if request.user.is_authenticated:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -55,8 +55,8 @@ def format_totals(aggregations):
         16: 'Bounty',
         25: 'Profile',
         73: 'Kudos',
-        133: 'Quest'
-        # pages??? I'm not sure
+        133: 'Quest',
+        120: 'Page'
     }
     totals = {}
     total_all = 0

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -44,8 +44,8 @@ def format_totals(aggregations):
         16: 'Bounty',
         25: 'Profile',
         73: 'Kudos',
-        133: 'Quest'
-        # pages??? I'm not sure
+        133: 'Quest',
+        120: 'Page'
     }
     totals = {}
     for content_type in content_types:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -37,15 +37,24 @@ def format_totals(aggregations):
     # get content type keys from search results
     type_keys = map(lambda d: d['key'], buckets)
     # Get content types for search results that were returned
-    content_types = ContentType.objects.filter(pk__in=type_keys).values('id', 'model')
+    content_types = ContentType.objects.filter(pk__in=type_keys).values('id', 'app_label', 'model')
 
+    mapped_labels = {
+        82: 'Grant',
+        16: 'Bounty',
+        25: 'Profile',
+        73: 'Kudos',
+        133: 'Quest'
+        # pages??? I'm not sure
+    }
     totals = {}
     for content_type in content_types:
         # find total based on content type
         bucket_index = buckets.index(next(filter(lambda n: n.get('key') == content_type['id'], buckets)))
         bucket = buckets[bucket_index]
-        # link model to search total
-        totals[content_type['model']] = bucket
+        bucket['label'] = mapped_labels[bucket['key']]
+        # link app_label to search total
+        totals[mapped_labels[bucket['key']]] = bucket['doc_count']
 
     return totals
 
@@ -54,6 +63,7 @@ def search_helper(request, keyword='', page=0, per_page=100):
     return_results = []
     results_total = 0
     next_page = 0
+    results_totals = None
     try:
         # collect the results from elasticsearch instance
         all_result_sets = search(keyword, page, per_page)

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -113,11 +113,14 @@ def search_helper(request, keyword='', search_type=None, page=0, per_page=100):
             )
     # return results + meta
     except Exception as e:
+        print(e, 'eeeeeee')
         logger.exception(e)
     finally:
+        print(settings.DEBUG, results_totals, 'settings.DEBUG, results_totalssettings.DEBUG, results_totals')
         if not settings.DEBUG or results_totals:
             return return_results, results_totals, next_page
 
+    print('fetch not elasticccc')
     # fetch the results for the given keyword
     raw_results = SearchResult.objects.filter(Q(title__icontains=keyword) | Q(description__icontains=keyword))
     if request.user.is_authenticated:

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import render
-from django.contrib.contenttypes.models import ContentType
 
 from dashboard.models import SearchHistory
 from ratelimit.decorators import ratelimit

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -48,6 +48,7 @@ def format_totals(aggregations):
         120: 'Page'
     }
     totals = {}
+    total_all = 0
     for content_type in content_types:
         # find total based on content type
         bucket_index = buckets.index(next(filter(lambda n: n.get('key') == content_type['id'], buckets)))
@@ -56,6 +57,9 @@ def format_totals(aggregations):
             bucket['label'] = mapped_labels[bucket['key']]
             # link mapped_labels to search total
             totals[mapped_labels[bucket['key']]] = bucket['doc_count']
+            total_all += bucket['doc_count']
+    totals['All'] = total_all
+
     return totals
 
 def search_helper(request, keyword='', page=0, per_page=100):
@@ -70,7 +74,7 @@ def search_helper(request, keyword='', page=0, per_page=100):
         # get the totals for each category
         results_totals = format_totals(all_result_sets['aggregations'])
         # check if there is a next page
-        next_page = int(page) + 1 if results_total > (int(page) + 1) * per_page else False
+        next_page = int(page) + 1 if int(results_totals['All']) > (int(page) + 1) * per_page else False
         # pull the results from the es response
         return_results = [ele['_source'] for ele in all_result_sets['hits']['hits']]
         # record that a search was made for this keyword

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -105,14 +105,11 @@ def search_helper(request, keyword='', search_type=None, page=0, per_page=100):
             )
     # return results + meta
     except Exception as e:
-        print(e, 'eeeeeee')
         logger.exception(e)
     finally:
-        print(settings.DEBUG, results_totals, 'settings.DEBUG, results_totalssettings.DEBUG, results_totals')
         if not settings.DEBUG or results_totals:
             return return_results, results_totals, next_page
 
-    print('fetch not elasticccc')
     # fetch the results for the given keyword
     raw_results = SearchResult.objects.filter(Q(title__icontains=keyword) | Q(description__icontains=keyword))
     if request.user.is_authenticated:


### PR DESCRIPTION
##### Description

These updates bring back totals for all of the different models that are being searched so that pagination is accurate for each tab. It adds another query to bring back results for each tab individually. 

Pagination was updated on the fe to request results based on the active tab. 

There is also a new environment variable that sets the elastic index once it is created. It corresponds to {index-name} passed to the above command and is named `ACTIVE_ELASTIC_INDEX`

##### Refers/Fixes

fixes: #10478 and #10480

##### Testing

https://user-images.githubusercontent.com/6887938/166337104-0d3f8029-950b-482a-bdcb-866a41a55f06.mov
