### PR TITLE
toggle user sybils: add comparisons to thresholds

### DIFF
--- a/app/grants/utils.py
+++ b/app/grants/utils.py
@@ -492,13 +492,13 @@ def bsci_script(csv: str) -> tuple:
                                                         labels_by_evaluation)))
 
         # Assign final `is_sybil` markings according to a priorization criteria
-        df.loc[labels_by_evaluation, 'is_sybil'] = df[labels_by_evaluation].evaluation_score
+        df.loc[labels_by_evaluation, 'is_sybil'] = df[labels_by_evaluation].evaluation_score > EVAL_THRESHOLD
         df.loc[labels_by_evaluation, 'label'] = "Human Evaluation"
-
-        df.loc[labels_by_heuristic, 'is_sybil'] = df[labels_by_heuristic].heuristic_score
+        
+        df.loc[labels_by_heuristic, 'is_sybil'] = df[labels_by_heuristic].heuristic_score > HEURISTIC_THRESHOLD
         df.loc[labels_by_heuristic, 'label'] = "Heuristics"
-
-        df.loc[labels_by_prediction, 'is_sybil'] = df[labels_by_prediction].prediction_score
+        
+        df.loc[labels_by_prediction, 'is_sybil'] = df[labels_by_prediction].prediction_score > ML_THRESHOLD
         df.loc[labels_by_prediction, 'label'] = "ML Prediction"
 
         # Generate dict records


### PR DESCRIPTION
##### Description

The `bsci_script` method was missing the comparison between the dataset elements and the relevant thresholds, therefore making the sybil flags more conservative than it should (only values = 0 or 1 were taken into consideration). This PR fixes that by introducing the comparison operator, which makes the script behave as expected.


##### Testing

Logical tests were done locally on Jupyter Notebooks to ensure that the sybil flags were equal to what was expected by using the `aggregate_score` column