### PR TITLE
Allow smart contract wallets to sign correctly (EIP-1271) for grant i…

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -83,7 +83,7 @@ from grants.tasks import (
 )
 from grants.utils import (
     emoji_codes, generate_collection_thumbnail, generate_img_thumbnail_helper, get_clr_rounds_metadata, get_user_code,
-    is_grant_team_member, sync_payout, toggle_user_sybil,
+    is_grant_team_member, is_valid_eip_1271_signature, sync_payout, toggle_user_sybil,
 )
 from marketing.mails import grant_cancellation, new_grant_flag_admin
 from marketing.models import ImageDropZone, Keyword, Stat
@@ -2956,8 +2956,12 @@ def ingest_contributions(request):
         message_hash = defunct_hash_message(text=message)
         recovered_address = w3.eth.account.recoverHash(message_hash, signature=signature)
         if recovered_address.lower() != expected_address.lower():
-            raise Exception("Signature could not be verified")
-
+            # The signature could still be valid if the wallet is a contract and supports EIP-1271
+            logger.info("Signatures didn't match from recoverHash(), trying EIP-1271 support")
+            if not is_valid_eip_1271_signature(w3, w3.toChecksumAddress(expected_address), message_hash, signature):
+                raise Exception("Signature could not be verified")
+            else:
+                logger.info("EIP-1271 signature verified")
     try:
         if txHash != '':
             receipt = w3.eth.getTransactionReceipt(txHash)


### PR DESCRIPTION
…ngesting

<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

Allow smart contract wallets that support EIP-1271 to properly validate the post-grant-funding signature. Previously, all contract wallets would fail the grants/ingest_contributions endpoint with "Signature could not be verified". This should attribute valid funders appropriately now and not require admin fixups later (assuming the wallet contract supports EIP-1271, which may not always be the case, so will still need admin fixups for these)

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

#10368

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->

Manually tested on an Argent wallet
