### PR TITLE
Change in API for gitcoin stamps: replacing field is_gr14_contributor to num_gr14_contributions for sake of consistency.

### DIFF
--- a/app/grants/views_api_vc.py
+++ b/app/grants/views_api_vc.py
@@ -123,7 +123,7 @@ def contributor_statistics(request):
             "num_grants_contribute_to": num_grants_contribute_to,
             "num_rounds_contribute_to": num_rounds_contribute_to,
             "total_contribution_amount": total_contribution_amount,
-            "is_gr14_contributor": num_gr14_contributions > 0,
+            "num_gr14_contributions": num_gr14_contributions,
         }
     )
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

Replacing field `is_gr14_contributor` to `num_gr14_contributions` for sake of consistency.

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a Github issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
