### PR TITLE
Fix:  duplicate subtext

### DIFF
--- a/app/retail/templates/bounties/contributor/feature.html
+++ b/app/retail/templates/bounties/contributor/feature.html
@@ -33,7 +33,7 @@
       </div>
       <div class="col-12 col-sm-10">
         <h3 class="font-title-lg font-weight-semibold">Sharpen Your {% if tech_stack %} {{ tech_stack }} {% endif %} Coding Skills</h3>
-        <p class="font-subheader">Get paid with ETH or any ERC-20 tokens for working on freelance {% if tech_stack %} {{ tech_stack|title }} {% endif %} jobs.</p>
+        <p class="font-subheader">Grow your {% if tech_stack %} {{ tech_stack|title }} {% endif %} experience and show the world.</p>
       </div>
     </div>
 


### PR DESCRIPTION
##### Description

The text underneath "Get Paid for Contributing to Freelance Issues" was duplicated underneath "Sharpen Your Coding Skills". I updated with some relevant descriptive content.

##### Refers/Fixes

N/A

##### Testing

N/A
