### PR TITLE
allows these common tasks to be flushed from the queue

### DIFF
--- a/app/dashboard/tasks.py
+++ b/app/dashboard/tasks.py
@@ -247,6 +247,10 @@ def profile_dict(self, pk, retry: bool = True) -> None:
     :param pk:
     :return:
     """
+
+    if settings.FLUSH_QUEUE:
+        return
+
     if isinstance(pk, list):
         pk = pk[0]
     with redis.lock("tasks:profile_dict:%s" % pk, timeout=LOCK_TIMEOUT):
@@ -389,6 +393,9 @@ def record_visit(self, user_pk, profile_pk, ip_address, visitorId, useragent, re
     :return: None
     """
 
+    if settings.FLUSH_QUEUE:
+        return
+
     user = User.objects.filter(pk=user_pk).first() if user_pk else None
     profile = Profile.objects.filter(pk=profile_pk).first() if profile_pk else None
     if user and profile:
@@ -447,6 +454,9 @@ def record_join(self, profile_pk, retry: bool = True) -> None:
     # error (becasue Activity.objects.create also performs delete operations in a
     # post_save signal)
     # To avoid the integrity error we execute this operation in a transaction
+    if settings.FLUSH_QUEUE:
+        return
+
     with transaction.atomic():
         profile = Profile.objects.filter(pk=profile_pk).first() if profile_pk else None
         if profile:

--- a/app/dashboard/tasks.py
+++ b/app/dashboard/tasks.py
@@ -364,6 +364,10 @@ def increment_view_count(self, pks, content_type, user_id, view_type, retry: boo
 
 @app.shared_task(bind=True, max_retries=1)
 def sync_profile(self, handle, user_pk, hide_profile, retry: bool = True) -> None:
+
+    if settings.FLUSH_QUEUE:
+        return
+
     from app.utils import actually_sync_profile
     user = User.objects.filter(pk=user_pk).first() if user_pk else None
     actually_sync_profile(handle, user=user, hide_profile=hide_profile)
@@ -371,6 +375,10 @@ def sync_profile(self, handle, user_pk, hide_profile, retry: bool = True) -> Non
 
 @app.shared_task(bind=True, max_retries=1)
 def recalculate_earning(self, pk, retry: bool = True) -> None:
+
+    if settings.FLUSH_QUEUE:
+        return
+
     from dashboard.models import Earning
     earning = Earning.objects.get(pk=pk)
     src = earning.source


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->
allows these common tasks to be flushed from the queue
record join
record  visti
profile dict
and a few others

2 years ago, id care more about the data integrity / analytics repercussions of doing something like this - and would do more serious refactoring of how this data is stored.  but since were ditching the monolith in a few months, i dont think it really matters anymore if visits arent recorded or if the profile dicts are recomputed with the same urgency.

what matters more now is freeing up the resources to the site to stay online so that the GPC can focus more on maintenance mode stuff like building grants 2.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->
https://discord.com/channels/562828676480237578/990199901633789962/990439454583967764

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
tested locally