### PR TITLE
Build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ WORKDIR /usr/src
 RUN apt-get update && apt-get install -y wget
 RUN wget "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
 RUN apt-get install -y $CHROME_DEPS
-RUN dpkg -i google-chrome-stable_current_amd64.deb
 
 # Install cypress dependencies
 RUN apt-get install -y $CYPRESS_DEPS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ requests_oauthlib
 Pillow==8.3.2
 premailer
 populus
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8
 PyJWT==1.5.3
 PyPdf2
 python-twitter==3.2


### PR DESCRIPTION
##### Description

This should resolve issues around building the docker containers for the repo. 

From my understanding `RUN dpkg -i google-chrome-stable_current_amd64.deb` was added for cypress integration testing, and it is not necessary

I'm lacking context on `psycopg2` but it seems as though everything is working as expected with the version bump.

##### Testing

Tested on build
