### PR TITLE
check if hackathon is expired and redirect to onboarding if true

### DIFF
--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -5095,6 +5095,15 @@ class HackathonEvent(SuperModel):
     def town_square_link(self):
         return f'townsquare/?tab=hackathon:{self.pk}'
 
+    def is_expired(self):
+        """Check if Hackathon is active
+
+        Returns:
+            boolean: Whether or not hackathon is expired
+        """
+        now = timezone.now()
+        return self.end_date < now
+
     def get_absolute_url(self):
         """Get the absolute URL for the HackathonEvent.
 

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4311,6 +4311,9 @@ def new_hackathon_bounty(request, hackathon=''):
     except HackathonEvent.DoesNotExist:
         return redirect(reverse('get_hackathons'))
 
+    if hackathon_event.is_expired():
+        return redirect(f"/hackathon/{hackathon_event.slug}/onboard")
+    
     bounty_params = {
         'newsletter_headline': _('Be the first to know about new funded issues.'),
         'issueURL': clean_bounty_url(request.GET.get('source') or request.GET.get('url', '')),

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -4312,7 +4312,7 @@ def new_hackathon_bounty(request, hackathon=''):
         return redirect(reverse('get_hackathons'))
 
     if hackathon_event.is_expired():
-        return redirect(f"/hackathon/{hackathon_event.slug}/onboard")
+        return redirect(reverse('hackathon_onboard', args=(hackathon_event.slug,)))
     
     bounty_params = {
         'newsletter_headline': _('Be the first to know about new funded issues.'),


### PR DESCRIPTION
##### Description

As a funder
I want to be prevented from creating bounties on expired hackathons
So that i dont give fale realities to contributors

Acceptance Criteria

Redirect user to Onboarding Page
GIVEN I have created a hackathon with a specific end date
AND it is past that specified end date... aka hackathon has ended
WHEN I navigate to [www.gitcoin.co/hackathon/slug-here/new](http://www.gitcoin.co/hackathon/slug-here/new)
THEN i should be redirected to the in focus hackathons onboarding page
AND i should be prevented to create any new bounties on that hackathon

##### Refers/Fixes

fixes: #10577 

##### Testing

Active Hackathon:

https://user-images.githubusercontent.com/6887938/167189236-166dea51-c8de-46af-b982-b5b0d11bce26.mov


Expired Hackathon:

https://user-images.githubusercontent.com/6887938/167189297-8b7fe1e3-8e3a-4aec-9d87-6162e9fdf1a0.mov


