### PR TITLE
Hardcode website static assets bucket name in Pulumi

### DIFF
--- a/infra/production/index.ts
+++ b/infra/production/index.ts
@@ -72,6 +72,7 @@ const staticAssetsBucket = new aws.s3.Bucket("bucket", {
     website: {
         indexDocument: "index.html",
     },
+    bucket: "bucket-0427bb4",
     forceDestroy: true,
 });
 


### PR DESCRIPTION
There are currently two buckets on S3, the new one, [bucket-fc46b51](https://s3.console.aws.amazon.com/s3/buckets/bucket-fc46b51?region=us-west-2), deployed Nov 11. The app is currently mis-configured to upload assets to the new bucket, but the CloudFront CDN still points to the old bucket
[bucket-0427bb4](https://s3.console.aws.amazon.com/s3/buckets/bucket-0427bb4?region=us-west-2). This hardcodes the app to point to the old bucket, which has had assets synced from the new one.
