### PR TITLE
Exclude round_num==null when counting number of rounds contributed to

### DIFF
--- a/app/grants/views_api_vc.py
+++ b/app/grants/views_api_vc.py
@@ -84,7 +84,7 @@ def contributor_statistics(request):
 
     # Get number of rounds the user contributed to
     num_rounds_contribute_to = (
-        GrantContributionIndex.objects.filter(profile__handle=handle)
+        GrantContributionIndex.objects.filter(profile__handle=handle, round_num__isnull=False)
         .order_by("round_num")
         .distinct("round_num")
         .count()


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

After the last modification `round_num` might be null in `GrantsContributionIndex`

##### Refers/Fixes

This relates to https://github.com/gitcoinco/passport/issues/593

##### Testing

Has been tested on local
