### PR TITLE
remove gas param

### DIFF
--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -344,9 +344,11 @@ Vue.component('grantsCartEthereumPolygon', {
       // Send transaction
       appCart.$refs.cart.showConfirmationModal = true;
 
+      const bnGasPrice = web3.utils.toWei(document.polygonGasPrice, 'gwei');
+
       bulkTransaction.methods
         .donate(donationInputsFiltered)
-        .send({ from: userAddress, value: this.donationInputsNativeAmount })
+        .send({ from: userAddress, value: this.donationInputsNativeAmount, gasPrice: bnGasPrice })
         .on('transactionHash', async(txHash) => {
           indicateMetamaskPopup(true);
           console.log('Donation transaction hash: ', txHash);

--- a/app/assets/v2/js/cart-ethereum-polygon.js
+++ b/app/assets/v2/js/cart-ethereum-polygon.js
@@ -346,7 +346,7 @@ Vue.component('grantsCartEthereumPolygon', {
 
       bulkTransaction.methods
         .donate(donationInputsFiltered)
-        .send({ from: userAddress, gas: this.polygon.estimatedGasCost, value: this.donationInputsNativeAmount })
+        .send({ from: userAddress, value: this.donationInputsNativeAmount })
         .on('transactionHash', async(txHash) => {
           indicateMetamaskPopup(true);
           console.log('Donation transaction hash: ', txHash);


### PR DESCRIPTION
##### Description

the version of web3js that gitcoin uses was updated recently to https://github.com/ChainSafe/web3.js/releases/tag/v1.7.5. In v1.7.5 if you do not add a `gasPrice` parameter the priority fee defaults to `2.5` 
pull that is referenced in v1.7.5 release: https://github.com/ChainSafe/web3.js/pull/5121/files#diff-365a22cb44473b7399e704d0bf30aefe872162914bf9af3ed3525d87beacc1aaR160

These are the gas prices when these screenshots were taken:
<img width="562" alt="Screen Shot 2022-09-09 at 4 04 31 PM" src="https://user-images.githubusercontent.com/6887938/189452089-43cc0e05-497b-448d-a4e6-2c7ca595d7b0.png">

This was happening before these changes:
<img width="355" alt="Screen Shot 2022-09-09 at 4 04 20 PM" src="https://user-images.githubusercontent.com/6887938/189452134-31fc8446-387e-4f62-aa46-6dd97b4d1668.png">
<img width="351" alt="Screen Shot 2022-09-09 at 4 04 10 PM" src="https://user-images.githubusercontent.com/6887938/189452136-2e94c88c-dfd3-4a46-9db2-b6073a361a7c.png">

The priority fee is defaulting to 2.5 ↘️ which is too low

This is what happens after these changes:
<img width="355" alt="Screen Shot 2022-09-09 at 4 03 34 PM" src="https://user-images.githubusercontent.com/6887938/189452224-e1349411-758c-4da2-a609-a0107a04e8a1.png">
<img width="350" alt="Screen Shot 2022-09-09 at 4 02 38 PM" src="https://user-images.githubusercontent.com/6887938/189452230-2d6f7c28-488a-41ac-926b-7a49d7b8d232.png">

The fee is being set to the fast value, which is why it is saying that the priority fee may be too high. Imo this is ok since it amounts to a fraction of penny and should ensure it is successful


