### PR TITLE
use BigInt to parse scientific notation

### DIFF
--- a/app/assets/onepager/js/receive.js
+++ b/app/assets/onepager/js/receive.js
@@ -132,7 +132,7 @@ $(document).ready(function() {
     var token_address = document.tip['token_address'];
     var token_contract = new web3.eth.Contract(token_abi, token_address);
     var holding_address = document.tip['holding_address'];
-    var amount_in_wei = new web3.utils.BN(String(document.tip['amount_in_wei']));
+    var amount_in_wei = BigInt(document.tip['amount_in_wei']).toString();
 
     web3.eth.getTransactionCount(holding_address, function(error, result) {
       var nonce = result;
@@ -156,7 +156,7 @@ $(document).ready(function() {
             nonce: web3.utils.toHex(nonce),
             to: forwarding_address,
             from: holding_address,
-            value: amount_in_wei.toString()
+            value: amount_in_wei
           };
           web3.eth.estimateGas(rawTx, function(err, gasLimit) {
             var buffer = new web3.utils.BN(0);
@@ -188,7 +188,7 @@ $(document).ready(function() {
         } else {
 
           // send ERC20
-          var encoded_amount = new web3.utils.BN(BigInt(document.tip['amount_in_wei'])).toString();
+          var encoded_amount = amount_in_wei;
           var data = token_contract.methods.transfer(forwarding_address, encoded_amount).encodeABI();
 
           rawTx = {


### PR DESCRIPTION
##### Description
When tips are paid in low value tokens the amount in wei is returned from python/django in scientific notation. Throwing an error when trying to convert it to a BN
<img width="926" alt="Screen Shot 2022-09-27 at 5 28 37 PM" src="https://user-images.githubusercontent.com/6887938/192655066-bf31e83d-60e0-4b0b-b490-6d1b96d7e88c.png">

This use `BigInt` to parse number because it works for numbers that are in scientific notation as well as ints
<img width="390" alt="Screen Shot 2022-09-27 at 5 29 46 PM" src="https://user-images.githubusercontent.com/6887938/192655157-89755e73-2962-4fdd-bd22-73e213236871.png">


fixes: #41