### PR TITLE
feat: auto-add main round to all grants

### DIFF
--- a/app/grants/views.py
+++ b/app/grants/views.py
@@ -3361,6 +3361,13 @@ class GrantSubmissionView(View):
             except Exception as e:
                 pass
 
+        if eth_payout_address and eth_payout_address != '0x0':
+            try:
+                tag = GrantTag.objects.get(name="* Main Round")
+                grant.tags_requested.add(tag)
+            except Exception as e:
+                pass
+
         grant.save()
         grant.calc_clr_round()
         grant.save()


### PR DESCRIPTION
##### Description

Given a grantee has submitted a new grant
When the grant record is saved 
Then the main round tag is selected in the requested tags field.



On creation of a new ethereum grant -> the *** Main Round** is applied to both tags requested and tags column

##### Refers/Fixes

Refer: https://discord.com/channels/562828676480237578/1017467074882326538/1017467076891394048

##### Testing

Please ensure the tag *** Main Round** is created while testing locally / staging

![Deploy](https://user-images.githubusercontent.com/5358146/189291201-58c5c0d4-0112-4d30-a1de-ec0c3bb7696e.gif)
