### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -8,6 +8,9 @@ on:
         default: "origin/master"
         type: string
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build-and-test:
     name: Build and Test

--- a/.github/workflows/ci-stage.yml
+++ b/.github/workflows/ci-stage.yml
@@ -12,6 +12,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build-and-test:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@ on:
   push:
     branches: [ master, stable ]
 
+permissions: {}
 jobs:
   build-and-test:
+    permissions:
+      contents: write # to push pages branch (peaceiris/actions-gh-pages)
+
     name: Build and Test
 
     # run only when code is compiling and tests are passing


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.