### PR TITLE
calc clr round upon approval to indicate grant is in round

### DIFF
--- a/app/grants/admin.py
+++ b/app/grants/admin.py
@@ -219,6 +219,8 @@ class GrantAdmin(GeneralAdmin):
             obj.is_clr_eligible = True
             obj.hidden = False
             obj.save()
+            obj.calc_clr_round()
+            obj.save()
             record_grant_activity_helper('new_grant', obj, obj.admin_profile)
             new_grant_approved(obj, obj.admin_profile)
             self.message_user(request, "Grant has been successfully approved")


### PR DESCRIPTION
##### Description

Previously grants were not showing as visible until in the ui until `calc_clr_round` was ran in `create_page_cache`. This runs `calc_clr_round` once grant is approved

##### Testing

Tested locally
