### PR TITLE
pin importlib-metadata==4.13.0 for celery to work on python3.7

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,3 +20,4 @@ livereload==2.6.3
 didkit==0.2.1
 datar==0.8.6
 pdtypes==0.0.4
+importlib-metadata==4.13.0


### PR DESCRIPTION
pin importlib-metadata==4.13.0 for celery to work on python3.7