### PR TITLE
force reload component if global wallet functions are undefined

### DIFF
--- a/app/assets/v2/js/cart.js
+++ b/app/assets/v2/js/cart.js
@@ -1732,6 +1732,12 @@ Vue.component('grants-cart', {
     // Show loading dialog
     this.isLoading = true;
 
+    // Check if shared/global wallet functions are loaded from shared.js
+    if (!window.indicateMetamaskPopup) {
+      // rerender component to pickup load of global fncts
+      vm.$forceUpdate();
+    }
+
     // Load list of all tokens
     const tokensResponse = await fetch('/api/v1/tokens');
     const allTokens = await tokensResponse.json();


### PR DESCRIPTION
##### Description

issue: #10633 reported a global function being undefined. It seems like an edge case, but its possible that the functions within`app/assets/v2/js/shared.js` were not globally available at the time that the component had mounted. This should reload the component and pick up the global functions that are outside of Vue's scope

##### Refers/Fixes

fixes: #10633
