### PR TITLE
Fixing the duplicate discovery of files by the bundle command, depend…

### DIFF
--- a/app/dashboard/management/commands/bundle.py
+++ b/app/dashboard/management/commands/bundle.py
@@ -55,6 +55,7 @@ class Command(BaseCommand):
         #   - from the app config
         #   - and from the template dirs config
         full_template_dir_list = set(template_dir_list + [os.path.abspath(p) for p in settings.TEMPLATES[0]['DIRS']])
+        print('\nThe following folder will be checked for templates:\n')
         for d in full_template_dir_list:
             print(d)
 

--- a/app/dashboard/management/commands/bundle.py
+++ b/app/dashboard/management/commands/bundle.py
@@ -50,8 +50,16 @@ class Command(BaseCommand):
             if settings.BASE_DIR in template_dir:
                 template_dir_list.append(template_dir)
 
+
+        # We work with absolute paths only, and make sure to exclude duplicates. Sometimes the same dir is comes in via 2 routes:
+        #   - from the app config
+        #   - and from the template dirs config
+        full_template_dir_list = set(template_dir_list + [os.path.abspath(p) for p in settings.TEMPLATES[0]['DIRS']])
+        for d in full_template_dir_list:
+            print(d)
+
         template_list = []
-        for template_dir in (template_dir_list + settings.TEMPLATES[0]['DIRS']):
+        for template_dir in full_template_dir_list:
             for base_dir, dirnames, filenames in os.walk(template_dir):
                 for filename in filenames:
                     if ".html" in filename:


### PR DESCRIPTION
…ing on the current working dir

<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Depending on the config, the `bundle` command might pick the same folder several times, because template folder are picked up from different sources.
We want to avoid duplicates, as duplicates will result in the bundle command to fail (as it now issues an error in case duplicate files are encountered).

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

Has been tested on branch infra_as_code_staging, and cherry-picked here.

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
