### PR TITLE
switch infura key with alchemy

### DIFF
--- a/app/dashboard/utils.py
+++ b/app/dashboard/utils.py
@@ -318,7 +318,7 @@ def get_web3(network, sockets=False, chain='std'):
         
         # Infura is throwing 403 errors on polygon due to current plan. Using Polygon RPC instead
         if network == 'polygon-mainnet':
-            provider = HTTPProvider(f'https://polygon-mainnet.g.alchemy.com/v2/{settings.INFURA_V3_PROJECT_ID}')
+            provider = HTTPProvider(f'https://polygon-mainnet.g.alchemy.com/v2/{settings.ALCHEMY_KEY}')
 
         w3 = Web3(provider)
         if network == 'rinkeby':


### PR DESCRIPTION
##### Description

This is a hotfix for https://github.com/gitcoinco/web/pull/10938 the `INFURA_V3_PROJECT_ID` needed to be switched out with `ALCHEMY_KEY`

