### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,9 @@ Gitcoin Grows Open Source. Learn more at [https://gitcoin.co](https://gitcoin.co
   <a href="">
     <img alt="GitHub" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg">
   </a>
+	<a href="https://www.gitpoap.io/gh/gitcoinco/web">
+		<img alt="GitPOAP Badge" src="https://public-api.gitpoap.io/v1/repo/gitcoinco/web/badge">
+	</a>
   <a href="">
   <img alt="GitHub top language" src="https://img.shields.io/github/languages/top/gitcoinco/web">
   <a/>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie

##### Refers/Fixes

##### Testing

No testing since this is only a change to the README displayed on GitHub. However, here's a screenshot of the updated README:
<img width="1082" alt="Screen Shot 2022-07-18 at 1 29 50 PM" src="https://user-images.githubusercontent.com/1555326/179568997-de5255e0-6830-4ae8-9ddb-bd0745e3083c.png">
 