### PR TITLE
peg django-oauth-toolkit version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ sentry-sdk==1.1.0
 websocket-client
 bleach
 python-magic
-django-oauth-toolkit
+django-oauth-toolkit==1.3.0
 ddtrace
 metadata-parser==0.10.0
 redis==3.3.11


### PR DESCRIPTION
##### Description

Build was failing and throwing an error originating from `django-oauth-toolkit`

Error:
`Traceback (most recent call last):
  File "./manage.py", line 59, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
    django.setup()
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/django/apps/config.py", line 211, in import_models
    self.models_module = import_module(models_module_name)
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/oauth2_provider/models.py", line 15, in <module>
    from jwcrypto import jwk
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/jwcrypto/jwk.py", line 200, in <module>
    'sha3-224': hashes.SHA3_224(),
AttributeError: module 'cryptography.hazmat.primitives.hashes' has no attribute 'SHA3_224'`

##### Refers/Fixes

This pegs `django-oauth-toolkit=1.3.0` to the last release that supports the version of `django==2.2.24` that is used in this repo https://django-oauth-toolkit.readthedocs.io/en/latest/changelog.html#id49

