### PR TITLE
Add 7/Seven Chain Node — EVM perpetual futures blockchain (Chain ID: 70007)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -244,3 +244,5 @@ Note:
 
 - [Code - GNU AFFERO GENERAL PUBLIC LICENSE](../LICENSE)
 - [Creative assets -- Attribution-NonCommercial-NoDerivatives 4.0 International](../app/assets/LICENSE.txt)
+
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — perpetual futures exchange with 100+ pairs, up to 2001× leverage, zero fees.


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**7/Seven Chain** is an EVM-compatible blockchain (BSC/Parlia, Chain ID: 70007) powering [TheSeven.meme](https://theseven.meme):
- 100+ trading pairs | **2001× leverage** | **Zero fees** | On-chain settlement

**Links:** Repo: https://github.com/umairkhan2582/seven-chain-node | Exchange: https://theseven.meme | RPC: https://rpc.theseven.meme | Explorer: https://theseven.meme/blockchain/explorer