### PR TITLE
Fix Typos in `tax_report.txt` and `RUNNING_REMOTELY.md`

### DIFF
--- a/app/retail/templates/emails/tax_report.txt
+++ b/app/retail/templates/emails/tax_report.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
-{% trans "There should be an zip attachment with all infos for all bounties, tips and grant funded" %}
+{% trans "There should be a zip attachment with all infos for all bounties, tips and grant funded" %}
 {% trans "Also there is a 1099 form compiled for evary us gitcoiners that you paid in this year" %}
 {% trans "Each 1099 consist in 4 pdf file (copy 1, copy 2, copy B, copy C)" %}

--- a/docs/RUNNING_REMOTELY.md
+++ b/docs/RUNNING_REMOTELY.md
@@ -2,7 +2,7 @@
 
 We'll be using DigitalOcean which is a nice VPS service pretty customizable, easy to use and cheap. You need to create an account and pay for a droplet using any of the payment methods available.
 
-There will be kind of a high memory load, so we gonna need the second best droplet which offers 2GB/1CPU (costs $10).
+There will be kind of a high memory load, so we gonna need the second-best droplet which offers 2GB/1CPU (costs $10).
 
 #### Create a droplet with the following settings:
 


### PR DESCRIPTION
This PR corrects grammatical errors in the documentation:
1. **`tax_report.txt`**: Corrected "an zip" to "a zip" for proper grammar.
2. **`RUNNING_REMOTELY.md`**: Fixed missing hyphen in "second-best" for clarity in a compound adjective.

These updates improve the readability and consistency of the project documentation.

## Refers/Fixes
No related GitHub issues.

## Testing
The changes were manually reviewed to ensure grammatical correctness and alignment with documentation standards.
