### PR TITLE
fix: sets a maximum healthCheck timeout of 60s on trust-bonus tab

### DIFF
--- a/app/assets/v2/js/pages/profile-trust.js
+++ b/app/assets/v2/js/pages/profile-trust.js
@@ -272,7 +272,7 @@ Vue.component('active-trust-manager', {
         // if we get a response then the connection is good
         this.isCeramicConnected = true;
         // increase the timeout by 50% on each successful check (2s, 3s, 4.5s etc...)
-        this.healthCheckTimeout = this.healthCheckTimeout * 1.5;
+        this.healthCheckTimeout = Math.min(60000, Math.max(0, this.healthCheckTimeout * 1.5)); // max ping of 60s
       } catch (e) {
         // no connection
         this.isCeramicConnected = false;


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

<!-- Describe your changes here. -->

This PR sets a maximum health-check timeout of 60s (a maximum of 60s between pings) when checking if ceramic is online.

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

Refers: https://github.com/gitcoinco/passport/issues/312

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Tested locally