### PR TITLE
Fix quests UI bug on mobile devices

### DIFF
--- a/app/assets/v2/scss/quests.scss
+++ b/app/assets/v2/scss/quests.scss
@@ -27,6 +27,11 @@
   bottom: -5px;
 }
 
+#btn-back-to-top {
+  width: auto;
+  top: auto;
+}
+
 // .btn:not(.btn-gc-blue) {
 //   width: 100px;
 //   position: relative;


### PR DESCRIPTION
## Problem:

There are media queries on buttons for screens less than 991px in `quests.scss` that are causing this issue. 

```css
.btn {
    width: -webkit-fill-available;
    top: 0.4rem;
    border: none;
  }
```

## Fix:

This PR adds higher specificity styles for the back-to-top button.

## Screenshots:

![image](https://user-images.githubusercontent.com/62268199/167867573-25dbc5fe-f9b2-499b-b177-18efb79bc609.png)
