### PR TITLE
Pinning django debug toolbar to version that works with our environment

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ requests_mock==1.7.0
 idna==2.7
 django-test-plus==1.1.1
 git+https://github.com/google/yapf.git#egg=yapf
-django-debug-toolbar
+django-debug-toolbar==3.2.4
 ipfshttpclient==0.6.0
 dj_static==0.0.6
 livereload==2.6.3


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Pinning django debug toolbar to a version that works with our environment.

##### Refers/Fixes

No specific issue, this fixes workflow errors.

##### Testing

GHA workflow is expected to pass and not fail due to django debug toolbar version.
