### PR TITLE
Visual improvement to scorecard titles

### DIFF
--- a/app/dashboard/templates/profiles/organization.html
+++ b/app/dashboard/templates/profiles/organization.html
@@ -46,7 +46,7 @@
             {% for profile, num_times in works_with_org.items %}
               {% if forloop.counter < 9 %}
                 <a href="{% url 'profile' profile %} ">
-                  <img src='{% avatar_url profile %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                  <img src='{% avatar_url profile %}' title="{{ profile }}: {{ num_times }} times">
                 </a>
               {% endif %}
             {% endfor %}

--- a/app/dashboard/templates/profiles/scorecard_funder.html
+++ b/app/dashboard/templates/profiles/scorecard_funder.html
@@ -66,7 +66,7 @@
                 {% for profile, num_times in works_with_funded.items %}
                   {% if forloop.counter < 6 %}
                     <a href="{% url 'profile' profile %} ">
-                      <img src='{% avatar_url profile %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                      <img src='{% avatar_url profile %}' title="{{ profile }}: {{ num_times }} times">
                     </a>
                   {% endif %}
                 {% endfor %}

--- a/app/dashboard/templates/profiles/scorecard_hunter.html
+++ b/app/dashboard/templates/profiles/scorecard_hunter.html
@@ -72,7 +72,7 @@
                 {% for profile, num_times in works_with_collected.items %}
                   {% if forloop.counter < 6 %}
                     <a href="{% url 'profile' profile %} ">
-                      <img src='{% avatar_url profile %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                      <img src='{% avatar_url profile %}' title="{{ profile }}: {{ num_times }} times">
                     </a>
                   {% endif %}
                 {% endfor %}

--- a/app/dashboard/templates/profiles/tribes-vue.html
+++ b/app/dashboard/templates/profiles/tribes-vue.html
@@ -1232,7 +1232,7 @@
                           {% for profile, num_times in works_with_org.items %}
                           {% if forloop.counter < 9 %}
                           <a href="{% url 'profile' profile %} ">
-                            <img src='{% avatar_url profile %}' title="<div class='tooltip-info tooltip-xs'>{{ profile }}: {{ num_times }} times</div>">
+                            <img src='{% avatar_url profile %}' title="{{ profile }}: {{ num_times }} times">
                           </a>
                           {% endif %}
                           {% endfor %}


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below, read through the contributor's guide, 
and ensure your pull request has fulfilled all requirements outlined by the Gitcoin Core team.
Have you read the contributors guide?: https://docs.gitcoin.co/mk_contributors/ 
-->

##### Description

For a while now, Gitcoin's profile scorecards shows titles as following:

<p align="center">
  <img src="https://user-images.githubusercontent.com/78161484/192293370-70d2e864-d4d1-4914-8f23-a3d2814c452e.png" alt="Image"/>
</p>

This chore is to make it so now, profile scorecards shows as the example:

<p align="center">
  <img src="https://user-images.githubusercontent.com/78161484/192294174-ae4cc377-5122-4c96-acda-7cf51b903a07.png" alt="Image"/>
</p>

<!-- Describe your changes here. -->

##### Refers/Fixes

This visual bug has been found in the following elements:

[scorecard_funder.html](https://github.com/gitcoinco/web/commit/056238bd453c6d4c5706ce326ab5e8057039e473)
[scorecard_hunter.html](https://github.com/gitcoinco/web/commit/293305c4ef5d11b8080a6fd581b314156c0ec43e)
[organization.html](https://github.com/gitcoinco/web/commit/7bb8a8ba19332750efa112ca988bc17c1efb3a8f)
[tribes_vue.html](https://github.com/gitcoinco/web/commit/55f23e40d33c6a7d1b6f60a1b92c3348fe609527)

<!-- If this PR is related to a Github issue, please add a link here. -->